### PR TITLE
Add question: best way to name Claude agent skills

### DIFF
--- a/docs/platforms/claude/questions/README.md
+++ b/docs/platforms/claude/questions/README.md
@@ -11,7 +11,7 @@ Questions specific to Anthropic's Claude models and API.
 
 | Question | Tags |
 |----------|------|
-| *Questions will be listed here as they are added* | |
+| [What is the best way to name Claude agent skills?](./what-is-the-best-way-to-name-claude-agent-skills.md) | `claude` |
 
 ## Related Resources
 

--- a/docs/platforms/claude/questions/what-is-the-best-way-to-name-claude-agent-skills.md
+++ b/docs/platforms/claude/questions/what-is-the-best-way-to-name-claude-agent-skills.md
@@ -1,0 +1,62 @@
+---
+question: "What is the best way to name Claude agent skills?"
+short_answer: "Name skills using a verb-noun pattern that describes the action and its context, like 'writing-workflow-sops' or 'registering-skills', so the name alone tells you what the skill does."
+platforms: [claude]
+topic: agents
+date: 2026-02-02
+author: James Gray
+---
+
+# What is the best way to name Claude agent skills?
+
+**Short answer:** Name skills using a verb-noun pattern that describes the action and its context, like 'writing-workflow-sops' or 'registering-skills', so the name alone tells you what the skill does.
+
+## The Full Answer
+
+Anthropic's official best practices recommend using **gerund form** (verb + -ing) as the primary naming pattern for agent skills. This clearly describes the activity or capability the skill provides. For example, `processing-pdfs` immediately tells you the skill handles PDF processing, and `writing-documentation` tells you it writes docs.
+
+The `name` field in a skill's YAML frontmatter has specific technical constraints: maximum 64 characters, lowercase letters, numbers, and hyphens only. You cannot use XML tags or reserved words like "anthropic" or "claude" in the name. These constraints keep names clean, URL-friendly, and consistent across the platform.
+
+Beyond the gerund convention, the most important principle is **consistency within your skill collection**. If you name one skill `writing-workflow-sops`, don't name the next one `sop-writer` or `create-sops`. Pick a pattern and stick with it. Consistent naming makes skills easier to reference in documentation, understand at a glance, search through, and maintain as your library grows.
+
+Noun phrases like `pdf-processing` and action-oriented names like `process-pdfs` are acceptable alternatives, but mixing patterns within the same collection creates confusion.
+
+## Naming Examples
+
+**Gerund form (recommended):**
+
+| Skill Name | What It Does |
+|-----------|--------------|
+| `processing-pdfs` | Handles PDF text extraction and manipulation |
+| `analyzing-spreadsheets` | Analyzes tabular data in spreadsheets |
+| `writing-documentation` | Generates documentation content |
+| `managing-databases` | Manages database operations |
+| `testing-code` | Runs and manages code tests |
+
+**Acceptable alternatives:**
+
+| Pattern | Example |
+|---------|---------|
+| Noun phrase | `pdf-processing`, `spreadsheet-analysis` |
+| Action-oriented | `process-pdfs`, `analyze-spreadsheets` |
+
+**Avoid these patterns:**
+
+| Pattern | Examples | Why |
+|---------|----------|-----|
+| Vague names | `helper`, `utils`, `tools` | Tells you nothing about what the skill does |
+| Overly generic | `documents`, `data`, `files` | Too broad to be useful |
+| Reserved words | `anthropic-helper`, `claude-tools` | Blocked by the platform |
+| Inconsistent patterns | Mixing `writing-docs` with `pdf-processor` | Creates confusion in your library |
+
+## Key Takeaways
+
+- Use **gerund form** (verb + -ing) as the default naming pattern: `writing-`, `processing-`, `analyzing-`
+- Keep names under 64 characters using only lowercase letters, numbers, and hyphens
+- Be consistent across your entire skill collection — don't mix naming patterns
+- The name should tell you what the skill does without reading the description
+- Avoid reserved words (`anthropic`, `claude`) and vague names (`helper`, `utils`)
+
+## Related Questions
+
+- [Official Anthropic skill authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#naming-conventions)

--- a/docs/questions/README.md
+++ b/docs/questions/README.md
@@ -34,6 +34,7 @@ Platform-specific questions are organized under each platform:
 | Question | Category | Platforms |
 |----------|----------|-----------|
 | [What is a system prompt?](./prompting/what-is-a-system-prompt.md) | Prompting | `openai` `claude` `gemini` |
+| [What is the best way to name Claude agent skills?](../platforms/claude/questions/what-is-the-best-way-to-name-claude-agent-skills.md) | Claude | `claude` |
 
 ## Can't Find Your Answer?
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,7 +83,9 @@ nav:
       - Skills:
         - Discover Your Best Claude Skills: platforms/claude/skills/skills-discovery-meta-prompt.md
         - Resources: platforms/claude/skills/resources.md
-      - Questions: platforms/claude/questions/README.md
+      - Questions:
+        - Overview: platforms/claude/questions/README.md
+        - Best way to name agent skills?: platforms/claude/questions/what-is-the-best-way-to-name-claude-agent-skills.md
       - Subagents:
         - Scheduling Subagents: platforms/claude/subagents/scheduling-subagents.md
         - Troubleshooting: platforms/claude/subagents/scheduling-subagent-issues.md


### PR DESCRIPTION
## Summary
- New AEO-optimized Q&A page: "What is the best way to name Claude agent skills?"
- Content sourced from Anthropic's official skill authoring best practices (gerund form, technical constraints, consistency)
- Added to Claude questions index, all questions table, and mkdocs.yml nav

## Test plan
- [ ] Preview page at `/platforms/claude/questions/what-is-the-best-way-to-name-claude-agent-skills/`
- [ ] Verify FAQPage JSON-LD schema renders in page source (from `question` and `short_answer` frontmatter)
- [ ] Confirm Claude Questions nav expands with the new entry
- [ ] Check links from the all questions table and category index resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)