### PR TITLE
Add Gemini Enterprise and Gemini in Chrome resources

### DIFF
--- a/docs/platforms/google-gemini/topics/resources.md
+++ b/docs/platforms/google-gemini/topics/resources.md
@@ -57,6 +57,30 @@ Recommended articles, docs, and courses for Google's Gemini models.
 | [Gemini Apps Community](https://support.google.com/gemini/community) | User forum for questions and feedback |
 | [Gemini CLI Discussions](https://github.com/google-gemini/gemini-cli/discussions) | Developer community for Gemini CLI |
 
+## Gemini Enterprise
+
+| Resource | Description |
+|----------|-------------|
+| [What is Gemini Enterprise?](https://docs.cloud.google.com/gemini/enterprise/docs) | Overview — intranet search, AI assistant, and agentic platform for organizations |
+| [Get Started with Gemini Enterprise](https://docs.cloud.google.com/gemini/enterprise/docs/quickstart-gemini-enterprise) | Quickstart tutorial to create your first Gemini Enterprise app |
+| [Compare Editions](https://docs.cloud.google.com/gemini/enterprise/docs/editions) | Feature comparison across Standard, Plus, and Frontline editions |
+| [Gemini Enterprise Resources Hub](https://cloud.google.com/gemini-enterprise/resources) | Admin support, setup guides, and documentation by edition |
+| [Workspace with Gemini (Admin)](https://support.google.com/a/answer/13623623) | Admin guide for Gemini in Google Workspace (Business/Enterprise) |
+| [Gemini for Workspace FAQ](https://support.google.com/a/answer/14130944) | Frequently asked questions about Gemini in Workspace apps |
+| [Gemini AI in Workspace](https://support.google.com/a/answer/15756885) | How Gemini features are included in Workspace subscriptions |
+| [What is NotebookLM Enterprise?](https://docs.cloud.google.com/gemini/enterprise/notebooklm-enterprise/docs/overview) | AI-powered research tool for enterprise — compliant, admin-managed |
+| [Set Up NotebookLM Enterprise](https://docs.cloud.google.com/gemini/enterprise/notebooklm-enterprise/docs/set-up-notebooklm) | Admin setup guide for authentication, IAM roles, and data residency |
+| [Release Notes](https://docs.cloud.google.com/gemini/enterprise/docs/release-notes) | Latest updates including Gemini 3 Flash, Agent Designer, and semantic search |
+
+## Gemini in Chrome
+
+| Resource | Description |
+|----------|-------------|
+| [Gemini in Chrome](https://gemini.google/overview/gemini-in-chrome/) | Official overview — AI assistance right in your browser |
+| [Chrome AI Innovations](https://www.google.com/chrome/ai-innovations/) | Feature showcase for Gemini-powered Chrome capabilities |
+| [Chrome Gets Gemini 3 Features](https://blog.google/products-and-platforms/products/chrome/gemini-3-auto-browse/) | Google blog — side panel, auto browse, image generation, and more |
+| [New AI Features for Chrome](https://blog.google/products/chrome/new-ai-features-for-chrome/) | Earlier Chrome AI features including tab organization and writing help |
+
 ## Research & Safety
 
 | Resource | Description |


### PR DESCRIPTION
## Summary
- Added **Gemini Enterprise** section (10 resources) — overview, quickstart, editions comparison, Workspace admin guides, NotebookLM Enterprise setup, and release notes
- Added **Gemini in Chrome** section (4 resources) — official overview, AI innovations, Gemini 3 features (side panel, auto browse), and earlier Chrome AI features

## Test plan
- [ ] Preview at `/platforms/google-gemini/topics/resources/` and verify both new sections render correctly
- [ ] Spot-check external links resolve to the correct Google documentation pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)