### PR TITLE
Add Workflow Examples documentation and plugin assets

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "course-examples",
       "source": "./plugins/course-examples",
       "description": "Working examples of agents and skills from the Hands-on AI cohort courses",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     {
       "name": "ai-registry",

--- a/.claude/agents/meeting-prep-researcher.md
+++ b/.claude/agents/meeting-prep-researcher.md
@@ -1,0 +1,90 @@
+---
+name: meeting-prep-researcher
+description: "Use this agent when the user needs to prepare for an upcoming meeting by researching attendees, companies, or topics. This includes requests to look up someone before a call, prepare talking points, find recent news about a company, or build context for a sales meeting, interview, or partnership discussion.\n\nExamples:\n\n<example>\nContext: User has an upcoming sales call\nuser: \"I have a meeting with Sarah Chen from Acme Corp tomorrow. Help me prepare.\"\nassistant: \"I'll use the meeting prep researcher agent to research the attendee and company so you have context for your call.\"\n<Task tool call to meeting-prep-researcher agent>\n</example>\n\n<example>\nContext: User needs context for a partnership meeting\nuser: \"Research DataFlow Labs before my meeting on Thursday\"\nassistant: \"Let me launch the meeting prep researcher agent to gather background on DataFlow Labs and prepare talking points.\"\n<Task tool call to meeting-prep-researcher agent>\n</example>\n\n<example>\nContext: User asks for a meeting brief\nuser: \"Put together a prep doc for my 2pm call with the marketing team at Rivian\"\nassistant: \"I'll use the meeting prep researcher agent to compile a meeting prep brief with company background, attendee profiles, and suggested talking points.\"\n<Task tool call to meeting-prep-researcher agent>\n</example>"
+model: sonnet
+color: blue
+---
+
+You are an expert Meeting Preparation Researcher. Your job is to help the user prepare for upcoming meetings by researching attendees, companies, and relevant topics, then producing a concise prep brief for human review.
+
+## Your Core Responsibilities
+
+1. **Attendee Research**: For each person the user will meet with:
+   - Search for their LinkedIn profile, role, and background
+   - Find recent posts, articles, or public statements they've made
+   - Identify shared connections, interests, or conversation starters
+   - Note their decision-making authority (if discernible)
+
+2. **Company Research**: For the company or organization involved:
+   - Search for recent news, press releases, and announcements (last 90 days)
+   - Identify the company's current priorities, challenges, or strategic direction
+   - Find relevant industry context and competitive landscape
+   - Check for any recent leadership changes, funding rounds, or product launches
+
+3. **Topic Preparation**: Based on the meeting context:
+   - Identify likely discussion topics and prepare talking points
+   - Surface potential objections or concerns and suggest responses
+   - Find relevant data points, case studies, or examples that support the user's position
+   - Identify open questions the user should ask
+
+## Output Format
+
+Produce a **Meeting Prep Brief** using this structure:
+
+---
+
+**Meeting Prep Brief**
+
+**Meeting:** [Purpose/type of meeting]
+**Date:** [If provided]
+**With:** [Attendee names and roles]
+
+### Attendee Profiles
+
+For each attendee:
+
+**[Name] — [Title] at [Company]**
+- **Background:** [2-3 sentences on their role, tenure, and relevant experience]
+- **Recent activity:** [Any recent posts, talks, or public statements worth noting]
+- **Conversation starters:** [1-2 specific, non-generic topics based on their interests or recent activity]
+
+### Company Snapshot
+
+- **What they do:** [One sentence]
+- **Size & stage:** [Employees, funding, revenue if public]
+- **Recent news:** [2-3 bullet points of notable recent developments]
+- **Strategic priorities:** [What they appear to be focused on based on recent signals]
+
+### Suggested Talking Points
+
+1. [Talking point with brief rationale]
+2. [Talking point with brief rationale]
+3. [Talking point with brief rationale]
+
+### Questions to Ask
+
+1. [Thoughtful question that demonstrates preparation]
+2. [Question that surfaces the attendee's priorities or pain points]
+3. [Question that advances the user's goal for the meeting]
+
+### Watch Out For
+
+- [Potential sensitive topic or landmine to avoid]
+- [Possible objection and suggested response]
+
+---
+
+## Research Process
+
+1. **Gather context** — Ask the user for: who they're meeting, what company, what the meeting is about, and what outcome they're hoping for. If they've only provided a name, ask for the rest.
+2. **Research broadly** — Use web search to find attendee profiles, company news, and relevant industry context. Cast a wide net first.
+3. **Synthesize and filter** — Focus on information that's actionable for the meeting. Cut anything that's generic, outdated, or irrelevant.
+4. **Present the brief** — Deliver the formatted prep brief and ask if the user wants to go deeper on any section.
+
+## Important Guidelines
+
+- **Recency matters.** Prioritize information from the last 90 days. Old news is not useful for meeting prep.
+- **Be specific, not generic.** "They recently launched a new AI product" is better than "They are focused on innovation."
+- **Flag uncertainty.** If you can't verify something, say so. Don't present speculation as fact.
+- **Respect the user's time.** Keep the brief scannable. The user should be able to read it in 5 minutes.
+- **This is collaborative.** You research and draft; the user reviews, adjusts, and decides what to use. Always ask if the brief needs refinement before the meeting.

--- a/.claude/skills/meeting-prep-research/SKILL.md
+++ b/.claude/skills/meeting-prep-research/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: meeting-prep-research
+description: >
+  Research attendees and companies before meetings. Produces a structured meeting prep
+  brief with attendee profiles, company snapshots, talking points, and suggested questions.
+  Use when the user mentions preparing for a meeting, researching someone before a call,
+  or needing talking points for an upcoming conversation.
+---
+
+# Meeting Prep Research
+
+Research meeting attendees and their companies to produce a concise, actionable prep brief.
+
+## Workflow
+
+1. **Gather meeting details** — Ask for: attendee name(s), company, meeting type, and the user's goal
+2. **Research attendees** — Search for LinkedIn profiles, recent posts, and public activity
+3. **Research company** — Search for recent news, strategic direction, and relevant context
+4. **Synthesize brief** — Produce a formatted Meeting Prep Brief (see format below)
+5. **Refine with user** — Ask if any section needs more depth or adjustment
+
+## Output Format
+
+```markdown
+**Meeting Prep Brief**
+
+**Meeting:** [Purpose]
+**With:** [Names and roles]
+
+### Attendee Profiles
+[Name — Title at Company]
+- Background: [2-3 sentences]
+- Recent activity: [Notable posts or statements]
+- Conversation starters: [1-2 specific topics]
+
+### Company Snapshot
+- What they do: [One sentence]
+- Recent news: [2-3 bullets, last 90 days]
+- Strategic priorities: [Current focus areas]
+
+### Suggested Talking Points
+1. [Point with rationale]
+2. [Point with rationale]
+3. [Point with rationale]
+
+### Questions to Ask
+1. [Preparation-demonstrating question]
+2. [Priority-surfacing question]
+3. [Goal-advancing question]
+
+### Watch Out For
+- [Sensitive topics or potential objections]
+```
+
+## Research Guidelines
+
+- **Prioritize recency** — information from the last 90 days is most valuable
+- **Be specific** — "They launched X product in January" beats "They're focused on innovation"
+- **Flag uncertainty** — distinguish verified facts from reasonable inferences
+- **Keep it scannable** — the brief should take under 5 minutes to read

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -14,6 +14,7 @@ Problem-focused guides that help you accomplish specific tasks.
 | [Prompting](./prompting/) | Prompt engineering techniques |
 | [Agents](./agents/) | Agent and tool use guides |
 | [Integrations](./integrations/) | Platform integration guides |
+| [Workflow Examples](./workflow-examples/) | Worked examples across the AI automation spectrum |
 
 ## All Guides
 

--- a/docs/how-to/workflow-examples/README.md
+++ b/docs/how-to/workflow-examples/README.md
@@ -1,0 +1,77 @@
+---
+title: Workflow Examples
+description: Three worked examples showing the spectrum of AI involvement in workflows — from deterministic automation to fully autonomous agents.
+---
+
+# Workflow Examples
+
+Not all AI workflows are created equal. The right level of AI involvement depends on the task — some workflows need rigid, repeatable automation; others need AI that can research, reason, and iterate with a human; and some work best when an agent handles everything end-to-end.
+
+These three examples show the spectrum in practice. Each includes a real-world scenario, working building blocks you can install and use, and guidance on when to apply the pattern to your own work.
+
+## Why This Matters
+
+Most people start using AI the same way: paste something into a chat, get a response, use it or don't. That works for simple tasks, but it misses the bigger picture. AI can operate at different levels of autonomy, and matching the right level to the right task is what separates "I use ChatGPT sometimes" from "AI is integrated into how I work."
+
+Understanding the spectrum helps you:
+
+- **Avoid over-engineering** — not every task needs an autonomous agent
+- **Avoid under-utilizing** — some tasks deserve more than a copy-paste prompt
+- **Build incrementally** — start with deterministic automation, graduate to collaborative, then autonomous as you gain confidence
+
+## The Spectrum
+
+| Type | AI Involvement | When to Use | Example |
+|------|---------------|-------------|---------|
+| [Deterministic Automation](./deterministic-automation.md) | AI follows fixed rules — criteria from input, output from template | Prospecting, recurring reports, template-driven research | LinkedIn prospect research |
+| [AI Collaborative](./ai-collaborative.md) | AI researches and drafts; human steers and decides | Meeting prep, competitive analysis, proposal drafting | Meeting prep researcher |
+| [Autonomous Agent](./autonomous-agent.md) | Multiple agents execute a full pipeline; human reviews at one gate | Research-driven content, multi-step pipelines, specialist roles | HBR article pipeline |
+
+## All Building Blocks
+
+These are the working building blocks included across all three examples. Each one links to its source on GitHub — read the full definition, understand how it works, and adapt it for your own workflows.
+
+| Building Block | Type | Workflow | Description | Source |
+|-------|------|----------|-------------|--------|
+| `linkedin-prospect-research` | Prompt | Deterministic | Finds and qualifies 5 LinkedIn prospects against a buyer persona | [View](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/prompts/linkedin-prospect-research.md) |
+| `buyer-persona-revenue-leader-rachel` | Prompt | Deterministic | Example buyer persona used as input to the research workflow | [View](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/prompts/buyer-persona-revenue-leader-rachel.md) |
+| `meeting-prep-researcher` | Agent | Collaborative | Researches attendees and companies for meeting prep | [View](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/agents/meeting-prep-researcher.md) |
+| `meeting-prep-research` | Skill | Collaborative | Step-by-step research workflow for the agent | [View](https://github.com/jamesgray-ai/handsonai/tree/main/plugins/course-examples/skills/meeting-prep-research/) |
+| `meeting-prep-quick` | Prompt | Collaborative | Portable one-shot meeting prep prompt | [View](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/prompts/meeting-prep-quick.md) |
+| `ai-productivity-researcher` | Agent | Autonomous | Finds case studies of companies using AI with quantified outcomes | [View](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/agents/ai-productivity-researcher.md) |
+| `tech-executive-writer` | Agent | Autonomous | Writes articles for business leadership audiences | [View](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/agents/tech-executive-writer.md) |
+| `hbr-editor` | Agent | Autonomous | Edits drafts against HBR editorial standards | [View](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/agents/hbr-editor.md) |
+| `editing-hbr-articles` | Skill | Autonomous | Editorial criteria and cut/replace patterns for the editor | [View](https://github.com/jamesgray-ai/handsonai/tree/main/plugins/course-examples/skills/editing-hbr-articles/) |
+| `hbr-publisher` | Agent | Autonomous | Formats approved articles as PDF + markdown with SEO metadata | [View](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/agents/hbr-publisher.md) |
+
+## How to Use These Examples
+
+=== "Any AI Tool"
+
+    Every example includes at least one **standalone prompt** — a text template you can copy and paste into Claude, ChatGPT, Gemini, M365 Copilot, or any other AI tool. Click the "View" links in the table above to read the prompt source on GitHub.
+
+    Prompts are the most portable building block type. They work everywhere, require no setup, and can be shared with anyone on your team.
+
+=== "Claude Code"
+
+    All building blocks — agents, skills, and prompts — are bundled in the `course-examples` plugin. Install it once and the agents activate automatically when you describe a matching task.
+
+    ```bash
+    # Add the Hands-on AI marketplace (one time)
+    /plugin marketplace add jamesgray-ai/handsonai
+
+    # Install the course-examples plugin
+    /plugin install course-examples@handsonai
+    ```
+
+    Then describe what you need in natural language:
+
+    - *"Run the LinkedIn prospect research workflow using the Revenue Leader Rachel persona"* — executes the deterministic prospecting workflow
+    - *"Prepare me for my meeting with Sarah Chen at Acme Corp"* — activates the meeting prep researcher agent
+    - *"Write an HBR-style article about companies successfully using AI agents"* — triggers the full multi-agent research → write → edit → publish pipeline
+
+## Related
+
+- [Find AI Workflow Opportunities](../prompting/ai-workflow-opportunity-finder.md) — discover which of your workflows are candidates for AI
+- [Deconstruct Workflows into AI Building Blocks](../prompting/workflow-deconstruction-meta-prompt.md) — break down workflows into automatable steps
+- [Plugin Marketplace](../../plugins/index.md) — browse all available plugins

--- a/docs/how-to/workflow-examples/ai-collaborative.md
+++ b/docs/how-to/workflow-examples/ai-collaborative.md
@@ -1,0 +1,117 @@
+---
+title: "Workflow Example: AI Collaborative"
+description: A worked example of a human-AI collaborative workflow — AI researches and drafts, the human reviews and refines.
+---
+
+# AI Collaborative
+
+> **AI involvement:** AI handles research and drafting; the human steers, reviews, and decides.
+
+## What This Workflow Type Is
+
+An AI collaborative workflow is one where the human and AI work together — the AI performs tasks like research, analysis, or drafting, and the human provides judgment, context, and final decisions. Neither operates alone. The human sets the direction; the AI handles the legwork.
+
+!!! info "At a Glance"
+    - **AI involvement:** Researches, drafts, and analyzes — but defers to human judgment
+    - **Human oversight:** Active — reviews output, provides direction, makes decisions
+    - **Best for:** Meeting prep, competitive analysis, draft creation, exploratory research
+    - **Complexity:** Medium — may use an agent and/or skill, with a portable prompt as a lightweight alternative
+
+### Characteristics
+
+- **Iterative** — the human and AI go back and forth, refining the output
+- **Judgment-dependent** — the AI can gather and organize information, but the human decides what matters
+- **Context-rich** — the AI benefits from knowing the human's goals, preferences, and constraints
+- **Quality-gated** — the human reviews before the output is used
+
+### When to Use
+
+Use AI collaborative workflows when the task:
+
+- Requires research, synthesis, or analysis that's time-consuming for a human
+- Involves subjective judgment that can't be fully encoded in rules
+- Benefits from a draft that the human can refine rather than create from scratch
+- Produces higher-quality output when a human reviews and adjusts
+
+## Example Scenario
+
+**The problem:** Before important meetings — sales calls, partnership discussions, interviews — a professional spends 20-45 minutes manually researching attendees on LinkedIn, scanning company news, and assembling talking points. The research is necessary but tedious, and the quality varies depending on how much time is available.
+
+**The solution:** An AI agent that handles the research and produces a structured meeting prep brief. The human reviews the brief, adjusts the talking points, and walks into the meeting prepared — with a fraction of the manual effort.
+
+## Building Blocks
+
+| Building Block | Type | Description | Source |
+|-------|------|-------------|--------|
+| `meeting-prep-researcher` | Agent | Researches attendees and companies, produces a meeting prep brief | [View on GitHub](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/agents/meeting-prep-researcher.md) |
+| `meeting-prep-research` | Skill | Step-by-step research workflow for the agent to follow | [View on GitHub](https://github.com/jamesgray-ai/handsonai/tree/main/plugins/course-examples/skills/meeting-prep-research/) |
+| `meeting-prep-quick` | Prompt | Portable one-shot prompt for quick meeting prep in any AI tool | [View on GitHub](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/prompts/meeting-prep-quick.md) |
+
+## How It Works
+
+```mermaid
+graph LR
+    A[User provides<br>meeting details] --> B[AI researches<br>attendees & company]
+    B --> C[AI drafts<br>prep brief]
+    C --> D[Human reviews<br>and refines]
+    D --> E[Final prep brief<br>ready for meeting]
+```
+
+**Step-by-step:**
+
+1. **User provides context** — who the meeting is with, what company, what the meeting is about, and what outcome they want.
+2. **AI researches attendees** — searches for LinkedIn profiles, recent posts, and public activity for each person.
+3. **AI researches the company** — finds recent news, strategic direction, and relevant industry context.
+4. **AI drafts the prep brief** — produces a structured document with attendee profiles, company snapshot, suggested talking points, questions to ask, and potential landmines.
+5. **Human reviews and refines** — the user reads the brief, adjusts talking points to match their style and goals, and decides what to use in the meeting.
+
+## Usage
+
+=== "Any AI Tool (Portable)"
+
+    Use the **meeting-prep-quick** prompt for a lightweight, one-shot version in any AI tool.
+
+    1. Open the [meeting-prep-quick prompt](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/prompts/meeting-prep-quick.md) on GitHub
+    2. Copy the prompt from the code block
+    3. Paste it into Claude, ChatGPT, Gemini, or M365 Copilot
+    4. Fill in the meeting details and send
+    5. Review the output and adjust talking points to match your style
+
+=== "Claude Code (Plugin)"
+
+    With the `course-examples` plugin installed, the **meeting-prep-researcher** agent activates automatically when you ask about meeting preparation.
+
+    ```bash
+    # Install the plugin (one time)
+    /plugin install course-examples@handsonai
+    ```
+
+    Then describe your meeting in a Claude Code conversation:
+
+    > "I have a sales call with Maria Torres, VP of Product at DataFlow Labs, on Thursday. Help me prepare."
+
+    The agent will:
+
+    - Research Maria Torres and DataFlow Labs
+    - Produce a structured prep brief
+    - Ask if you want to go deeper on any section
+
+    The agent + skill combination provides a richer, more iterative experience than the one-shot prompt — it can ask follow-up questions, refine talking points based on your feedback, and adjust depth based on how much time you have.
+
+## Adapting This Example
+
+Meeting prep is one scenario, but the collaborative pattern applies to any task where AI handles research and drafting while the human provides judgment:
+
+- **Competitive analysis** — AI researches competitors, drafts a comparison matrix; human validates and adds strategic context
+- **Proposal drafting** — AI structures a proposal based on requirements; human refines messaging and adds relationship context
+- **Job candidate screening** — AI summarizes resumes and flags qualifications; human makes interview decisions
+- **Customer research** — AI compiles account history and recent activity; human identifies upsell opportunities
+
+To adapt: identify tasks where you spend significant time gathering information before applying judgment. The gathering is AI work; the judgment is human work.
+
+## Related
+
+- [Deterministic Automation Workflow Example](./deterministic-automation.md) — when AI follows fixed rules with no judgment needed
+- [Autonomous Agent Workflow Example](./autonomous-agent.md) — when AI executes end-to-end with minimal supervision
+- [Find AI Workflow Opportunities](../prompting/ai-workflow-opportunity-finder.md) — discover which workflows are candidates for AI collaboration
+- [Deconstruct Workflows into AI Building Blocks](../prompting/workflow-deconstruction-meta-prompt.md) — break down workflows into AI-ready steps

--- a/docs/how-to/workflow-examples/autonomous-agent.md
+++ b/docs/how-to/workflow-examples/autonomous-agent.md
@@ -1,0 +1,166 @@
+---
+title: "Workflow Example: Autonomous Agent"
+description: A worked example of multi-agent orchestration — multiple specialized agents research, write, edit, and publish an HBR-style article with a human review gate.
+---
+
+# Autonomous Agent
+
+> **AI involvement:** Multiple specialized agents execute a full pipeline — research, write, edit, review, publish — with human approval at one gate.
+
+## What This Workflow Type Is
+
+An autonomous agent workflow is one where AI handles the entire process — from research to final deliverable — with minimal human intervention. In this example, it goes further: multiple specialized agents each handle one phase of the pipeline, coordinated by Claude Code. The human sets the goal and reviews the draft at one checkpoint. Everything else runs autonomously.
+
+!!! info "At a Glance"
+    - **AI involvement:** Full — multiple agents plan, research, write, edit, and publish
+    - **Human oversight:** One review gate between editing and publishing
+    - **Best for:** Research-driven content production, multi-step pipelines with specialist roles
+    - **Complexity:** High — multi-agent orchestration with a skill, a hook, and tool use
+
+### Characteristics
+
+- **Multi-agent** — different agents handle different phases, each with domain expertise
+- **Pipeline-structured** — output from one agent becomes input to the next
+- **Skill-enhanced** — the editor agent loads the `editing-hbr-articles` skill to apply codified editorial standards during its editing pass
+- **Self-reviewing** — the editor agent applies quality criteria from that skill before the human sees the draft
+- **Gate-controlled** — a SubagentStop hook pauses execution for human review before publishing
+- **End-to-end** — produces a finished deliverable (PDF + markdown) from a single goal statement
+
+### When to Use
+
+Use autonomous agent workflows when the task:
+
+- Requires multiple distinct capabilities (research, writing, editing, formatting)
+- Follows a pipeline where each phase has clear inputs and outputs
+- Benefits from specialist expertise at each stage
+- Produces a deliverable that should meet professional standards
+- Can include a human review gate without breaking the flow
+
+## Example Scenario
+
+**The problem:** A business leader wants to publish an HBR-style article about companies successfully using AI agents. The process requires deep research (finding real case studies with quantified outcomes), executive-level writing (translating technical concepts for business audiences), rigorous editing (applying HBR editorial standards), and professional publishing (PDF formatting with SEO metadata). Doing this manually involves multiple skill sets and takes days of focused work.
+
+**The solution:** A multi-agent pipeline in Claude Code. One prompt triggers a chain of specialized agents — a researcher finds case studies, a writer produces the article, an editor applies HBR standards, the human reviews the draft, and a publisher formats the final deliverable. Each agent brings domain expertise that would otherwise require a different person.
+
+### The Goal Prompt
+
+This single prompt triggers the entire pipeline:
+
+> *"Please write an analysis and Harvard Business Review-style article on successful companies that you can find by doing research that have successfully used and applied AI agents to their business. This article is for a business leadership audience, and I'd like to have the final deliverable as a PDF, and markdown file."*
+
+## Building Blocks
+
+All building blocks are already included in the `course-examples` plugin — no additional installation required.
+
+| Building Block | Type | Role in Pipeline | Source |
+|-------|------|-----------------|--------|
+| `ai-productivity-researcher` | Agent | Finds documented case studies of companies using AI with quantified outcomes | [View on GitHub](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/agents/ai-productivity-researcher.md) |
+| `tech-executive-writer` | Agent | Writes the article for a business leadership audience | [View on GitHub](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/agents/tech-executive-writer.md) |
+| `hbr-editor` | Agent | Edits the draft against HBR editorial standards | [View on GitHub](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/agents/hbr-editor.md) |
+| `editing-hbr-articles` | Skill | Provides editorial criteria and cut/replace patterns for the editor | [View on GitHub](https://github.com/jamesgray-ai/handsonai/tree/main/plugins/course-examples/skills/editing-hbr-articles/) |
+| `hbr-publisher` | Agent | Formats the approved article as PDF and markdown with SEO metadata | [View on GitHub](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/agents/hbr-publisher.md) |
+
+## How It Works
+
+```mermaid
+graph TD
+    A["Goal prompt"] --> B["Claude Code<br>(orchestrator)"]
+    B --> C["ai-productivity-researcher<br>finds case studies"]
+    C --> D["tech-executive-writer<br>drafts the article"]
+    D --> E["hbr-editor<br>+ editing-hbr-articles skill"]
+    E --> F{"SubagentStop Hook"}
+    F --> G["Human reviews draft"]
+    G -->|Approved| H["hbr-publisher<br>formats PDF + markdown"]
+    G -->|Rejected| I(("Stop"))
+    H --> J["Final deliverables:<br>PDF + markdown article"]
+```
+
+**Step-by-step:**
+
+1. **User provides the goal** — a single prompt describing the article topic, audience, and desired deliverables.
+2. **`ai-productivity-researcher` runs** — searches news outlets, business publications, and analyst reports for documented case studies of companies using AI agents. Prioritizes HBR-caliber sources with quantified outcomes (revenue impact, productivity gains, cost savings).
+3. **`tech-executive-writer` runs** — takes the research output and produces a full-length article. Translates technical AI concepts for a non-technical business audience. Structures the piece with a compelling narrative, specific examples, and executive-level insights.
+4. **`hbr-editor` runs** — reads the `editing-hbr-articles` skill to load editorial criteria, then edits the draft. Checks structure (does the opening hook?), evidence quality (are claims supported by named companies and data?), voice (active, no hedging), and length (2,500-3,500 words for features). Makes direct, prescriptive edits.
+5. **SubagentStop hook fires** — pauses the pipeline and presents the edited draft to the human for review.
+6. **Human reviews** — reads the edited article and either approves it to continue or stops the pipeline for manual revision.
+7. **`hbr-publisher` runs** (on approval) — formats the article for web publication (SEO metadata, social snippets) and generates a professional PDF. Produces two files: a markdown version and a PDF.
+
+## The Pipeline in Detail
+
+| Phase | Agent/Component | Input | Output | What Makes It Autonomous |
+|-------|----------------|-------|--------|--------------------------|
+| Research | `ai-productivity-researcher` | Goal prompt | Structured case study briefs | Agent decides which sources to search and which cases meet the quality bar |
+| Writing | `tech-executive-writer` | Research briefs | Full article draft | Agent structures the narrative, chooses which cases to feature, and adapts tone for the audience |
+| Editing | `hbr-editor` + skill | Article draft | Edited draft with tracked changes | Agent applies codified editorial criteria — not subjective taste, but documented standards |
+| Review gate | SubagentStop hook | Edited draft | Human approval or rejection | Pipeline pauses automatically — human decides quality, not the AI |
+| Publishing | `hbr-publisher` | Approved draft | PDF + markdown files | Agent handles formatting, metadata, and layout without human input |
+
+### Why Multiple Agents Instead of One?
+
+Each agent is a specialist. The researcher knows where to find credible business case studies. The writer knows how to structure executive-level content. The editor knows HBR's specific editorial standards (loaded from a skill file with reference criteria). The publisher knows formatting and SEO.
+
+A single generalist prompt could attempt all of this, but the output quality degrades because no single prompt can encode deep expertise across research methodology, executive writing style, editorial standards, and publication formatting. Splitting into specialists lets each agent focus on what it does best.
+
+### The Human Review Gate
+
+The SubagentStop hook is critical. It fires after the editor finishes and before the publisher starts, giving the human a chance to:
+
+- **Approve** — the article meets standards, continue to publishing
+- **Reject** — the article needs changes the AI can't make (factual corrections, strategic adjustments, tone shifts)
+
+This is a deliberate design choice. The pipeline is autonomous enough to produce a near-final draft without human involvement, but publishing is a high-stakes action — once an article goes out, it represents the author. The gate ensures a human makes that call.
+
+## Usage
+
+=== "Claude Code (Plugin)"
+
+    All five agents and the editing skill are included in the `course-examples` plugin.
+
+    ```bash
+    # Install the plugin (one time)
+    /plugin install course-examples@handsonai
+    ```
+
+    Then provide the goal prompt:
+
+    > "Please write an analysis and Harvard Business Review-style article on successful companies that you can find by doing research that have successfully used and applied AI agents to their business. This article is for a business leadership audience, and I'd like to have the final deliverable as a PDF, and markdown file."
+
+    Claude Code orchestrates the full pipeline automatically. You'll be prompted to review the draft at the human-in-the-loop gate before publishing proceeds.
+
+    !!! tip "Customize the topic"
+        Swap the article topic for anything relevant to a business audience. The pipeline structure stays the same — only the research and writing content changes:
+
+        - *"Write an HBR-style article about how mid-market companies are using AI to reduce customer churn"*
+        - *"Research and write a thought leadership piece on AI-driven supply chain optimization"*
+        - *"Produce a business article analyzing how professional services firms are adopting AI agents"*
+
+=== "Adapting Without Claude Code"
+
+    This pipeline is designed for Claude Code's multi-agent orchestration. Without it, you can still replicate the workflow manually by running each phase as a separate conversation:
+
+    1. **Research phase** — In any AI tool with web search, prompt: *"Find 5-7 documented case studies of companies successfully using AI agents, with quantified business outcomes. Prioritize sources from HBR, McKinsey, Forrester, or major business publications."*
+    2. **Writing phase** — In a new conversation, paste the research output and prompt: *"Write a 2,500-3,500 word article for a business leadership audience about these companies' AI agent implementations. Use an HBR editorial style."*
+    3. **Editing phase** — In a new conversation, paste the draft and prompt: *"Edit this article to HBR publication standards. Focus on: opening hook, evidence quality, active voice, and cutting redundancy."*
+    4. **Review** — Read the edited draft yourself.
+    5. **Publishing** — Format manually or use your preferred publishing tools.
+
+    The manual approach works but loses the seamless handoff between agents, the codified editorial standards from the skill file, and the automatic human review gate.
+
+## Adapting This Example
+
+The HBR article pipeline is one application, but the multi-agent orchestration pattern applies to any workflow where different phases require different expertise:
+
+- **Client deliverable pipeline** — researcher gathers data → analyst produces insights → writer creates the report → reviewer checks quality → designer formats the final document
+- **Sales proposal generation** — researcher profiles the prospect → writer drafts the proposal → pricing specialist adds numbers → reviewer ensures accuracy → formatter produces the PDF
+- **Course content creation** — researcher gathers source material → instructional designer structures the lesson → writer creates slides and exercises → editor reviews for clarity → publisher formats for the LMS
+- **Competitive intelligence reports** — scanner monitors competitor channels → analyst identifies key changes → writer summarizes findings → editor ensures accuracy → distributor sends to stakeholders
+
+To adapt: identify the distinct phases of your workflow and the specialist expertise each phase requires. If you'd assign different people to different phases in a team setting, those phases are candidates for different agents.
+
+## Related
+
+- [Deterministic Automation Workflow Example](./deterministic-automation.md) — when AI follows fixed rules with no judgment needed
+- [AI Collaborative Workflow Example](./ai-collaborative.md) — when AI and human iterate together
+- [Find AI Workflow Opportunities](../prompting/ai-workflow-opportunity-finder.md) — discover which workflows are candidates for autonomous agents
+- [Deconstruct Workflows into AI Building Blocks](../prompting/workflow-deconstruction-meta-prompt.md) — break down workflows into agent-ready steps
+- [Plugin Marketplace](../../plugins/index.md) — browse all agents and skills used in this pipeline

--- a/docs/how-to/workflow-examples/deterministic-automation.md
+++ b/docs/how-to/workflow-examples/deterministic-automation.md
@@ -1,0 +1,140 @@
+---
+title: "Workflow Example: Deterministic Automation"
+description: A worked example of a fully deterministic AI workflow — fixed rules, consistent output, no human judgment required during execution.
+---
+
+# Deterministic Automation
+
+> **AI involvement:** Executes a predefined sequence — criteria come from the input, output follows a fixed template.
+
+## What This Workflow Type Is
+
+A deterministic automation is a workflow where AI follows a fixed sequence of steps, applies predefined evaluation criteria, and produces output in a rigid template. The rules are defined upfront (in this case, by a buyer persona), the process is linear, and the output format never changes. The same input produces the same structured output every time.
+
+!!! info "At a Glance"
+    - **AI involvement:** Follows prescribed steps and applies predefined criteria
+    - **Human oversight:** Review output only — no steering during execution
+    - **Best for:** Prospecting, recurring reports, data formatting, template-driven research
+    - **Complexity:** Low — single prompt with structured input, no iteration required
+
+### Characteristics
+
+- **Repeatable** — runs the same way every time with any buyer persona
+- **Predictable** — output format and evaluation criteria are defined in advance
+- **Delegatable** — anyone with the persona file can run it and get consistent results
+- **Automatable** — can run on a schedule or be triggered by a pipeline
+
+### When to Use
+
+Use deterministic automation when you have a task that:
+
+- Follows clear, documented rules or criteria
+- Takes structured input and produces structured output
+- Doesn't require subjective judgment during execution
+- Repeats on a regular cadence (weekly prospecting, monthly reporting)
+
+## Example Scenario
+
+**The problem:** A sales leader needs to identify LinkedIn prospects that match a specific buyer persona. The research process is always the same — search by title and industry, evaluate against persona criteria, document findings in a consistent format — but manually doing it takes 45-60 minutes per batch. The criteria don't change between runs; only the prospects found are different.
+
+**The solution:** A workflow prompt that takes a buyer persona as input, executes a prescribed LinkedIn research sequence, and produces a structured prospect report with engagement recommendations. The evaluation criteria come directly from the persona file, so there's no subjective judgment — just systematic matching.
+
+## Building Blocks
+
+| Building Block | Type | Description | Source |
+|-------|------|-------------|--------|
+| `linkedin-prospect-research` | Prompt | Workflow that finds and qualifies 5 LinkedIn prospects against a buyer persona | [View on GitHub](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/prompts/linkedin-prospect-research.md) |
+| `buyer-persona-revenue-leader-rachel` | Prompt | Example buyer persona used as input to the research workflow | [View on GitHub](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/prompts/buyer-persona-revenue-leader-rachel.md) |
+
+## How It Works
+
+```mermaid
+graph LR
+    A[Buyer persona<br>defines criteria] --> B[Workflow prompt<br>searches LinkedIn]
+    B --> C[Evaluate prospects<br>against persona criteria]
+    C --> D[Structured report<br>with 5 qualified prospects]
+```
+
+**Step-by-step:**
+
+1. **Provide the buyer persona** — the persona file defines the target titles, industries, company sizes, pain points, and trigger events. These become the evaluation criteria.
+2. **Workflow analyzes the persona** — extracts job titles, industry, company size, seniority, location, and exclusion criteria.
+3. **Workflow searches LinkedIn** — uses the persona criteria as search filters, systematically reviewing results.
+4. **Workflow evaluates each prospect** — checks role match, company fit, engagement signals, and accessibility (mutual connections, shared groups). Selects the top 5.
+5. **Workflow generates the report** — documents each prospect with profile URL, title, company, persona match reasons, and a specific engagement hook. Includes a summary with selection rationale, common themes, and priority ranking.
+6. **Quality check** — verifies all 5 prospects match criteria, URLs are complete, engagement recommendations are specific (not generic), and the output is properly formatted.
+
+## The Workflow in Detail
+
+The prompt encodes a five-step sequence that the AI executes in order:
+
+| Step | What Happens | Why It's Deterministic |
+|------|-------------|----------------------|
+| 1. Analyze persona | Extract titles, industry, size, location, pain points, triggers | Criteria are predefined in the input file |
+| 2. Access LinkedIn | Navigate and confirm authentication | Binary check — logged in or not |
+| 3. Search and evaluate | Apply persona criteria as search filters, score prospects | Evaluation rules are fixed: title match → company fit → engagement signals → accessibility |
+| 4. Document prospects | Capture name, URL, title, company, match reasons, engagement hook | Output fields are prescribed |
+| 5. Generate report | Format into template with summary, themes, and priority order | Template is rigid — same structure every run |
+
+The prompt also includes explicit error handling for three failure modes (fewer than 5 matches, LinkedIn access restricted, incomplete persona), so the workflow handles exceptions without human intervention.
+
+## The Buyer Persona
+
+The included example persona — "Revenue Leader Rachel" — demonstrates the kind of structured input this workflow expects. Key fields the workflow extracts:
+
+- **Target titles:** SVP/VP of Revenue, CRO, VP of Customer Solutions, VP/Head of Operations, Chief Customer Officer
+- **Company context:** B2B SaaS, 200-2,000 employees, Series B through public
+- **Location:** Major metro areas (NYC, SF, Boston, Chicago)
+- **Pain points:** Scaling without headcount, cross-functional execution gaps, ROI on AI investments
+- **Trigger events:** Board asking about AI strategy, competitors announcing AI features, failed AI pilots
+
+You can swap in any buyer persona that follows a similar structure. The workflow adapts to whatever criteria the persona defines.
+
+## Usage
+
+=== "Any AI Tool (Portable)"
+
+    This example uses two **standalone prompts** — the workflow and the buyer persona. Both are plain markdown files you can use with any AI tool that has web browsing.
+
+    1. Open the [linkedin-prospect-research prompt](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/prompts/linkedin-prospect-research.md) on GitHub
+    2. Open the [buyer persona](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/prompts/buyer-persona-revenue-leader-rachel.md) on GitHub
+    3. Copy the workflow prompt into Claude, ChatGPT, or Gemini (with web browsing enabled)
+    4. Paste or attach the buyer persona as context
+    5. The AI executes the workflow and produces the prospect report
+
+    !!! note "Web browsing required"
+        This workflow requires an AI tool with web browsing capability (LinkedIn access). In ChatGPT, enable "Browse with Bing." In Claude, use a session with computer use or MCP browser access. In Gemini, web search is enabled by default.
+
+=== "Claude Code (Plugin)"
+
+    If you have the `course-examples` plugin installed, both prompt files are available locally in the plugin directory.
+
+    ```bash
+    # Install the plugin (one time)
+    /plugin install course-examples@handsonai
+    ```
+
+    Then reference both files in a Claude Code conversation:
+
+    > "Run the LinkedIn prospect research workflow using the Revenue Leader Rachel buyer persona"
+
+    Claude will read both files from the plugin directory, execute the workflow steps, and produce the structured report.
+
+## Adapting This Example
+
+LinkedIn prospect research is one application, but the deterministic pattern works for any task with predefined criteria and a fixed output template:
+
+- **Customer account scoring** — score accounts against an ideal customer profile, produce a ranked list
+- **Job candidate screening** — evaluate resumes against a job description's requirements, produce a shortlist with match reasons
+- **Vendor evaluation** — assess proposals against scoring criteria, produce a comparison matrix
+- **Content audit** — evaluate published content against brand guidelines, produce a compliance report
+- **Competitive monitoring** — check competitor websites against a tracking template, produce a change report
+
+To adapt: identify the **input criteria** (the persona equivalent), the **evaluation rules** (how to score matches), and the **output template** (what the report looks like). If all three are defined before execution, it's a deterministic automation.
+
+## Related
+
+- [AI Collaborative Workflow Example](./ai-collaborative.md) — when AI needs to research, reason, and iterate with a human
+- [Autonomous Agent Workflow Example](./autonomous-agent.md) — when AI executes end-to-end with minimal supervision
+- [Find AI Workflow Opportunities](../prompting/ai-workflow-opportunity-finder.md) — discover which of your workflows are candidates for automation
+- [Deconstruct Workflows into AI Building Blocks](../prompting/workflow-deconstruction-meta-prompt.md) — break down complex workflows into automatable steps

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -57,12 +57,14 @@ Working examples of agents and skills from the Hands-on AI cohort courses.
     | [`ai-news-researcher`](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/agents/ai-news-researcher.md) | Scans news outlets, blogs, YouTube channels, podcasts, and communities for the latest AI developments. Categorizes findings by product releases, research, company updates, and community highlights. |
     | [`ai-productivity-researcher`](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/agents/ai-productivity-researcher.md) | Finds documented case studies of companies using AI for productivity gains. Prioritizes HBR-caliber sources with quantified outcomes. Outputs structured case study briefs. |
     | [`claude-research-daily`](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/agents/claude-research-daily.md) | Produces a daily brief on Anthropic, Claude, Claude Code, and Cowork. Covers official announcements, tech news, video content, tutorials, and community discussions from the last 24 hours. |
+    | [`meeting-prep-researcher`](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/agents/meeting-prep-researcher.md) | Researches meeting attendees and companies, then produces a structured prep brief with profiles, talking points, and suggested questions. |
 
 ???+ skills "Skills included"
 
     | Skill | What it does |
     |-------|-------------|
     | [`editing-hbr-articles`](https://github.com/jamesgray-ai/handsonai/tree/main/plugins/course-examples/skills/editing-hbr-articles/) | Loads HBR editorial criteria for article editing. Used by the `hbr-editor` agent to apply specific standards for openings, evidence, voice, and length. Includes a reference file with cut/replace patterns and source quality hierarchy. |
+    | [`meeting-prep-research`](https://github.com/jamesgray-ai/handsonai/tree/main/plugins/course-examples/skills/meeting-prep-research/) | Step-by-step research workflow for meeting preparation. Guides the meeting-prep-researcher agent through attendee research, company analysis, and prep brief generation. |
 
 ???+ usage "Example usage"
 
@@ -84,6 +86,9 @@ Working examples of agents and skills from the Hands-on AI cohort courses.
 
     "What's the latest news about Claude?"
     → claude-research-daily produces a 24-hour brief on all things Claude
+
+    "I have a meeting with Sarah Chen from Acme Corp tomorrow. Help me prepare."
+    → meeting-prep-researcher researches the attendee and company, produces a prep brief
     ```
 
 ---
@@ -140,7 +145,7 @@ Document, name, register, and sync AI operational workflows and skills.
 
 | Plugin | Agents | Skills | Install command |
 |--------|--------|--------|----------------|
-| `course-examples` | 6 | 1 | `/plugin install course-examples@handsonai` |
+| `course-examples` | 7 | 2 | `/plugin install course-examples@handsonai` |
 | `ai-registry` | 0 | 5 | `/plugin install ai-registry@handsonai` |
 
 All plugins are maintained in the [handsonai GitHub repository](https://github.com/jamesgray-ai/handsonai).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,6 +137,11 @@ nav:
       - Find AI Workflow Opportunities: how-to/prompting/ai-workflow-opportunity-finder.md
       - Deconstruct Workflows into AI Building Blocks: how-to/prompting/workflow-deconstruction-meta-prompt.md
       - Write Custom Workspace Instructions: how-to/prompting/workspace-instructions-meta-prompt.md
+    - Workflows:
+      - Overview: how-to/workflow-examples/README.md
+      - Deterministic Automation: how-to/workflow-examples/deterministic-automation.md
+      - AI Collaborative: how-to/workflow-examples/ai-collaborative.md
+      - Autonomous Agent: how-to/workflow-examples/autonomous-agent.md
   - Questions:
     - Overview: questions/README.md
     - Agents: questions/agents/README.md

--- a/plugins/course-examples/.claude-plugin/plugin.json
+++ b/plugins/course-examples/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "course-examples",
   "description": "Working examples of Claude Code agents and skills from the Hands-on AI cohort courses. Includes HBR content writing, editing, and publishing agents, AI research agents, and an editorial criteria skill.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "James Gray"
   },
   "homepage": "https://handsonai.info/plugins/",
   "license": "MIT",
-  "keywords": ["course", "examples", "agents", "skills", "hbr", "research"]
+  "keywords": ["course", "examples", "agents", "skills", "hbr", "research", "workflows", "automation", "collaborative", "autonomous"]
 }

--- a/plugins/course-examples/agents/meeting-prep-researcher.md
+++ b/plugins/course-examples/agents/meeting-prep-researcher.md
@@ -1,0 +1,90 @@
+---
+name: meeting-prep-researcher
+description: "Use this agent when the user needs to prepare for an upcoming meeting by researching attendees, companies, or topics. This includes requests to look up someone before a call, prepare talking points, find recent news about a company, or build context for a sales meeting, interview, or partnership discussion.\n\nExamples:\n\n<example>\nContext: User has an upcoming sales call\nuser: \"I have a meeting with Sarah Chen from Acme Corp tomorrow. Help me prepare.\"\nassistant: \"I'll use the meeting prep researcher agent to research the attendee and company so you have context for your call.\"\n<Task tool call to meeting-prep-researcher agent>\n</example>\n\n<example>\nContext: User needs context for a partnership meeting\nuser: \"Research DataFlow Labs before my meeting on Thursday\"\nassistant: \"Let me launch the meeting prep researcher agent to gather background on DataFlow Labs and prepare talking points.\"\n<Task tool call to meeting-prep-researcher agent>\n</example>\n\n<example>\nContext: User asks for a meeting brief\nuser: \"Put together a prep doc for my 2pm call with the marketing team at Rivian\"\nassistant: \"I'll use the meeting prep researcher agent to compile a meeting prep brief with company background, attendee profiles, and suggested talking points.\"\n<Task tool call to meeting-prep-researcher agent>\n</example>"
+model: sonnet
+color: blue
+---
+
+You are an expert Meeting Preparation Researcher. Your job is to help the user prepare for upcoming meetings by researching attendees, companies, and relevant topics, then producing a concise prep brief for human review.
+
+## Your Core Responsibilities
+
+1. **Attendee Research**: For each person the user will meet with:
+   - Search for their LinkedIn profile, role, and background
+   - Find recent posts, articles, or public statements they've made
+   - Identify shared connections, interests, or conversation starters
+   - Note their decision-making authority (if discernible)
+
+2. **Company Research**: For the company or organization involved:
+   - Search for recent news, press releases, and announcements (last 90 days)
+   - Identify the company's current priorities, challenges, or strategic direction
+   - Find relevant industry context and competitive landscape
+   - Check for any recent leadership changes, funding rounds, or product launches
+
+3. **Topic Preparation**: Based on the meeting context:
+   - Identify likely discussion topics and prepare talking points
+   - Surface potential objections or concerns and suggest responses
+   - Find relevant data points, case studies, or examples that support the user's position
+   - Identify open questions the user should ask
+
+## Output Format
+
+Produce a **Meeting Prep Brief** using this structure:
+
+---
+
+**Meeting Prep Brief**
+
+**Meeting:** [Purpose/type of meeting]
+**Date:** [If provided]
+**With:** [Attendee names and roles]
+
+### Attendee Profiles
+
+For each attendee:
+
+**[Name] — [Title] at [Company]**
+- **Background:** [2-3 sentences on their role, tenure, and relevant experience]
+- **Recent activity:** [Any recent posts, talks, or public statements worth noting]
+- **Conversation starters:** [1-2 specific, non-generic topics based on their interests or recent activity]
+
+### Company Snapshot
+
+- **What they do:** [One sentence]
+- **Size & stage:** [Employees, funding, revenue if public]
+- **Recent news:** [2-3 bullet points of notable recent developments]
+- **Strategic priorities:** [What they appear to be focused on based on recent signals]
+
+### Suggested Talking Points
+
+1. [Talking point with brief rationale]
+2. [Talking point with brief rationale]
+3. [Talking point with brief rationale]
+
+### Questions to Ask
+
+1. [Thoughtful question that demonstrates preparation]
+2. [Question that surfaces the attendee's priorities or pain points]
+3. [Question that advances the user's goal for the meeting]
+
+### Watch Out For
+
+- [Potential sensitive topic or landmine to avoid]
+- [Possible objection and suggested response]
+
+---
+
+## Research Process
+
+1. **Gather context** — Ask the user for: who they're meeting, what company, what the meeting is about, and what outcome they're hoping for. If they've only provided a name, ask for the rest.
+2. **Research broadly** — Use web search to find attendee profiles, company news, and relevant industry context. Cast a wide net first.
+3. **Synthesize and filter** — Focus on information that's actionable for the meeting. Cut anything that's generic, outdated, or irrelevant.
+4. **Present the brief** — Deliver the formatted prep brief and ask if the user wants to go deeper on any section.
+
+## Important Guidelines
+
+- **Recency matters.** Prioritize information from the last 90 days. Old news is not useful for meeting prep.
+- **Be specific, not generic.** "They recently launched a new AI product" is better than "They are focused on innovation."
+- **Flag uncertainty.** If you can't verify something, say so. Don't present speculation as fact.
+- **Respect the user's time.** Keep the brief scannable. The user should be able to read it in 5 minutes.
+- **This is collaborative.** You research and draft; the user reviews, adjusts, and decides what to use. Always ask if the brief needs refinement before the meeting.

--- a/plugins/course-examples/prompts/buyer-persona-revenue-leader-rachel.md
+++ b/plugins/course-examples/prompts/buyer-persona-revenue-leader-rachel.md
@@ -1,0 +1,203 @@
+# Buyer Persona: "Revenue Leader Rachel"
+
+## Demographics & Background
+
+**Name**: Rachel
+**Age**: 40-55
+**Education**: MBA from top-tier business school (Harvard, Stanford, Wharton) + technical/specialized master's degree
+**Location**: Major metro area (New York, San Francisco, Boston, Chicago)
+**Years of Experience**: 15-25+ years, with 10+ in executive leadership
+
+## Professional Profile
+
+**Current Role**: SVP/VP-level Revenue, Operations, or Commercial Leader
+**Title Examples**:
+- SVP/VP of Revenue
+- Chief Revenue Officer
+- VP of Customer Solutions
+- VP/Head of Operations
+- Chief Customer Officer
+
+**Company Context**:
+- B2B SaaS or technology company
+- 200-2,000 employees
+- Series B through publicly-traded
+- Complex, technical products requiring consultative sales
+- Already invested in AI platforms (Microsoft, OpenAI, Google, Anthropic)
+
+**Organizational Scope**:
+Rachel owns multiple cross-functional teams spanning sales, marketing, customer success, support, technical services, and operations. She built teams from 0 to 50-80+ people and is accountable for both revenue generation and customer retention. She's a player-coach who balances strategic thinking with operational execution.
+
+## The Challenge: What Keeps Rachel Up at Night
+
+### Primary Pain Points
+
+**1. Scale Without Proportional Headcount**
+"We scaled enrollments 60x but I can't scale my team 60x. I need AI to help us work smarter, but my team doesn't know where to start."
+
+**2. Cross-Functional Execution Gaps**
+Rachel manages diverse teams (technical and non-technical) who need to work seamlessly together. She struggles with:
+- Inefficient handoffs between marketing → sales → delivery
+- Manual processes that slow time-to-launch
+- Lack of standardized playbooks across teams
+
+**3. Demonstrating ROI on Tech Investments**
+Her company already invested in enterprise AI tools, but adoption is low and measurable impact is unclear. The board wants to see results.
+
+**4. Competitive Pressure to Modernize**
+Competitors are moving faster with AI-first approaches. Rachel knows her teams need to become AI-capable or risk falling behind.
+
+**5. Building Operational Rigor at Speed**
+She's trying to mature operations (forecast accuracy, pipeline hygiene, account planning) while simultaneously scaling fast. She needs systems and tools that help her team execute consistently.
+
+## Goals & Motivations
+
+### Professional Goals
+- **Scale efficiently**: Drive 2-3x growth without 2-3x headcount expansion
+- **Build durable systems**: Create repeatable, scalable processes across GTM and delivery
+- **Team transformation**: Upskill teams from "AI-curious" to "AI-capable"
+- **Measurable impact**: Show clear ROI on AI investments through productivity gains and faster execution
+- **Executive credibility**: Position herself as a forward-thinking leader driving innovation
+
+### Personal Motivations
+- **Continuous learner**: Values staying ahead of industry trends (evidenced by taking multiple certifications)
+- **Hands-on executor**: Not interested in theory; wants practical tools she can implement Monday morning
+- **Team builder**: Takes pride in developing high-performing teams and wants to give them cutting-edge skills
+- **Problem solver**: Energized by figuring out how to do more with less
+
+## Behavioral Characteristics
+
+**Decision-Making Style**:
+- **Fast when convinced**: Can move quickly with executive sponsorship
+- **ROI-focused**: Wants to see clear business outcomes, not just completion rates
+- **Experimentation mindset**: Willing to pilot new approaches but needs early wins to justify broader investment
+- **Peer validation**: Values case studies and testimonials from other leaders in similar roles
+
+**Learning Preferences**:
+- **Hands-on, applied learning** over theoretical frameworks
+- **Cohort-based** for peer learning and accountability
+- **Custom, relevant** to her specific tech stack and use cases
+- **Intensive but efficient**: Will invest focused time if outcomes are clear
+
+**Communication Style**:
+- Direct, results-oriented
+- Uses business language, not technical jargon
+- Values operational rigor and accountability
+- Focused on "how" not just "what"
+
+## The Buyer Journey
+
+### Awareness Stage: "We need to do something about AI"
+**Trigger Events**:
+- Board asks about AI strategy and ROI on existing tools
+- Competitors announce AI-powered features or productivity gains
+- Team struggling with manual, repetitive tasks that AI could automate
+- Failed pilot projects that didn't gain traction
+
+**What Rachel Does**:
+- Searches LinkedIn for "AI for executives," "AI adoption," "AI productivity"
+- Reads articles from HBR, McKinsey about AI transformation
+- Asks peers in her network what they're doing about AI
+- Attends webinars or conferences about AI in business
+
+### Consideration Stage: "What kind of training do we need?"
+**Key Questions**:
+- Is this theoretical or hands-on?
+- Will my team actually be able to implement this?
+- How long will it take and what's the time commitment?
+- Can it be customized to our specific tools and use cases?
+- What results have other executives seen?
+
+**What Rachel Evaluates**:
+- Instructor credibility (has this person actually done what I'm trying to do?)
+- Student testimonials from similar roles/industries
+- Curriculum relevance to her tech stack
+- Flexibility for busy executives
+- Price relative to expected ROI
+
+### Decision Stage: "Is this the right investment?"
+**Decision Criteria**:
+- **Practical application**: Can implement immediately in real workflows
+- **Executive-level**: Not too technical, not too basic
+- **Proven results**: Case studies showing productivity gains
+- **Time-efficient**: Respects busy executive schedules
+- **Ongoing support**: Not just a one-time course
+
+**Budget Authority**: Rachel controls or heavily influences L&D/training budget. She can make decisions up to $10K-$50K without extensive approvals.
+
+**Who Else Is Involved**:
+- May discuss with CEO/COO for larger engagements
+- May coordinate with Chief People Officer for team-wide rollouts
+- Seeks peer validation from other executives in her network
+
+## How Rachel Uses AI (Post-Training)
+
+After completing training, Rachel applies AI to:
+
+**Personal Productivity**:
+- Email triage and response drafting
+- Meeting preparation and note-taking
+- Strategic document creation (exec summaries, board updates)
+- Research and competitive analysis
+
+**Team Enablement**:
+- Creating sales enablement materials at scale
+- Standardizing playbooks and processes
+- Automating reporting and forecasting
+- Improving customer communication templates
+
+**Strategic Initiatives**:
+- Analyzing customer feedback to inform product roadmap
+- Identifying operational bottlenecks
+- Testing new GTM approaches faster
+- Building business cases for new investments
+
+## Objections & Barriers
+
+**Common Concerns**:
+- "My team is already overwhelmed—how do we find time for training?"
+- "We tried AI pilots before and they didn't stick"
+- "Is this just going to be theoretical or can we actually use this?"
+- "Will this work with our specific tools and workflows?"
+- "How do I measure success and ROI?"
+
+**What Overcomes Objections**:
+- Testimonials from other executives showing time savings
+- Clear implementation plan and ongoing support
+- Custom curriculum aligned to their tech stack
+- Quick wins in first week that demonstrate value
+- Cohort model providing peer accountability
+
+## Media Consumption & Channels
+
+**Professional Development**:
+- LinkedIn (primary platform for content consumption)
+- Industry conferences and executive forums
+- Harvard Business Review, McKinsey Quarterly
+- Podcasts during commute (business/leadership focused)
+- Peer recommendation groups and Slack communities
+
+**Content Preferences**:
+- Case studies and success stories
+- Practical how-to guides
+- Executive interviews and panels
+- Data-driven insights with clear takeaways
+- Short-form content (can consume in 5-10 minutes)
+
+## Success Metrics (How Rachel Defines Value)
+
+**90 Days Post-Training**:
+- Team using AI tools daily for high-value tasks
+- Measurable time savings (e.g., 5-10 hours/week per team member)
+- At least 3 new workflows automated or optimized with AI
+- Improved quality/consistency in team outputs
+
+**6-12 Months Post-Training**:
+- Demonstrable productivity gains (can do more with same team size)
+- Faster execution on key initiatives (reduced time-to-launch)
+- Team members become AI champions who train others
+- Clear ROI that can be presented to board/CEO
+
+## Quote That Captures Rachel
+
+*"I don't need my team to become AI engineers—I need them to become AI-capable operators who can leverage these tools to execute faster, scale smarter, and deliver better outcomes for our customers. Show me how to do that in 30 days, and I'm in."*

--- a/plugins/course-examples/prompts/linkedin-prospect-research.md
+++ b/plugins/course-examples/prompts/linkedin-prospect-research.md
@@ -1,0 +1,173 @@
+# LinkedIn Prospect Research Workflow
+
+A portable workflow prompt that takes a buyer persona and identifies 5 matching LinkedIn prospects with engagement recommendations. Works with any AI tool that has web browsing capability — Claude, ChatGPT, Gemini, or M365 Copilot.
+
+## How to Use
+
+1. Copy the prompt below into any AI conversation (with web browsing enabled)
+2. Attach or paste your buyer persona file as context
+3. Receive a structured prospect research report with 5 qualified prospects
+
+## The Prompt
+
+```text
+# LinkedIn Prospect Research Workflow
+
+## Purpose
+Identify and qualify 5 LinkedIn prospects that match a provided buyer persona, then output actionable engagement recommendations.
+
+---
+
+## Instructions
+
+### Step 1: Analyze the Buyer Persona
+
+Read the provided buyer persona markdown file completely. Extract and internalize:
+
+- **Job titles/roles** the ideal prospect holds
+- **Industry/vertical** they work in
+- **Company size** (employees, revenue if specified)
+- **Seniority level** (C-suite, VP, Director, Manager, etc.)
+- **Geographic location** preferences
+- **Key pain points** they likely experience
+- **Trigger events** that indicate buying readiness
+- **Any exclusion criteria** (companies/roles to avoid)
+
+If the persona file is missing critical information, note what assumptions you're making based on common patterns for similar buyer profiles.
+
+---
+
+### Step 2: Access LinkedIn
+
+1. Navigate to **linkedin.com**
+2. Confirm you are logged into the authenticated account
+3. If not logged in, stop and notify the user that authentication is required
+
+---
+
+### Step 3: Search for Matching Prospects
+
+Use LinkedIn's search functionality strategically:
+
+**Search approach:**
+1. Start with **People search** using the primary job title(s) from the persona
+2. Apply filters that match persona criteria:
+   - Current company industry
+   - Location/geography
+   - Connections (2nd degree often best for warm outreach)
+   - Company size if available
+3. Review search results systematically
+
+**For each potential prospect, evaluate:**
+- Does their current role match the persona's target titles?
+- Is their company in the right industry/size range?
+- Do they show signals of relevance (posts about relevant topics, recent role changes, company growth)?
+- Are there mutual connections or shared groups?
+
+**Select exactly 5 prospects** that best match the persona criteria. Prioritize:
+1. Strong title/role match
+2. Company fit (industry, size)
+3. Engagement signals (active on LinkedIn, posts about relevant topics)
+4. Accessibility (2nd-degree connections, shared groups)
+
+---
+
+### Step 4: Document Each Prospect
+
+For each of the 5 selected prospects, capture:
+
+- **Full name**
+- **LinkedIn profile URL**
+- **Current job title**
+- **Company name**
+- **Why they match the persona** (2-3 specific reasons)
+- **Engagement hook** (something specific from their profile to reference in outreach)
+
+---
+
+### Step 5: Generate Output File
+
+Create a markdown file named `prospect-research-[DATE].md` with the following structure:
+
+# Prospect Research Results
+
+**Date:** [Current Date]
+**Buyer Persona:** [Persona Name/Title from input file]
+**Prospects Identified:** 5
+
+---
+
+## Prospect 1: [Full Name]
+
+**LinkedIn:** [Profile URL]
+**Title:** [Current Job Title]
+**Company:** [Company Name]
+
+**Persona Match:**
+[2-3 bullet points explaining why this prospect fits the buyer persona]
+
+**Recommended Engagement Approach:**
+[Specific, actionable next step based on their profile - e.g., comment on a recent post, reference shared connection, mention specific content they've engaged with]
+
+---
+
+[Continue for all 5 prospects]
+
+---
+
+## Summary
+
+**Selection Rationale:**
+[Brief paragraph explaining the overall approach and why these 5 prospects represent strong opportunities]
+
+**Common Themes:**
+[Any patterns noticed across prospects that could inform messaging]
+
+**Recommended Priority Order:**
+1. [Name] - [One-line reason]
+2. [Name] - [One-line reason]
+3. [Name] - [One-line reason]
+4. [Name] - [One-line reason]
+5. [Name] - [One-line reason]
+
+---
+
+## Quality Criteria
+
+Before completing, verify:
+
+- [ ] All 5 prospects clearly match the buyer persona criteria
+- [ ] Each LinkedIn URL is complete and accurate
+- [ ] Engagement recommendations are specific (not generic)
+- [ ] The summary explains selection logic clearly
+- [ ] Output file is properly formatted markdown
+
+---
+
+## Error Handling
+
+**If fewer than 5 matching prospects are found:**
+- Document however many were found
+- Note in the summary what criteria were relaxed or what limitations were encountered
+- Suggest alternative search strategies
+
+**If LinkedIn access is restricted:**
+- Stop immediately and notify the user
+- Do not attempt to bypass any LinkedIn limitations
+
+**If persona file is incomplete:**
+- Note missing information
+- State assumptions made
+- Proceed with best judgment based on available data
+```
+
+## What Makes This Deterministic
+
+This workflow is deterministic — it follows a fixed sequence of steps, applies predefined evaluation criteria (from the buyer persona), and produces output in a rigid template. The rules for selecting and evaluating prospects are defined upfront, the output format never changes, and the quality checklist provides a binary pass/fail verification.
+
+This makes it ideal for:
+
+- **Delegation** — Anyone with the buyer persona file can run this workflow and get consistent results
+- **Repeatability** — Run it weekly or monthly against the same persona to find fresh prospects
+- **Consistency** — Every research report follows the same structure, making it easy to compare across runs
+- **Handoff** — The structured output is immediately usable by a sales team without further formatting

--- a/plugins/course-examples/prompts/meeting-prep-quick.md
+++ b/plugins/course-examples/prompts/meeting-prep-quick.md
@@ -1,0 +1,40 @@
+# Meeting Prep Quick Prompt
+
+A portable prompt for quick meeting preparation. Works with any AI tool — Claude, ChatGPT, Gemini, or M365 Copilot. For a more thorough, automated research experience in Claude Code, use the `meeting-prep-researcher` agent instead.
+
+## How to Use
+
+1. Copy the prompt below into any AI conversation
+2. Fill in the details about your upcoming meeting
+3. Review and refine the output before your meeting
+
+## The Prompt
+
+```text
+I have an upcoming meeting and need to prepare. Here are the details:
+
+**Meeting with:** [Name(s) and title(s)]
+**Company:** [Company name]
+**Meeting type:** [Sales call / partnership discussion / interview / team sync / other]
+**My goal:** [What I want to accomplish in this meeting]
+**Context:** [Any additional context — how we connected, prior conversations, etc.]
+
+Please research the attendee(s) and company, then produce a concise meeting prep brief that includes:
+
+1. **Attendee profiles** — Background, role, recent public activity, and 1-2 specific conversation starters
+2. **Company snapshot** — What they do, recent news (last 90 days), and apparent strategic priorities
+3. **Suggested talking points** — 3 specific points tailored to my goal, with brief rationale for each
+4. **Questions to ask** — 3 thoughtful questions that demonstrate preparation and advance my goal
+5. **Watch out for** — Any sensitive topics, potential objections, or landmines to avoid
+
+Keep the brief scannable — I should be able to read it in under 5 minutes. Prioritize recent, specific, actionable information over generic background.
+```
+
+## When to Use This vs. the Agent
+
+| Scenario | Use this prompt | Use the agent |
+|----------|----------------|---------------|
+| Quick prep in any AI tool | Yes | No — agent is Claude Code only |
+| Deep research with follow-up questions | No — limited to one exchange | Yes — agent can iterate |
+| Need to prep for multiple meetings | Copy-paste for each | Agent handles the conversation flow |
+| Team members without Claude Code | Yes | Not available to them |

--- a/plugins/course-examples/skills/meeting-prep-research/SKILL.md
+++ b/plugins/course-examples/skills/meeting-prep-research/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: meeting-prep-research
+description: >
+  Research attendees and companies before meetings. Produces a structured meeting prep
+  brief with attendee profiles, company snapshots, talking points, and suggested questions.
+  Use when the user mentions preparing for a meeting, researching someone before a call,
+  or needing talking points for an upcoming conversation.
+---
+
+# Meeting Prep Research
+
+Research meeting attendees and their companies to produce a concise, actionable prep brief.
+
+## Workflow
+
+1. **Gather meeting details** — Ask for: attendee name(s), company, meeting type, and the user's goal
+2. **Research attendees** — Search for LinkedIn profiles, recent posts, and public activity
+3. **Research company** — Search for recent news, strategic direction, and relevant context
+4. **Synthesize brief** — Produce a formatted Meeting Prep Brief (see format below)
+5. **Refine with user** — Ask if any section needs more depth or adjustment
+
+## Output Format
+
+```markdown
+**Meeting Prep Brief**
+
+**Meeting:** [Purpose]
+**With:** [Names and roles]
+
+### Attendee Profiles
+[Name — Title at Company]
+- Background: [2-3 sentences]
+- Recent activity: [Notable posts or statements]
+- Conversation starters: [1-2 specific topics]
+
+### Company Snapshot
+- What they do: [One sentence]
+- Recent news: [2-3 bullets, last 90 days]
+- Strategic priorities: [Current focus areas]
+
+### Suggested Talking Points
+1. [Point with rationale]
+2. [Point with rationale]
+3. [Point with rationale]
+
+### Questions to Ask
+1. [Preparation-demonstrating question]
+2. [Priority-surfacing question]
+3. [Goal-advancing question]
+
+### Watch Out For
+- [Sensitive topics or potential objections]
+```
+
+## Research Guidelines
+
+- **Prioritize recency** — information from the last 90 days is most valuable
+- **Be specific** — "They launched X product in January" beats "They're focused on innovation"
+- **Flag uncertainty** — distinguish verified facts from reasonable inferences
+- **Keep it scannable** — the brief should take under 5 minutes to read


### PR DESCRIPTION
## Summary

- Adds a **Workflows** subsection under How-To Guides with three worked examples showing the spectrum of AI involvement:
  - **Deterministic Automation** — LinkedIn prospect research using a buyer persona prompt and fixed evaluation rules
  - **AI Collaborative** — Meeting prep researcher where AI handles research and the human steers and reviews
  - **Autonomous Agent** — Multi-agent HBR article pipeline (existing agents: researcher → writer → editor → publisher) with a human review gate
- Adds new plugin assets to `course-examples` (1.0.0 → 1.1.0): `meeting-prep-researcher` agent, `meeting-prep-research` skill, and 3 portable prompts
- Updates plugin catalog page with new agent/skill counts and usage examples
- Each workflow page includes a mermaid diagram, building blocks table with GitHub links, dual-audience usage tabs (Any AI Tool / Claude Code), and adaptation guidance

## Test plan

- [ ] Run `mkdocs serve` and verify all four workflow pages render correctly under How-To Guides → Workflows
- [ ] Verify nav shows "Workflows" with "Overview", "Deterministic Automation", "AI Collaborative", "Autonomous Agent" as children
- [ ] Confirm mermaid diagrams render on all three workflow pages
- [ ] Confirm tabbed content (Any AI Tool / Claude Code) renders on all pages
- [ ] Verify plugin catalog page shows updated counts (7 agents, 2 skills)
- [ ] Confirm all GitHub links in building blocks tables point to valid paths after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)