### PR TITLE
Add Claude Skills resources page

### DIFF
--- a/docs/_templates/resources-template.md
+++ b/docs/_templates/resources-template.md
@@ -1,16 +1,44 @@
+---
+title: "[Topic] Resources"
+description: "Recommended docs, tutorials, courses, and community links for [topic]"
+---
+
 # [Topic] Resources
 
-Recommended articles, docs, and courses for [topic].
+Recommended docs, tutorials, and community links for [topic].
 
-| Resource | Type | Note |
-|----------|------|------|
-| [Example Title](https://example.com) | Article | Brief note on why it's useful |
+## Get Started
 
-## Types
+| Resource | Description |
+|----------|-------------|
+| [Resource Title](https://example.com) | Brief description of why it's useful |
 
-- **Article** - Blog posts, Substack, newsletters
-- **Docs** - Official documentation
-- **Course** - Video courses, tutorials
-- **Video** - YouTube, conference talks
-- **Tool** - Useful tools and utilities
-- **Paper** - Research papers
+## Documentation
+
+| Resource | Description |
+|----------|-------------|
+| [Resource Title](https://example.com) | Brief description of why it's useful |
+
+## Learn
+
+| Resource | Description |
+|----------|-------------|
+| [Resource Title](https://example.com) | Brief description of why it's useful |
+
+## Developer Resources
+
+| Resource | Description |
+|----------|-------------|
+| [Resource Title](https://example.com) | Brief description of why it's useful |
+
+## Community
+
+| Resource | Description |
+|----------|-------------|
+| [Resource Title](https://example.com) | Brief description of why it's useful |
+
+## Watch
+
+| Resource | Description |
+|----------|-------------|
+| [Resource Title](https://example.com) | Brief description of why it's useful |

--- a/docs/platforms/claude/skills/resources.md
+++ b/docs/platforms/claude/skills/resources.md
@@ -1,0 +1,60 @@
+---
+title: Claude Skills Resources
+description: Recommended docs, tutorials, courses, and community links for Claude Agent Skills
+---
+
+# Claude Skills Resources
+
+Recommended docs, tutorials, and community links for Claude Agent Skills.
+
+## Get Started
+
+| Resource | Description |
+|----------|-------------|
+| [Introducing Agent Skills](https://claude.com/blog/skills) | Official announcement — what Skills are and why they matter |
+| [What are Skills?](https://support.claude.com/en/articles/12512176-what-are-skills) | Help Center overview of Skill types and how they work |
+| [Skills Explained](https://claude.com/blog/skills-explained) | How Skills compares to prompts, Projects, MCP, and subagents |
+| [Using Skills in Claude](https://support.claude.com/en/articles/12512180-using-skills-in-claude) | How to activate and use Skills in Claude.ai |
+
+## Documentation
+
+| Resource | Description |
+|----------|-------------|
+| [Agent Skills Overview](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview) | API docs — Skill structure, progressive disclosure, and platform support |
+| [Skills in Claude Code](https://code.claude.com/docs/en/skills) | Claude Code docs — creating, configuring, and sharing Skills |
+| [How to Create Custom Skills](https://support.claude.com/en/articles/12512198-how-to-create-custom-skills) | Help Center guide to building your own Skills |
+| [Teach Claude Your Way of Working](https://support.claude.com/en/articles/12580051-teach-claude-your-way-of-working-using-skills) | Practical guide to encoding your workflows as Skills |
+
+## Learn
+
+| Resource | Description |
+|----------|-------------|
+| [A Complete Guide to Building Skills for Claude](https://claude.com/blog/complete-guide-to-building-skills-for-claude) | In-depth blog guide covering structure, testing, and distribution |
+| [Equipping Agents for the Real World with Agent Skills](https://claude.com/blog/equipping-agents-for-the-real-world-with-agent-skills) | Engineering blog — architecture, progressive disclosure, and best practices |
+| [Improving Frontend Design through Skills](https://claude.com/blog/improving-frontend-design-through-skills) | Applied AI team case study — using Skills to move beyond generic AI-generated aesthetics |
+| [How to Create Skills](https://claude.com/blog/how-to-create-skills-key-steps-limitations-and-examples) | Key steps, limitations, and examples — structured 5-step creation guide |
+| [Extending Claude's Capabilities with Skills and MCP Servers](https://claude.com/blog/extending-claude-capabilities-with-skills-mcp-servers) | How Skills and MCP work together for workflows and external tools |
+| [Building Agents with Skills](https://claude.com/blog/building-agents-with-skills-equipping-agents-for-specialized-work) | Equipping agents for specialized work with packaged domain expertise |
+| [Agent Skills Webinar](https://www.anthropic.com/webinars/agent-skills-transform-claude-from-assistant-to-specialized-agent) | Recorded webinar with live demos from Anthropic's Applied AI team |
+| [Claude Code: A Highly Agentic Coding Assistant](https://learn.deeplearning.ai/courses/claude-code-a-highly-agentic-coding-assistant) | DeepLearning.AI short course covering Claude Code, MCP, and practical projects |
+
+## Developer Resources
+
+| Resource | Description |
+|----------|-------------|
+| [anthropics/skills](https://github.com/anthropics/skills) | Official Skills repo — example Skills, spec, and starter template |
+| [Skills Cookbook](https://github.com/anthropics/claude-cookbooks/tree/main/skills) | Jupyter notebooks for building Skills with the API (document, financial, custom) |
+| [Skills API Cookbook](https://platform.claude.com/cookbook/skills-notebooks-01-skills-introduction) | Interactive API cookbook — quick-start examples for pre-built Skills |
+
+## Community
+
+| Resource | Description |
+|----------|-------------|
+| [Awesome Claude Skills](https://github.com/travisvn/awesome-claude-skills) | Curated list of Skills resources, tools, and examples |
+| [Claude Skills Hub](https://claudeskills.info/) | Browsable directory of downloadable Claude Code Skills |
+
+## Watch
+
+| Resource | Description |
+|----------|-------------|
+| [Stop Reprompting — Start Building Skill-Powered Workflows](https://graymatter.jamesgray.ai/p/stop-reprompting-start-building-skills) | Lightning Lesson on packaging expertise into reusable Skills that activate automatically |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
         - Claude Projects: platforms/claude/projects/claude-projects-setup.md
       - Skills:
         - Discover Your Best Claude Skills: platforms/claude/skills/skills-discovery-meta-prompt.md
+        - Resources: platforms/claude/skills/resources.md
       - Questions: platforms/claude/questions/README.md
       - Subagents:
         - Scheduling Subagents: platforms/claude/subagents/scheduling-subagents.md


### PR DESCRIPTION
## Summary
- Create `docs/platforms/claude/skills/resources.md` with curated links to official Anthropic blog posts, Help Center articles, API docs, developer repos, community collections, and a Lightning Lesson video
- Add `Resources` nav entry under Claude > Skills in `mkdocs.yml`
- Update `docs/_templates/resources-template.md` from the old 3-column format to the 2-column categorized table format used by all populated resources pages

## Test plan
- [ ] `mkdocs build` completes with no new errors
- [ ] `mkdocs serve` renders the page at `/platforms/claude/skills/resources/`
- [ ] Nav shows "Resources" under Claude > Skills, after the discovery page
- [ ] All external links open correctly (spot-check in browser)
- [ ] Tables render with proper formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)