### PR TITLE
Add strategy question category and three new Q&A pages

### DIFF
--- a/docs/platforms/claude/questions/README.md
+++ b/docs/platforms/claude/questions/README.md
@@ -12,6 +12,7 @@ Questions specific to Anthropic's Claude models and API.
 | Question | Tags |
 |----------|------|
 | [What is the best way to name Claude agent skills?](./what-is-the-best-way-to-name-claude-agent-skills.md) | `claude` |
+| [How do I schedule an automated Claude subagent?](./how-do-i-schedule-an-automated-claude-subagent.md) | `claude` |
 
 ## Related Resources
 

--- a/docs/platforms/claude/questions/how-do-i-schedule-an-automated-claude-subagent.md
+++ b/docs/platforms/claude/questions/how-do-i-schedule-an-automated-claude-subagent.md
@@ -1,0 +1,55 @@
+---
+question: "How do I schedule an automated Claude subagent?"
+short_answer: "Add scheduling instructions to your project's CLAUDE.md file, then ask Claude Code to schedule your subagent — it creates the wrapper scripts, logging, and OS-level scheduled task (launchd on macOS, Task Scheduler on Windows) automatically."
+platforms: [claude]
+topic: agents
+date: 2026-02-02
+author: James Gray
+---
+
+# How do I schedule an automated Claude subagent?
+
+**Short answer:** Add scheduling instructions to your project's CLAUDE.md file, then ask Claude Code to schedule your subagent — it creates the wrapper scripts, logging, and OS-level scheduled task (launchd on macOS, Task Scheduler on Windows) automatically.
+
+## The Full Answer
+
+Claude Code subagents can run on a schedule without any human interaction — like a research assistant that gathers information while you sleep, or a competitor monitor that runs every Monday morning. The key is that Claude Code handles all the platform-specific scheduling configuration for you. You don't need to write cron jobs, plist files, or PowerShell scripts yourself.
+
+The process has two prerequisites: Claude Code installed and authenticated, and a subagent already defined as a markdown file (e.g., `.claude/agents/my-agent.md`). Once those are in place, you add a scheduling section to your project's CLAUDE.md that tells Claude Code how to set up headless operation — using `--dangerously-skip-permissions` for unattended tool use, full paths to the Claude binary, and proper logging. Without these instructions, Claude Code won't know the special flags needed for scheduled operation and your subagent will fail silently.
+
+With the CLAUDE.md updated, scheduling is as simple as asking Claude Code: "Schedule my research-daily subagent to run every weekday at 7:30 AM." Claude Code creates the wrapper script, configures the OS scheduler (launchd on macOS, Task Scheduler on Windows), sets up logging, and activates it. On macOS, if your machine is asleep at the scheduled time, the subagent runs when it wakes up.
+
+You manage scheduled subagents entirely through Claude Code — pausing, resuming, changing schedules, viewing logs, and removing tasks are all conversational commands.
+
+## How to Get Started
+
+Follow the step-by-step guide: **[Scheduling Claude Code Subagents](../subagents/scheduling-subagents.md)**
+
+The guide covers:
+
+1. Adding the required scheduling instructions to your CLAUDE.md
+2. Asking Claude Code to create the schedule
+3. Testing the subagent manually
+4. Managing and troubleshooting scheduled tasks
+
+### Common Scheduling Patterns
+
+| Subagent Type | Suggested Schedule | Example Prompt |
+|---------------|-------------------|----------------|
+| Daily news/research | Weekdays at 7–8 AM | "Run every weekday at 7:30 AM" |
+| Competitor monitoring | Weekly on Monday | "Run every Monday at 8:00 AM" |
+| Weekly summaries | Friday afternoon | "Run every Friday at 4:00 PM" |
+| Frequent updates | Every few hours | "Run every 4 hours during business hours" |
+
+## Key Takeaways
+
+- Claude Code handles all the OS-level scheduling configuration — you just ask it in natural language
+- You must add scheduling instructions to your project's CLAUDE.md first, or headless operation will fail silently
+- Subagents use `--dangerously-skip-permissions` to run unattended — review what your subagent does before enabling this
+- On macOS, launchd catches up on missed runs when your machine wakes — your morning digest still gets created
+- Manage everything through Claude Code: pause, resume, reschedule, view logs, and remove tasks conversationally
+
+## Related Questions
+
+- [What is the best way to name Claude agent skills?](./what-is-the-best-way-to-name-claude-agent-skills.md)
+- [Scheduled Subagent Troubleshooting](../subagents/scheduling-subagent-issues.md)

--- a/docs/questions/README.md
+++ b/docs/questions/README.md
@@ -15,6 +15,12 @@ Questions about writing effective prompts, system messages, and prompt engineeri
 
 [Browse Prompting Questions](./prompting/README.md)
 
+### Strategy
+
+Questions about AI strategy, workflow analysis, opportunity identification, and business-level AI decisions.
+
+[Browse Strategy Questions](./strategy/README.md)
+
 ### Agents
 
 Questions about building AI agents, function calling, tool use, and multi-step workflows.
@@ -34,7 +40,10 @@ Platform-specific questions are organized under each platform:
 | Question | Category | Platforms |
 |----------|----------|-----------|
 | [What is a system prompt?](./prompting/what-is-a-system-prompt.md) | Prompting | `openai` `claude` `gemini` |
+| [How do I find workflows worth applying AI to?](./strategy/how-do-i-find-workflows-worth-applying-ai-to.md) | Strategy | `openai` `claude` `gemini` |
+| [How do I identify the right AI tools for a workflow?](./strategy/how-do-i-identify-the-right-ai-tools-for-a-workflow.md) | Strategy | `openai` `claude` `gemini` |
 | [What is the best way to name Claude agent skills?](../platforms/claude/questions/what-is-the-best-way-to-name-claude-agent-skills.md) | Claude | `claude` |
+| [How do I schedule an automated Claude subagent?](../platforms/claude/questions/how-do-i-schedule-an-automated-claude-subagent.md) | Claude | `claude` |
 
 ## Can't Find Your Answer?
 

--- a/docs/questions/strategy/README.md
+++ b/docs/questions/strategy/README.md
@@ -1,0 +1,20 @@
+---
+title: Strategy Questions
+description: Questions about AI strategy, workflow analysis, opportunity identification, and business-level AI decisions
+---
+
+# Strategy Questions
+
+Questions about AI strategy, workflow analysis, opportunity identification, and business-level AI decisions.
+
+## Questions
+
+| Question | Platforms |
+|----------|-----------|
+| [How do I find workflows worth applying AI to?](./how-do-i-find-workflows-worth-applying-ai-to.md) | `openai` `claude` `gemini` |
+| [How do I identify the right AI tools for a workflow?](./how-do-i-identify-the-right-ai-tools-for-a-workflow.md) | `openai` `claude` `gemini` |
+
+## Related Resources
+
+- [AI Workflow Opportunity Finder](../../how-to/prompting/ai-workflow-opportunity-finder.md)
+- [Workflow Deconstruction Meta-Prompt](../../how-to/prompting/workflow-deconstruction-meta-prompt.md)

--- a/docs/questions/strategy/how-do-i-find-workflows-worth-applying-ai-to.md
+++ b/docs/questions/strategy/how-do-i-find-workflows-worth-applying-ai-to.md
@@ -1,0 +1,44 @@
+---
+question: "How do I find workflows worth applying AI to?"
+short_answer: "Run a structured audit of your daily and weekly tasks across three categories — collaborative AI, deterministic workflows, and multi-agent systems — to find where AI can save time, reduce errors, or automate entire processes."
+platforms: [openai, claude, gemini]
+topic: strategy
+date: 2026-02-02
+author: James Gray
+---
+
+# How do I find workflows worth applying AI to?
+
+**Short answer:** Run a structured audit of your daily and weekly tasks across three categories — collaborative AI, deterministic workflows, and multi-agent systems — to find where AI can save time, reduce errors, or automate entire processes.
+
+## The Full Answer
+
+Most people adopt AI reactively — they reach for ChatGPT when stuck on an email or ask Claude to summarize a document. That's useful, but it misses the bigger picture. A proactive, structured audit of your workflows will reveal opportunities you'd never notice in the moment: repetitive tasks that could run on autopilot, decisions that benefit from an AI collaborator, and multi-step processes that could be orchestrated end-to-end.
+
+The key is thinking in three categories. **Collaborative AI** covers tasks where you and AI work together in real time — drafting, brainstorming, reviewing, analyzing. **Deterministic workflows** are repeatable processes with clear inputs and outputs that AI can execute reliably with little supervision — formatting reports, processing forms, generating routine communications. **Multi-agent systems** are complex workflows where multiple AI agents coordinate across steps — research-to-report pipelines, intake-to-triage systems, monitoring-to-response workflows.
+
+To run the audit, use the [AI Workflow Opportunity Finder](../../how-to/prompting/ai-workflow-opportunity-finder.md) — a meta prompt that guides an AI through a three-phase process: scanning what it already knows about your work, interviewing you to fill gaps, then producing a categorized report with specific opportunities and actionable first steps.
+
+Once you've identified opportunities, use the [Workflow Deconstruction Meta-Prompt](../../how-to/prompting/workflow-deconstruction-meta-prompt.md) to break individual workflows into AI building blocks and understand exactly where automation fits.
+
+## How to Get Started
+
+1. **Enable memory** in your AI tool of choice (Claude, ChatGPT, or Gemini) so the AI can draw on what it already knows about your work
+2. **Copy the prompt** from the [AI Workflow Opportunity Finder](../../how-to/prompting/ai-workflow-opportunity-finder.md)
+3. **Paste it into any conversation** — the AI will scan its context, interview you, and produce a structured report
+4. **Pick 1-2 opportunities** to pilot first — don't try to pursue everything at once
+
+!!! tip "Start with Collaborative AI"
+    If you're new to AI, start with Collaborative AI opportunities — they're the easiest to try and lowest risk. Move to Deterministic Workflows once you've identified a process you repeat often. Explore Multi-Agent Systems when you have experience with the other two categories.
+
+## Key Takeaways
+
+- Don't wait for problems — proactively audit your workflows to find AI opportunities
+- Think in three categories: collaborative AI, deterministic workflows, and multi-agent systems
+- Use the [AI Workflow Opportunity Finder](../../how-to/prompting/ai-workflow-opportunity-finder.md) meta prompt to run a structured audit
+- The richer context your AI has about your work, the better the recommendations
+- Start small — pick 1-2 opportunities and pilot them before scaling
+
+## Related Questions
+
+- [What is a system prompt?](../../questions/prompting/what-is-a-system-prompt.md)

--- a/docs/questions/strategy/how-do-i-identify-the-right-ai-tools-for-a-workflow.md
+++ b/docs/questions/strategy/how-do-i-identify-the-right-ai-tools-for-a-workflow.md
@@ -1,0 +1,56 @@
+---
+question: "How do I identify the right AI tools for a workflow?"
+short_answer: "Break your workflow into discrete steps using the 4-question framework (steps, decisions, data flows, context needs), then map each step to AI building blocks like prompts, skills, agents, and connectors to see exactly what to build."
+platforms: [openai, claude, gemini]
+topic: strategy
+date: 2026-02-02
+author: James Gray
+---
+
+# How do I identify the right AI tools for a workflow?
+
+**Short answer:** Break your workflow into discrete steps using the 4-question framework (steps, decisions, data flows, context needs), then map each step to AI building blocks like prompts, skills, agents, and connectors to see exactly what to build.
+
+## The Full Answer
+
+You can't choose the right AI tools for a workflow you don't fully understand. Most people jump straight to tool selection — "Should I use an agent? Do I need an API?" — before they've properly decomposed what the workflow actually involves. The result is over-engineered solutions for simple problems, or under-powered tools for complex ones.
+
+The right approach is to **deconstruct first, then map**. Start by breaking your workflow into discrete steps using the 4-question framework: What are the individual steps? Where are the decision points? What data flows in and out? What context does each step need? Add a fifth question — what happens when this step fails? — to surface the exception paths where the most important logic often lives.
+
+Once you have the refined step-by-step breakdown, map each step to one of six AI building blocks:
+
+| Building Block | What It Is | When to Use It |
+|---------------|------------|----------------|
+| **Prompt** | A well-crafted instruction that tells the model what to do | Single-step tasks with clear inputs and outputs |
+| **Context** | Background information, reference docs, or examples | Steps that need domain knowledge or specific data |
+| **Skill** | A reusable, parameterized routine the model can invoke | Repeatable tasks you'll run many times |
+| **Agent** | An autonomous AI that plans, uses tools, and executes multi-step work | Complex steps requiring judgment and tool use |
+| **MCP (Model Context Protocol)** | A connector to external tools, APIs, or databases | Steps that need to read from or write to external systems |
+| **Project** | A persistent workspace grouping prompts, context, skills, and agents | Organizing everything for a specific workflow |
+
+Not every step needs AI. The deconstruction also classifies each step on an autonomy spectrum — from fully human to fully autonomous — so you can see which steps are candidates for AI and which should stay manual.
+
+## How to Get Started
+
+Use the [Workflow Deconstruction Meta-Prompt](../../how-to/prompting/workflow-deconstruction-meta-prompt.md) to run through this process interactively. Paste it into any AI tool and it will:
+
+1. **Discover your scenario** — understand the workflow objective and rough steps
+2. **Deep dive into each step** — apply the 4-question framework plus failure modes
+3. **Map to building blocks** — classify each step and recommend the right AI tools
+4. **Generate deliverables** — produce a workflow analysis document and an executable prompt you can save and reuse
+
+!!! tip "Start with a workflow you actually do"
+    Real workflows produce the best analysis. The meta prompt is designed to work with rough, incomplete descriptions — don't over-prepare. Even "I onboard new clients and it takes forever" is enough to start. The model will find the hidden steps and assumptions you've internalized.
+
+## Key Takeaways
+
+- Deconstruct the workflow before choosing tools — you can't pick the right AI building blocks for a process you don't fully understand
+- Use the 4-question framework: discrete steps, decision points, data flows, and context needs (plus failure modes)
+- Map each step to one of six building blocks: Prompt, Context, Skill, Agent, MCP, or Project
+- Not every step needs AI — the autonomy classification helps you see which steps are candidates and which should stay manual
+- Use the [Workflow Deconstruction Meta-Prompt](../../how-to/prompting/workflow-deconstruction-meta-prompt.md) to run through this process interactively
+
+## Related Questions
+
+- [How do I find workflows worth applying AI to?](./how-do-i-find-workflows-worth-applying-ai-to.md)
+- [What is a system prompt?](../../questions/prompting/what-is-a-system-prompt.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
       - Questions:
         - Overview: platforms/claude/questions/README.md
         - Best way to name agent skills?: platforms/claude/questions/what-is-the-best-way-to-name-claude-agent-skills.md
+        - Schedule an automated subagent: platforms/claude/questions/how-do-i-schedule-an-automated-claude-subagent.md
       - Subagents:
         - Scheduling Subagents: platforms/claude/subagents/scheduling-subagents.md
         - Troubleshooting: platforms/claude/subagents/scheduling-subagent-issues.md
@@ -146,6 +147,10 @@ nav:
       - Autonomous Agent: how-to/workflow-examples/autonomous-agent.md
   - Questions:
     - Overview: questions/README.md
+    - Strategy:
+      - Overview: questions/strategy/README.md
+      - Find workflows worth applying AI to: questions/strategy/how-do-i-find-workflows-worth-applying-ai-to.md
+      - Identify the right AI tools for a workflow: questions/strategy/how-do-i-identify-the-right-ai-tools-for-a-workflow.md
     - Agents: questions/agents/README.md
     - Prompting:
       - Overview: questions/prompting/README.md


### PR DESCRIPTION
## Summary
- New **Strategy** question category (`docs/questions/strategy/`) for business-level AI questions
- **How do I find workflows worth applying AI to?** — links to the AI Workflow Opportunity Finder meta prompt
- **How do I identify the right AI tools for a workflow?** — links to the Workflow Deconstruction meta prompt, includes building blocks table
- **How do I schedule an automated Claude subagent?** — Claude-specific, links to the scheduling subagents guide
- All question indexes and mkdocs.yml nav updated

## Test plan
- [ ] Preview strategy category at `/questions/strategy/`
- [ ] Preview each new question page and verify admonitions, tables, and links render correctly
- [ ] Verify FAQPage JSON-LD schema in page source for all three new pages
- [ ] Confirm nav entries appear under Questions > Strategy and Platforms > Claude > Questions
- [ ] Check all cross-links between questions and how-to guides resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)