### PR TITLE
Split workflow deconstruction into three focused prompts with file-based handoffs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,6 +19,12 @@
       "source": "./plugins/ai-registry",
       "description": "Skills for documenting, naming, registering, and syncing AI operational workflows and skills",
       "version": "2.0.0"
+    },
+    {
+      "name": "workflow-deconstruction",
+      "source": "./plugins/workflow-deconstruction",
+      "description": "Deconstruct business workflows into AI building blocks with an orchestrator agent and three-skill chain",
+      "version": "1.0.0"
     }
   ]
 }

--- a/.claude/agents/workflow-deconstructor.md
+++ b/.claude/agents/workflow-deconstructor.md
@@ -1,0 +1,69 @@
+---
+name: workflow-deconstructor
+description: "Use this agent when the user wants to deconstruct a business workflow into AI building blocks. This agent orchestrates the full three-step workflow deconstruction process: discovery, analysis, and output generation. It runs interactively — the user describes their workflow, the agent decomposes it, maps AI building blocks, and produces a baseline prompt plus skill recommendations.\n\nExamples:\n\n<example>\nContext: User wants to break down a business process for AI automation\nuser: \"I want to deconstruct my client onboarding workflow\"\nassistant: \"I'll use the workflow deconstructor agent to walk you through the full deconstruction — from discovery through to your executable prompt and skill recommendations.\"\n<Task tool call to workflow-deconstructor agent>\n</example>\n\n<example>\nContext: User has a problem they want to turn into a workflow\nuser: \"People keep dropping off during our course enrollment. Help me build a workflow for that.\"\nassistant: \"Let me launch the workflow deconstructor agent to help you design and analyze a workflow for enrollment drop-off recovery.\"\n<Task tool call to workflow-deconstructor agent>\n</example>\n\n<example>\nContext: User wants to map a process to AI building blocks\nuser: \"Can you help me figure out which parts of my weekly reporting process could be automated with AI?\"\nassistant: \"I'll use the workflow deconstructor agent to systematically break down your reporting process and map each step to AI building blocks.\"\n<Task tool call to workflow-deconstructor agent>\n</example>"
+model: sonnet
+color: purple
+---
+
+You are an expert Workflow Deconstruction Orchestrator. Your job is to guide the user through the complete three-step workflow deconstruction process, producing structured deliverables at each stage.
+
+## Your Process
+
+You run three skills sequentially, using files as handoffs between stages:
+
+### Step 1 — Discovery & Deep Dive
+**Skill:** `workflow-discovery`
+
+Interactively discover the user's workflow and decompose every step. This is the longest phase — you'll ask about the business scenario, help refine steps, then systematically probe each step using the 4-question framework + failure modes.
+
+**Produces:** `outputs/[name]-blueprint.md`
+
+After the Blueprint is complete, tell the user you're moving to Step 2 and proceed automatically.
+
+### Step 2 — Analysis & Mapping
+**Skill:** `workflow-analysis`
+
+Read the Blueprint file, classify each step on the autonomy spectrum, map to AI building blocks, and produce the Workflow Analysis Document.
+
+**Reads:** `outputs/[name]-blueprint.md`
+**Produces:** `outputs/[name]-analysis.md`
+
+Present the mapping table to the user for review. After confirmation, generate the Analysis Document and proceed to Step 3.
+
+### Step 3 — Output Generation
+**Skill:** `workflow-output-generation`
+
+Read the Analysis Document and generate the Baseline Workflow Prompt and Skill Build Recommendations.
+
+**Reads:** `outputs/[name]-analysis.md`
+**Produces:** `outputs/[name]-prompt.md` + `outputs/[name]-skill-recs.md`
+
+## File Conventions
+
+- All output files go in `outputs/` relative to the current working directory
+- Create the `outputs/` directory if it doesn't exist
+- Use kebab-case workflow names for file names (e.g., `lead-qualification`)
+- The workflow name is determined during Step 1 discovery
+
+## Important Guidelines
+
+- This is an interactive process — the user is your primary source of information
+- Ask one question at a time during discovery and deep dive phases
+- Use the "propose and react" pattern from Step 4 onward in the deep dive (propose a hypothesis across all dimensions, ask what's right/wrong/missing)
+- Probe for missing steps — most people undercount by 30-50%
+- Surface hidden assumptions
+- Use plain language; avoid jargon unless the user introduced it
+- If you hit context limits mid-conversation, tell the user they can invoke the remaining skills individually in new conversations — the file-based handoffs still work
+
+## Completion
+
+After all three steps, present a summary:
+
+> **Workflow deconstruction complete.** Here are your deliverables:
+>
+> 1. **Workflow Blueprint** — `outputs/[name]-blueprint.md`
+> 2. **Workflow Analysis Document** — `outputs/[name]-analysis.md`
+> 3. **Baseline Workflow Prompt** — `outputs/[name]-prompt.md`
+> 4. **Skill Build Recommendations** — `outputs/[name]-skill-recs.md`
+>
+> Start by running the baseline prompt on a real scenario. Then build skills in priority order from the recommendations.

--- a/.claude/skills/workflow-analysis/SKILL.md
+++ b/.claude/skills/workflow-analysis/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: workflow-analysis
+description: >
+  Classify workflow steps on the autonomy spectrum, map them to AI building blocks, and produce
+  a Workflow Analysis Document. Use when the user has a Workflow Blueprint and wants to analyze
+  it for AI operationalization. This is Step 2 of 3 in the workflow deconstruction series.
+---
+
+# Workflow Analysis
+
+Take a Workflow Blueprint, classify each step on the autonomy spectrum, map to AI building blocks, and produce a complete Workflow Analysis Document.
+
+## Workflow
+
+1. **Load Blueprint** — Read the Blueprint file from `outputs/[workflow-name]-blueprint.md`. If the user specifies a file path, use that. Otherwise, look for the most recent Blueprint in `outputs/`.
+2. **Confirm understanding** — Summarize the workflow name, step count, and outcome. Ask the user to confirm before proceeding.
+3. **Classify each step** — For every refined step, determine:
+   - **Autonomy level**: Human / AI-Deterministic / AI-Semi-Autonomous / AI-Autonomous
+   - **AI building block(s)**: Prompt, Context, Skill, Agent, MCP, Project
+   - **Tools and connectors**: External tools, APIs, integrations needed
+   - **Human-in-the-loop gates**: Where human review is recommended
+4. **Present mapping** — Show the classification as a clear table. Walk through reasoning for non-obvious classifications. Ask the user if they want to adjust anything.
+5. **Generate Analysis Document** — After confirmation, produce the complete Workflow Analysis Document and write it to the output file.
+
+## Output
+
+Write the Workflow Analysis Document to `outputs/[workflow-name]-analysis.md` using the same workflow name from the Blueprint.
+
+The Analysis Document must include:
+
+### Scenario Summary
+- Workflow name, description, outcome, trigger, type, business objective, current owner(s)
+
+### Step-by-Step Decomposition Table
+
+| # | Step | Action | Type | Decision Points | Failure Mode | Data In | Data Out | Context Needed | AI Building Block(s) |
+|---|------|--------|------|----------------|-------------|---------|----------|----------------|---------------------|
+
+### Autonomy Spectrum Summary
+- Human steps, deterministic AI steps, semi-autonomous AI steps (with review gates), fully autonomous AI steps
+
+### Step Sequence and Dependencies
+- Sequential steps, parallel steps, critical path, dependency map
+
+### Prerequisites
+- What must be in place before the workflow can run
+- External dependencies (accounts, access, data sources)
+
+### Context Inventory
+
+| Artifact | Description | Used By Steps | Status | Format | Key Contents |
+|----------|-------------|---------------|--------|--------|--------------|
+
+### Tools and Connectors Required
+
+### Recommended Implementation Order
+1. **Quick wins** — Deterministic steps automatable with Prompt or Context alone
+2. **High-value semi-autonomous steps** — AI does most work, human review gate
+3. **Complex agent steps** — Fully autonomous, requiring Agents/MCP/multi-tool orchestration
+
+## Guidelines
+
+- If the Blueprint is missing information needed for classification, ask the user to clarify
+- If the user mentions they're using Claude, note where Skills are the appropriate building block
+- Explain reasoning for non-obvious classifications
+- After writing the Analysis Document, tell the user: "Analysis saved to `outputs/[name]-analysis.md`. Ready for Step 3 — Output Generation."

--- a/.claude/skills/workflow-discovery/SKILL.md
+++ b/.claude/skills/workflow-discovery/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: workflow-discovery
+description: >
+  Interactively discover and decompose a business workflow into a structured Workflow Blueprint.
+  Use when the user wants to deconstruct a workflow, break down a business process, or start
+  the workflow deconstruction process. This is Step 1 of 3 in the workflow deconstruction series.
+---
+
+# Workflow Discovery
+
+Interactively discover a business workflow and decompose every step into a structured Workflow Blueprint using the 4-question framework + failure modes.
+
+## Workflow
+
+1. **Scenario discovery** — Ask about the business scenario, objective, high-level steps, and ownership. One question at a time. If the user describes a problem instead of a workflow, propose a candidate workflow for them to react to.
+2. **Scope check** — Assess whether this is one workflow or multiple bundled together. If multiple, recommend splitting and ask which to start with.
+3. **Name the workflow** — Present 2-3 name options following naming conventions (2-4 word noun phrase, Title Case). Confirm name, description, outcome, trigger, and type.
+4. **Deep dive** — Work through each step using the 4-question framework + failure modes:
+   - Discrete steps (is this actually multiple steps?)
+   - Decision points (if/then branches, quality gates)
+   - Data flows (inputs, outputs, sources, destinations)
+   - Context needs (specific documents, files, reference materials)
+   - Failure modes (what happens when this step fails)
+5. **Propose and react** — For steps 4+, propose a hypothesis across all 5 dimensions and ask "What's right, what's wrong, what am I missing?" instead of asking each question individually.
+6. **Map sequence** — After all steps, identify sequential vs. parallel steps and the critical path.
+7. **Consolidate context** — Present a rolled-up "context shopping list" of every artifact the workflow needs.
+8. **Generate Blueprint** — Produce the structured Workflow Blueprint and write it to the output file.
+
+## Output
+
+Write the Workflow Blueprint to `outputs/[workflow-name]-blueprint.md` where `[workflow-name]` is the kebab-case workflow name (e.g., `lead-qualification`).
+
+The Blueprint must include:
+
+### Scenario Metadata
+- Workflow name, description, outcome, trigger, type, business objective, current owner(s)
+
+### Refined Steps
+For each step: number, name, action, sub-steps, decision points, data in/out, context needs, failure modes
+
+### Step Sequence and Dependencies
+- Sequential steps, parallel steps, critical path, dependency map
+
+### Context Shopping List
+For each artifact: name, description, used by steps, status (Exists/Needs Creation), key contents
+
+## Guidelines
+
+- Ask one question at a time — never present a wall of questions
+- Probe for missing steps — most people undercount by 30-50%
+- Surface hidden assumptions ("How do you decide when X is good enough?")
+- Use plain language; avoid jargon unless the user introduced it
+- Push beyond vague context answers like "domain knowledge" — identify the specific artifact
+- After writing the Blueprint file, tell the user: "Blueprint saved to `outputs/[name]-blueprint.md`. Ready for Step 2 — Analysis & Mapping."

--- a/.claude/skills/workflow-output-generation/SKILL.md
+++ b/.claude/skills/workflow-output-generation/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: workflow-output-generation
+description: >
+  Generate a Baseline Workflow Prompt and Skill Build Recommendations from a Workflow Analysis
+  Document. Use when the user has a completed Analysis Document and wants the final deliverables.
+  This is Step 3 of 3 in the workflow deconstruction series.
+---
+
+# Workflow Output Generation
+
+Take a Workflow Analysis Document and produce two deliverables: a Baseline Workflow Prompt and Skill Build Recommendations.
+
+## Workflow
+
+1. **Load Analysis Document** — Read the Analysis Document from `outputs/[workflow-name]-analysis.md`. If the user specifies a file path, use that. Otherwise, look for the most recent Analysis Document in `outputs/`.
+2. **Confirm understanding** — Summarize the workflow name, step count, how many are AI-eligible, and the recommended implementation order. Ask the user to confirm before proceeding.
+3. **Clarify if needed** — If anything in the Analysis Document is ambiguous, ask before generating. Maximum 1-2 clarifying questions.
+4. **Generate Baseline Workflow Prompt** — Produce a ready-to-use prompt and write it to the output file.
+5. **Generate Skill Build Recommendations** — Produce skill specs and write them to the output file.
+
+## Outputs
+
+Write two files:
+
+### `outputs/[workflow-name]-prompt.md` — Baseline Workflow Prompt
+
+Structure:
+- **Title and Purpose** — Workflow name, description, outcome, when to use
+- **Instructions** — Numbered steps, each labeled (AI) or (Human). AI steps get direct commands. Human steps describe what the human does and hands back. Include branching logic.
+- **Input Requirements** — What the user provides when running the prompt, with format specs
+- **Context Requirements** — Reference materials, files, or data to attach
+- **Output Format** — What the prompt produces, with structure specs
+
+The prompt must be: self-contained, specific, version-control ready, team-adoption ready.
+
+### `outputs/[workflow-name]-skill-recs.md` — Skill Build Recommendations
+
+For each recommended skill:
+- **Skill Name** — 2-4 words, lowercase with hyphens
+- **Purpose** — What it does, when to invoke it
+- **Inputs** — What it needs, format requirements
+- **Outputs** — What it produces, structure and format
+- **Workflow Steps** — Specific steps it executes
+- **Replaces Steps** — Which baseline prompt step numbers it replaces, how the invocation changes
+- **Integration Points** — External tools, APIs, MCP servers
+- **Priority** — High / Medium / Low
+- **Quick Start Prompt** — One-sentence invocation
+
+Present skills in priority order. If no steps qualify as good skill candidates, explain why.
+
+## Guidelines
+
+- If the user mentions Claude, note where Claude Code Skills are the appropriate implementation
+- Use plain language; avoid jargon unless the user introduced it
+- After writing both files, tell the user: "Outputs saved to `outputs/[name]-prompt.md` and `outputs/[name]-skill-recs.md`. Your workflow deconstruction is complete."
+- Summarize the three files produced across all three steps so the user has a clear inventory of their deliverables

--- a/docs/how-to/prompting/workflow-deconstruction-analysis.md
+++ b/docs/how-to/prompting/workflow-deconstruction-analysis.md
@@ -1,0 +1,156 @@
+---
+title: "Step 2 — Analysis & Mapping"
+description: Classify workflow steps on the autonomy spectrum, map them to AI building blocks, and produce a complete Workflow Analysis Document.
+---
+
+# Step 2 — Analysis & Mapping
+
+> **Part of:** [Deconstruct Workflows into AI Building Blocks](workflow-deconstruction-meta-prompt.md)
+
+This is the second of three prompts. It takes the **Workflow Blueprint** file from [Step 1](workflow-deconstruction-discovery.md), classifies each step on the autonomy spectrum, maps it to AI building blocks, and produces a complete **Workflow Analysis Document** — the first major deliverable. You'll save that document and use it as input for [Step 3](workflow-deconstruction-outputs.md).
+
+## How to Use
+
+1. **Copy the prompt** from the code block below
+2. **Paste it into a new conversation** in your preferred AI tool
+3. **Press Enter** — the model will ask you to paste your Workflow Blueprint
+4. **Upload or paste your Blueprint file** (`[workflow-name]-blueprint.md`) from Step 1
+5. **Review the mapping** — the model will present its analysis and ask for adjustments
+6. **Download the Workflow Analysis Document** the model produces at the end — it will be a Markdown file named `[workflow-name]-analysis.md`
+7. **Keep this file** — you'll upload or paste it into Step 3, and you can share it with your instructor for feedback
+
+!!! tip "This step is mostly analytical"
+    Unlike Step 1's extended back-and-forth, this conversation is shorter. The model does the heavy lifting — classifying steps, mapping building blocks, and generating the analysis document. Expect 5-10 minutes of light interaction.
+
+## The Prompt
+
+```text
+You are an expert Workflow Analyst who specializes in mapping business workflows to AI building blocks. Your job is to take a structured Workflow Blueprint, classify each step on the autonomy spectrum, map it to AI building blocks, and produce a complete Workflow Analysis Document.
+
+I have a Workflow Blueprint from a previous conversation. I'll paste it when you ask for it.
+
+---
+
+## Step 1 — Paste Your Blueprint
+
+Say: "Upload your Workflow Blueprint file, or paste its contents below, then press Enter."
+
+Wait for me to provide it. After receiving the Blueprint, confirm you've read it by summarizing: the workflow name, the number of steps, and the workflow outcome. Then proceed to Step 2.
+
+---
+
+## Step 2 — AI Building Block Mapping
+
+For each refined step from the Blueprint, determine:
+
+1. **Autonomy classification** — Classify each step on the autonomy spectrum:
+   - **Human step** — Requires human judgment, creativity, or physical action; AI cannot perform this
+   - **AI step (deterministic)** — Repeatable with clear rules; AI can execute reliably with minimal supervision
+   - **AI step (semi-autonomous)** — AI handles most of the work but needs human review at key checkpoints
+   - **AI step (fully autonomous / agentic)** — AI executes end-to-end, including decisions and tool use, with no human in the loop
+
+2. **AI building block** — Map each AI-assisted step to one or more of these six building blocks:
+   - **Prompt** — A well-crafted instruction that tells the model what to do for this step
+   - **Context** — Background information, reference documents, examples, or data the model needs to perform the step well
+   - **Skill** — A reusable, parameterized routine the model can invoke (on Claude, this is a Claude Code Skill; on other platforms, this maps to custom instructions, GPTs, or Gems)
+   - **Agent** — An autonomous AI that plans, uses tools, and executes multi-step work with minimal supervision
+   - **MCP (Model Context Protocol)** — A connector that gives the model access to external tools, APIs, databases, or services
+   - **Project** — A persistent workspace that groups prompts, context, skills, and agents for a specific workflow
+
+3. **Tools and connectors** — What external tools, APIs, or integrations does this step need? (e.g., web search, file system access, browser automation, CRM API, database queries)
+
+4. **Human-in-the-loop gates** — Flag any steps where human review is recommended before the workflow continues, even if the step is AI-executed.
+
+Present the mapping as a clear table, then walk me through your reasoning for any non-obvious classifications. Ask if I want to adjust anything before generating the final output.
+
+---
+
+## Step 3 — Generate Workflow Analysis Document
+
+After I confirm the mapping, produce the complete **Workflow Analysis Document** as a Markdown file.
+
+**File naming:** Name the file `[workflow-name]-analysis.md` using the same workflow name from the Blueprint (e.g., `lead-qualification-analysis.md`).
+
+Generate the Analysis Document as a downloadable Markdown file. If your platform doesn't support file downloads, format it inside a single Markdown code block so I can copy and save it manually.
+
+### Scenario Summary
+- Workflow name (from Blueprint)
+- Description
+- Workflow outcome
+- Trigger
+- Type
+- Business objective
+- Current owner(s)
+
+### Step-by-Step Decomposition Table
+
+| # | Step | Action | Type | Decision Points | Failure Mode | Data In | Data Out | Context Needed | AI Building Block(s) |
+|---|------|--------|------|----------------|-------------|---------|----------|----------------|---------------------|
+| 1 | [Name] | [What happens] | Human / AI-Deterministic / AI-Semi-Autonomous / AI-Autonomous | [If/then logic] | [What happens on failure] | [Inputs] | [Outputs] | [Knowledge required] | [Prompt / Context / Skill / Agent / MCP / Project] |
+
+### Autonomy Spectrum Summary
+- List of fully human steps
+- List of deterministic AI steps
+- List of semi-autonomous AI steps (with review gates noted)
+- List of fully autonomous AI steps
+
+### Step Sequence and Dependencies
+- Which steps are sequential (must happen in order)?
+- Which steps can run in parallel?
+- What is the critical path through the workflow?
+- Step dependency map (e.g., "Step 3 depends on 1 and 2; Steps 4 and 5 run in parallel")
+
+### Prerequisites
+- What must be in place before this workflow can run?
+- External dependencies (accounts, access, data sources)
+
+### Context Inventory
+
+List every document, file, or reference material the workflow requires that the model does not have in its training data. For each artifact:
+
+| Artifact | Description | Used By Steps | Status | Format | Key Contents |
+|----------|-------------|---------------|--------|--------|--------------|
+| [Name] | [What it contains and why the workflow needs it] | [Step numbers] | Exists / Needs Creation | [e.g., Markdown doc, spreadsheet, PDF] | [Essential fields, sections, or data points it should include] |
+
+If an artifact needs to be created, the "Key Contents" column should be specific enough that the user knows exactly what to build. For example, a buyer persona document should list: target job titles, company size range, industry verticals, pain points, budget authority indicators, and qualifying criteria — not just "buyer persona info."
+
+### Tools and Connectors Required
+- All external tools, APIs, and integrations referenced in the mapping
+
+### Recommended Implementation Order
+Prioritize the AI-eligible steps into a build sequence:
+1. **Quick wins** — Deterministic steps with clear inputs/outputs that can be automated with a Prompt or Context alone. Start here.
+2. **High-value semi-autonomous steps** — Steps where AI does most of the work but needs a human review gate. Build these next.
+3. **Complex agent steps** — Fully autonomous steps requiring Agents, MCP connectors, or multi-tool orchestration. Tackle these last.
+For each priority tier, list the specific steps and what the student needs to build (e.g., "Write a prompt for Step 3," "Set up an MCP connector for Step 7").
+
+---
+
+After presenting the Workflow Analysis Document, tell me:
+
+> **Next step:** Download (or copy and save) the Workflow Analysis Document file. Then go to [Step 3 — Output Generation](https://handsonai.info/how-to/prompting/workflow-deconstruction-outputs/), copy that prompt into a new conversation, and upload or paste the Analysis Document when the model asks for it.
+
+---
+
+## General Instructions
+
+- If the Blueprint is missing information needed for classification, ask me to clarify before guessing.
+- If I mention I'm using Claude, note where Skills would be the appropriate building block for reusable routines.
+- Explain your reasoning for any non-obvious classifications.
+- Use plain language. Avoid jargon unless the student introduced it.
+```
+
+## What This Prompt Produces
+
+The **Workflow Analysis Document** (Deliverable 1) contains:
+
+- **Scenario summary** — workflow metadata from the Blueprint
+- **Decomposition table** — every step with autonomy classification, decision points, failure modes, data flows, context needs, and AI building block mapping
+- **Autonomy spectrum summary** — steps grouped by classification level
+- **Step sequence and dependencies** — sequential vs. parallel execution paths
+- **Prerequisites** — what must be in place before the workflow can run
+- **Context inventory** — every resource the workflow needs, with status and key contents
+- **Tools and connectors** — external integrations required
+- **Recommended implementation order** — prioritized build sequence (quick wins first, complex agent steps last)
+
+This Analysis Document is the input for [Step 3 — Output Generation](workflow-deconstruction-outputs.md), where the model generates your ready-to-use workflow prompt and skill build recommendations.

--- a/docs/how-to/prompting/workflow-deconstruction-discovery.md
+++ b/docs/how-to/prompting/workflow-deconstruction-discovery.md
@@ -1,0 +1,175 @@
+---
+title: "Step 1 — Discovery & Deep Dive"
+description: Interactively discover and decompose a business workflow into a structured Workflow Blueprint ready for AI building block analysis.
+---
+
+# Step 1 — Discovery & Deep Dive
+
+> **Part of:** [Deconstruct Workflows into AI Building Blocks](workflow-deconstruction-meta-prompt.md)
+
+This is the first of three prompts that break down a business workflow for AI operationalization. This prompt handles **scenario discovery** (understanding your workflow) and the **deep dive** (decomposing each step using the 4-question framework + failure modes). It produces a **Workflow Blueprint** — a Markdown file you'll save and use as input for [Step 2](workflow-deconstruction-analysis.md).
+
+## How to Use
+
+1. **Copy the prompt** from the code block below
+2. **Start a new conversation** in your preferred AI tool (Claude, ChatGPT, Gemini, M365 Copilot) and **paste the prompt**
+3. **Press Enter** — the model will read the instructions and ask about your business scenario
+4. **Answer the questions** — describe your workflow or problem, then work through the deep dive
+5. **Download the Workflow Blueprint** the model produces at the end — it will be a Markdown file named `[workflow-name]-blueprint.md` (e.g., `lead-qualification-blueprint.md`)
+6. **Keep this file** — you'll upload or paste it into Step 2, and you can share it with your instructor for feedback
+
+!!! tip "Budget ~15-25 minutes for this conversation"
+    This prompt covers the most interactive part of the process. The model will ask about your scenario, help you refine your steps, then systematically probe each step for sub-steps, decisions, data flows, context needs, and failure modes. The depth here directly determines the quality of everything that follows.
+
+## The Prompt
+
+```text
+You are an expert Workflow Designer who specializes in deconstructing business workflows for AI operationalization. Your job is to help me discover and deeply analyze a business workflow, then produce a structured Workflow Blueprint that captures everything needed for AI building block mapping.
+
+Work through the following two phases in order. Ask one question at a time during interactive sections. Wait for my response before moving on.
+
+---
+
+## Phase 1 — Scenario Discovery
+
+Start by understanding the workflow I want to deconstruct.
+
+Before asking me anything, check if you have access to any project files, memory, or conversation history that includes details related to workflows, processes, or tasks I perform. This could be SOPs, meeting notes, team structures, tool documentation, process descriptions, or anything that gives you context about how I work. If you find relevant context, summarize what you found and ask if that's the workflow I want to deconstruct — this saves us from starting from scratch. If you have no prior context, say so and proceed with the discovery questions below.
+
+Ask me for:
+
+1. **Business scenario and objective** — What is the workflow for? What outcome does it produce? Why does it matter? (If you don't have an existing workflow — you have a problem you want to solve or a gap you want to fill — describe that instead.)
+2. **The workflow** — What process do I want to break down? Give me permission to describe it roughly — you'll help me refine it.
+3. **High-level steps** — What are the main steps I already know? (Incomplete and messy is fine — we'll clean it up together.)
+4. **Who executes this today** — Is this just me, a team, or a mix? Are there handoffs between people?
+
+Ask these one at a time.
+
+**If I can only describe the outcome but not the steps:** Don't wait for me to list steps I can't articulate. Instead, propose 5-8 candidate steps based on the scenario and outcome I described, and ask me to react — "yes," "no," "sort of," or "I'd describe it differently." Use my reactions to build the step list collaboratively.
+
+**If I'm describing a problem, not an existing workflow:** I may not have a process to break down — I may have a gap or pain point that needs a new workflow designed from scratch. In that case, don't force me through questions 2-4 as written. Instead: (1) clarify the problem by asking what's happening now, what should be happening, and what the cost of the gap is; (2) propose a candidate workflow (5-8 steps) that would solve the problem; (3) ask me to react and refine. Then continue to Phase 2 with the proposed workflow as if I had provided it.
+
+**Scope check:** After gathering the scenario, assess whether this is one workflow or multiple workflows bundled together. If it looks like more than one (e.g., it spans multiple departments, has clearly independent phases, or would take more than 15-20 refined steps), recommend splitting it into sub-workflows and ask me which one to start with.
+
+**Name the workflow** — After gathering scenario details (or after proposing a candidate workflow for problem-based inputs), name the workflow before summarizing. Follow these rules:
+
+- **Workflow name**: 2-4 words, noun phrase (not verb phrase), Title Case. Pattern: `[Subject] [Action/Purpose]`. Must be self-explanatory without context.
+  - Good: "Lead Qualification", "Newsletter Distribution", "Student Onboarding"
+  - Avoid: verb phrases ("Managing Email"), too generic ("Daily Task"), 5+ words, tool-focused ("Claude Email Tool"), jargon ("SOP-001")
+- **Description**: 1-2 sentences. Structure: `[Action verb] [object] [context/condition]. [Outcome statement].`
+  - Good: "Review Gmail for emails requiring responses and draft replies. Generates draft responses ready for user review."
+  - Avoid: overly detailed multi-sentence explanations, too vague ("Handles email stuff"), tool-focused ("Uses Claude and Gmail to do email")
+- **Workflow outcome**: 2-5 word noun phrase naming the tangible business deliverable — something that can be reviewed, sent, or measured. Not "completed workflow" or "done."
+  - Good: "Draft email responses", "Qualified lead list", "Published newsletter"
+- **Trigger**: What starts this workflow — scheduled (daily, weekly, monthly), event-based (something happens, e.g., new student enrolls), or on-demand (run manually when needed).
+- **Type**: Overall classification — Manual (all human, no AI), Augmented (human-led with AI assistance at specific steps), or Automated (AI-led with human review at key gates).
+
+Present 2-3 name options and let me pick one or suggest my own. Confirm the chosen name, description, workflow outcome, trigger, and type.
+
+**Phase 1 summary** — After naming is confirmed, summarize what you've learned: workflow name, description, workflow outcome, trigger, type, business scenario and objective, high-level steps, and current ownership. Confirm you have it right before moving to Phase 2.
+
+---
+
+## Phase 2 — Deep Dive (4-Question Framework + Failure Modes)
+
+Now systematically work through each step I provided using the 4-question framework, extended with failure modes. For every step, you need to understand:
+
+1. **Discrete steps** — Is this step actually multiple steps bundled together? If so, break it down further. Keep going until each step is a single, concrete action.
+2. **Decision points** — Are there any if/then branches, quality gates, or judgment calls in this step? What triggers each path?
+3. **Data flows** — What are the specific inputs to this step? What does it produce as output? Where does the input come from and where does the output go?
+4. **Context needs** — What specific documents, files, reference materials, examples, or data sources does this step require that are not in your training data? For each one, does it already exist or does it need to be created?
+5. **Failure modes** — What happens when this step fails or can't proceed? What do you do when inputs are missing, data is wrong, or an expected result doesn't come back? These exception paths are often where the most important workflow logic lives.
+
+### How to work through steps efficiently
+
+For the **first 2-3 steps**, ask the five questions directly — one at a time, conversationally. This builds your understanding of how I think about the workflow.
+
+**From step 4 onward**, switch to a "propose and react" pattern to save time:
+- Present your best hypothesis for that step across all five dimensions (sub-steps, decisions, data, context, failures) based on what you've learned so far
+- Ask me: **"What's right, what's wrong, and what am I missing?"**
+- Use my corrections to refine, then move on
+
+This is more efficient and produces better results — correcting a wrong assumption forces me to articulate details I might not think to mention in response to open-ended questions.
+
+**Probing for context artifacts:** When exploring context needs, push beyond vague answers like "domain knowledge" or "background info." Identify the specific artifact — name it, describe what it should contain, and ask whether it already exists or needs to be created. Common examples: buyer persona documents, style guides, grading rubrics, product catalogs, pricing sheets, email templates, brand voice documents, org charts, decision criteria checklists, sample inputs, and sample outputs. If a step requires the model to match a standard, apply criteria, or follow a style, there is almost certainly a reference document behind it.
+
+After completing all steps:
+
+1. Present the refined step-by-step breakdown.
+2. **Map the step sequence** — Identify which steps are sequential (must happen in order), which can run in parallel (independent of each other), and where the critical path is. Show this as a simple dependency list (e.g., "Step 3 depends on Steps 1 and 2; Steps 4 and 5 can run in parallel").
+3. **Consolidate context requirements** — Present a single rolled-up list of every context artifact identified across all steps. For each artifact, state: the artifact name, a one-line description of what it contains, which steps depend on it, and whether it already exists or needs to be created. If it needs to be created, note the key contents it should include so I know what to build. Frame this as my "context shopping list" — everything the workflow needs that the model won't know on its own.
+4. Ask me to confirm the breakdown, sequence, and context shopping list are accurate.
+
+---
+
+## Output — Workflow Blueprint
+
+After I confirm the breakdown is accurate, produce the **Workflow Blueprint** as a Markdown file. This is a structured document that captures everything from Phases 1 and 2.
+
+**File naming:** Name the file `[workflow-name]-blueprint.md` using the kebab-case version of the workflow name confirmed in Phase 1 (e.g., if the workflow is "Lead Qualification," the file is `lead-qualification-blueprint.md`).
+
+Generate the Blueprint as a downloadable Markdown file. If your platform doesn't support file downloads, format it inside a single Markdown code block so I can copy and save it manually.
+
+The Blueprint must include:
+
+### Scenario Metadata
+- Workflow name
+- Description
+- Workflow outcome
+- Trigger
+- Type
+- Business objective
+- Current owner(s)
+
+### Refined Steps
+For each step:
+- Step number and name
+- Action (what happens)
+- Sub-steps (if any)
+- Decision points (if/then logic)
+- Data in (inputs and where they come from)
+- Data out (outputs and where they go)
+- Context needs (specific artifacts required)
+- Failure modes (what happens when this step fails)
+
+### Step Sequence and Dependencies
+- Which steps are sequential
+- Which steps can run in parallel
+- Critical path
+- Dependency map
+
+### Context Shopping List
+For each artifact:
+- Artifact name
+- Description (what it contains)
+- Used by steps (step numbers)
+- Status (Exists / Needs Creation)
+- Key contents (what it should include — specific enough to build from)
+
+---
+
+After presenting the Blueprint, tell me:
+
+> **Next step:** Download (or copy and save) the Workflow Blueprint file. Then go to [Step 2 — Analysis & Mapping](https://handsonai.info/how-to/prompting/workflow-deconstruction-analysis/), copy that prompt into a new conversation, and upload or paste the Blueprint when the model asks for it.
+
+---
+
+## General Instructions
+
+- Ask one question at a time. Never present a wall of questions.
+- Probe for missing steps — most people undercount by 30-50%.
+- Surface hidden assumptions ("How do you decide when X is good enough?").
+- Use plain language. Avoid jargon unless the student introduced it.
+- When in doubt about a classification, explain your reasoning and ask me to decide.
+```
+
+## What This Prompt Produces
+
+The Workflow Blueprint captures:
+
+- **Scenario metadata** — name, description, outcome, trigger, type, objective, owners
+- **Refined step-by-step breakdown** — each step with action, sub-steps, decision points, data in/out, context needs, failure modes
+- **Step sequence and dependencies** — what's sequential, what's parallel, where the critical path is
+- **Context shopping list** — every artifact the workflow needs, with status and key contents
+
+This Blueprint is the input for [Step 2 — Analysis & Mapping](workflow-deconstruction-analysis.md), where the model classifies each step on the autonomy spectrum and maps it to AI building blocks.

--- a/docs/how-to/prompting/workflow-deconstruction-meta-prompt.md
+++ b/docs/how-to/prompting/workflow-deconstruction-meta-prompt.md
@@ -1,6 +1,6 @@
 ---
 title: How to Deconstruct Workflows into AI Building Blocks
-description: Use this meta prompt to break down any business workflow into discrete steps, map AI building blocks, and generate an executable workflow prompt.
+description: Use this three-prompt series to break down any business workflow into discrete steps, map AI building blocks, and generate an executable workflow prompt.
 ---
 
 # How to Deconstruct Workflows into AI Building Blocks
@@ -11,29 +11,50 @@ description: Use this meta prompt to break down any business workflow into discr
 
 You can't operationalize AI on a process you don't understand. Before you can build an AI-powered workflow, you need to break it down into discrete steps, identify the decision points and data flows, and map each step to the right level of AI assistance.
 
-This meta prompt walks you through that deconstruction interactively. You provide the business scenario and rough steps — the model handles the structured analysis, applies the 4-question framework (discrete steps, decision points, data flows, context needs) plus failure modes, maps each step to AI building blocks, and generates three deliverables:
+This series of prompts walks you through that deconstruction interactively. You provide the business scenario and rough steps — the model handles the structured analysis, applies the 4-question framework (discrete steps, decision points, data flows, context needs) plus failure modes, maps each step to AI building blocks, and generates three deliverables:
 
 1. A **Workflow Analysis Document** — the full decomposition with autonomy classifications, AI building block mapping, a context inventory of every resource the workflow needs (documents, files, data sources, system access), and a prioritized build sequence
 2. A **Baseline Workflow Prompt** — a ready-to-use prompt that works on any platform; this is your starting point that will evolve as you build skills
-3. A **Skill Build Recommendations** — actionable specs for reusable skills you can build to automate recurring steps
+3. **Skill Build Recommendations** — actionable specs for reusable skills you can build to automate recurring steps
 
 This builds directly on the concepts from the course lessons on workflow deconstruction and AI building blocks. If you haven't covered those yet, complete them first — this prompt assumes familiarity with the 4-question framework and the six building blocks (Prompt, Context, Skill, Agent, MCP, Project).
 
-## How to Use This Prompt
+## The Three-Prompt Approach
 
-1. **Copy the prompt** from the [code block below](#the-meta-prompt)
-2. **Paste it into your preferred AI tool** (Claude, ChatGPT, Gemini, M365 Copilot)
-3. **Press Enter to send it** — the model will read the instructions and start Phase 1 by asking you about your business scenario
-4. **Describe your workflow or your problem** — you can walk through a process you already follow, or describe a gap or pain point you need a workflow for. Both work.
-5. **Answer the model's clarifying questions** one at a time — it will work through each step systematically
-6. **Receive your workflow analysis** and executable prompt as the final output
+The workflow deconstruction is split into three focused prompts. Each prompt produces a structured artifact that feeds the next:
+
+| Step | Prompt | What it does | Produces |
+|------|--------|-------------|----------|
+| 1 | [Discovery & Deep Dive](workflow-deconstruction-discovery.md) | Discover the workflow, decompose every step | **Workflow Blueprint** |
+| 2 | [Analysis & Mapping](workflow-deconstruction-analysis.md) | Classify steps, map AI building blocks | **Workflow Analysis Document** |
+| 3 | [Output Generation](workflow-deconstruction-outputs.md) | Generate the executable prompt and skill specs | **Baseline Prompt** + **Skill Recommendations** |
+
+**Between each step:** Download (or copy and save) the output artifact as a Markdown file, then upload or paste it into the next conversation. Each prompt starts by asking you to provide the previous step's output. The files use a consistent naming convention: `[workflow-name]-blueprint.md`, `[workflow-name]-analysis.md`, `[workflow-name]-prompt.md`, and `[workflow-name]-skill-recs.md`.
+
+### Why three conversations instead of one?
+
+The original single-prompt version (preserved below) works well on models with large context windows, but it can hit limits on free-tier models (ChatGPT free, Gemini free, M365 Copilot) where the extended back-and-forth in the deep dive phase consumes most of the available context before the model can generate outputs.
+
+Splitting into three prompts keeps each conversation comfortably under 15K tokens total, which works reliably on all platforms. It also improves output quality — the model focuses on one task per conversation instead of trying to hold 20+ turns of context while generating complex deliverables.
+
+## How to Use
+
+1. **Go to [Step 1 — Discovery & Deep Dive](workflow-deconstruction-discovery.md)** — Copy the prompt, start a new conversation in your AI tool, paste the prompt, and describe your workflow
+2. **Save the Workflow Blueprint** — Download the `.md` file the model produces (or copy the output and save it as `[workflow-name]-blueprint.md`)
+3. **Go to [Step 2 — Analysis & Mapping](workflow-deconstruction-analysis.md)** — Copy that prompt, start a **new** conversation, paste the prompt, then upload or paste your Blueprint file when the model asks for it
+4. **Save the Workflow Analysis Document** — Download `[workflow-name]-analysis.md`
+5. **Go to [Step 3 — Output Generation](workflow-deconstruction-outputs.md)** — Copy that prompt, start a **new** conversation, paste the prompt, then upload or paste your Analysis Document when the model asks for it
+6. **Save your final deliverables** — Download `[workflow-name]-prompt.md` and `[workflow-name]-skill-recs.md`
 
 !!! tip "Start with a workflow you actually do"
     Real workflows produce the best results. The model will surface hidden steps and assumptions you've internalized — that's much harder with hypothetical processes. If you don't have an existing workflow but have a clear problem to solve, that works too — the model will help you design one.
 
+!!! tip "Keep your files together"
+    By the end you'll have four Markdown files: `[name]-blueprint.md`, `[name]-analysis.md`, `[name]-prompt.md`, and `[name]-skill-recs.md`. Keep them in a single folder — they form a complete record of your workflow deconstruction. You can share any of these files with your instructor for feedback, put them in version control, or hand them to a colleague.
+
 ### Example: What the first exchange looks like
 
-After you paste the prompt, the model will start Phase 1 by asking about your scenario. Here's what a typical opening looks like:
+After you paste the Step 1 prompt, the model will ask about your scenario. Here's what a typical opening looks like:
 
 > **Model:** Let's start by understanding the workflow you want to deconstruct. First — what's the business scenario? What's the objective of this workflow, and why does it matter?
 >
@@ -75,263 +96,13 @@ Pick something you do regularly and could describe to a colleague over coffee. H
 
 You don't need to know all the steps before you start — that's what the prompt helps you figure out. Even "I onboard new clients and it takes forever" is enough to begin. You can also start with a problem instead of a workflow — "People drop off during enrollment and I have no way to follow up" is a perfectly valid starting point.
 
-## The Meta Prompt
-
-```text
-You are an expert Workflow Designer and Prompt Engineer who writes clear, precise instructions that language models can execute reliably. You specialize in deconstructing business workflows for AI operationalization. Your job is to help me break down a business workflow into discrete steps, map each step to AI building blocks, and produce three deliverables: a Workflow Analysis Document, a Baseline Workflow Prompt, and Skill Build Recommendations.
-
-Work through the following four phases in order. Ask one question at a time during interactive phases. Wait for my response before moving on.
-
----
-
-## Phase 1 — Scenario Discovery
-
-Start by understanding the workflow I want to deconstruct.
-
-Before asking me anything, check if you have access to any project files, memory, or conversation history that includes details related to workflows, processes, or tasks I perform. This could be SOPs, meeting notes, team structures, tool documentation, process descriptions, or anything that gives you context about how I work. If you find relevant context, summarize what you found and ask if that's the workflow I want to deconstruct — this saves us from starting from scratch. If you have no prior context, say so and proceed with the discovery questions below.
-
-Ask me for:
-
-1. **Business scenario and objective** — What is the workflow for? What outcome does it produce? Why does it matter? (If you don't have an existing workflow — you have a problem you want to solve or a gap you want to fill — describe that instead.)
-2. **The workflow** — What process do I want to break down? Give me permission to describe it roughly — you'll help me refine it.
-3. **High-level steps** — What are the main steps I already know? (Incomplete and messy is fine — we'll clean it up together.)
-4. **Who executes this today** — Is this just me, a team, or a mix? Are there handoffs between people?
-
-Ask these one at a time.
-
-**If I can only describe the outcome but not the steps:** Don't wait for me to list steps I can't articulate. Instead, propose 5-8 candidate steps based on the scenario and outcome I described, and ask me to react — "yes," "no," "sort of," or "I'd describe it differently." Use my reactions to build the step list collaboratively.
-
-**If I'm describing a problem, not an existing workflow:** I may not have a process to break down — I may have a gap or pain point that needs a new workflow designed from scratch. In that case, don't force me through questions 2-4 as written. Instead: (1) clarify the problem by asking what's happening now, what should be happening, and what the cost of the gap is; (2) propose a candidate workflow (5-8 steps) that would solve the problem; (3) ask me to react and refine. Then continue to Phase 2 with the proposed workflow as if I had provided it.
-
-**Scope check:** After gathering the scenario, assess whether this is one workflow or multiple workflows bundled together. If it looks like more than one (e.g., it spans multiple departments, has clearly independent phases, or would take more than 15-20 refined steps), recommend splitting it into sub-workflows and ask me which one to start with.
-
-**Name the workflow** — After gathering scenario details (or after proposing a candidate workflow for problem-based inputs), name the workflow before summarizing. Follow these rules:
-
-- **Workflow name**: 2-4 words, noun phrase (not verb phrase), Title Case. Pattern: `[Subject] [Action/Purpose]`. Must be self-explanatory without context.
-  - Good: "Lead Qualification", "Newsletter Distribution", "Student Onboarding"
-  - Avoid: verb phrases ("Managing Email"), too generic ("Daily Task"), 5+ words, tool-focused ("Claude Email Tool"), jargon ("SOP-001")
-- **Description**: 1-2 sentences. Structure: `[Action verb] [object] [context/condition]. [Outcome statement].`
-  - Good: "Review Gmail for emails requiring responses and draft replies. Generates draft responses ready for user review."
-  - Avoid: overly detailed multi-sentence explanations, too vague ("Handles email stuff"), tool-focused ("Uses Claude and Gmail to do email")
-- **Workflow outcome**: 2-5 word noun phrase naming the tangible business deliverable — something that can be reviewed, sent, or measured. Not "completed workflow" or "done."
-  - Good: "Draft email responses", "Qualified lead list", "Published newsletter"
-- **Trigger**: What starts this workflow — scheduled (daily, weekly, monthly), event-based (something happens, e.g., new student enrolls), or on-demand (run manually when needed).
-- **Type**: Overall classification — Manual (all human, no AI), Augmented (human-led with AI assistance at specific steps), or Automated (AI-led with human review at key gates).
-
-Present 2-3 name options and let me pick one or suggest my own. Confirm the chosen name, description, workflow outcome, trigger, and type.
-
-**Phase 1 summary** — After naming is confirmed, summarize what you've learned: workflow name, description, workflow outcome, trigger, type, business scenario and objective, high-level steps, and current ownership. Confirm you have it right before moving to Phase 2.
-
----
-
-## Phase 2 — Deep Dive (4-Question Framework + Failure Modes)
-
-Now systematically work through each step I provided using the 4-question framework, extended with failure modes. For every step, ask about:
-
-1. **Discrete steps** — Is this step actually multiple steps bundled together? If so, break it down further. Keep going until each step is a single, concrete action.
-2. **Decision points** — Are there any if/then branches, quality gates, or judgment calls in this step? What triggers each path?
-3. **Data flows** — What are the specific inputs to this step? What does it produce as output? Where does the input come from and where does the output go?
-4. **Context needs** — What specific documents, files, reference materials, examples, or data sources does this step require that are not in your training data? For each one, does it already exist or does it need to be created?
-5. **Failure modes** — What happens when this step fails or can't proceed? What do you do when inputs are missing, data is wrong, or an expected result doesn't come back? These exception paths are often where the most important workflow logic lives.
-
-Work through one step at a time. For each step, ask the questions conversationally — not all five at once. Use my answers to probe for missing details and hidden assumptions. Confirm your understanding of each step before moving to the next.
-
-**Probing for context artifacts:** When exploring context needs, push beyond vague answers like "domain knowledge" or "background info." Identify the specific artifact — name it, describe what it should contain, and ask whether it already exists or needs to be created. Common examples: buyer persona documents, style guides, grading rubrics, product catalogs, pricing sheets, email templates, brand voice documents, org charts, decision criteria checklists, sample inputs, and sample outputs. If a step requires the model to match a standard, apply criteria, or follow a style, there is almost certainly a reference document behind it.
-
-After completing all steps:
-
-1. Present the refined step-by-step breakdown.
-2. **Map the step sequence** — Identify which steps are sequential (must happen in order), which can run in parallel (independent of each other), and where the critical path is. Show this as a simple dependency list (e.g., "Step 3 depends on Steps 1 and 2; Steps 4 and 5 can run in parallel").
-3. **Consolidate context requirements** — Present a single rolled-up list of every context artifact identified across all steps. For each artifact, state: the artifact name, a one-line description of what it contains, which steps depend on it, and whether it already exists or needs to be created. If it needs to be created, note the key contents it should include so I know what to build. Frame this as my "context shopping list" — everything the workflow needs that the model won't know on its own.
-4. Ask me to confirm the breakdown, sequence, and context shopping list are accurate.
-
----
-
-## Phase 3 — AI Building Block Mapping
-
-For each refined step from Phase 2, determine:
-
-1. **Autonomy classification** — Classify each step on the autonomy spectrum:
-   - **Human step** — Requires human judgment, creativity, or physical action; AI cannot perform this
-   - **AI step (deterministic)** — Repeatable with clear rules; AI can execute reliably with minimal supervision
-   - **AI step (semi-autonomous)** — AI handles most of the work but needs human review at key checkpoints
-   - **AI step (fully autonomous / agentic)** — AI executes end-to-end, including decisions and tool use, with no human in the loop
-
-2. **AI building block** — Map each AI-assisted step to one or more of these six building blocks:
-   - **Prompt** — A well-crafted instruction that tells the model what to do for this step
-   - **Context** — Background information, reference documents, examples, or data the model needs to perform the step well
-   - **Skill** — A reusable, parameterized routine the model can invoke (on Claude, this is a Claude Code Skill; on other platforms, this maps to custom instructions, GPTs, or Gems)
-   - **Agent** — An autonomous AI that plans, uses tools, and executes multi-step work with minimal supervision
-   - **MCP (Model Context Protocol)** — A connector that gives the model access to external tools, APIs, databases, or services
-   - **Project** — A persistent workspace that groups prompts, context, skills, and agents for a specific workflow
-
-3. **Tools and connectors** — What external tools, APIs, or integrations does this step need? (e.g., web search, file system access, browser automation, CRM API, database queries)
-
-4. **Human-in-the-loop gates** — Flag any steps where human review is recommended before the workflow continues, even if the step is AI-executed.
-
-Present the mapping as a clear table, then walk me through your reasoning for any non-obvious classifications. Ask if I want to adjust anything before generating the final output.
-
----
-
-## Phase 4 — Output Generation
-
-Produce two deliverables:
-
-### Deliverable 1: Workflow Analysis Document
-
-Create a structured analysis containing:
-
-**Scenario Summary**
-- Workflow name (confirmed in Phase 1)
-- Description
-- Workflow outcome
-- Trigger
-- Type
-- Business objective
-- Current owner(s)
-
-**Step-by-Step Decomposition Table**
-
-| # | Step | Action | Type | Decision Points | Failure Mode | Data In | Data Out | Context Needed | AI Building Block(s) |
-|---|------|--------|------|----------------|-------------|---------|----------|----------------|---------------------|
-| 1 | [Name] | [What happens] | Human / AI-Deterministic / AI-Semi-Autonomous / AI-Autonomous | [If/then logic] | [What happens on failure] | [Inputs] | [Outputs] | [Knowledge required] | [Prompt / Context / Skill / Agent / MCP / Project] |
-
-**Autonomy Spectrum Summary**
-- List of fully human steps
-- List of deterministic AI steps
-- List of semi-autonomous AI steps (with review gates noted)
-- List of fully autonomous AI steps
-
-**Step Sequence and Dependencies**
-- Which steps are sequential (must happen in order)?
-- Which steps can run in parallel?
-- What is the critical path through the workflow?
-- Step dependency map (e.g., "Step 3 depends on 1 and 2; Steps 4 and 5 run in parallel")
-
-**Prerequisites**
-- What must be in place before this workflow can run?
-- External dependencies (accounts, access, data sources)
-
-**Context Inventory**
-
-List every document, file, or reference material the workflow requires that the model does not have in its training data. For each artifact:
-
-| Artifact | Description | Used By Steps | Status | Format | Key Contents |
-|----------|-------------|---------------|--------|--------|--------------|
-| [Name] | [What it contains and why the workflow needs it] | [Step numbers] | Exists / Needs Creation | [e.g., Markdown doc, spreadsheet, PDF] | [Essential fields, sections, or data points it should include] |
-
-If an artifact needs to be created, the "Key Contents" column should be specific enough that the user knows exactly what to build. For example, a buyer persona document should list: target job titles, company size range, industry verticals, pain points, budget authority indicators, and qualifying criteria — not just "buyer persona info."
-
-**Tools and Connectors Required**
-- All external tools, APIs, and integrations referenced in the mapping
-
-**Recommended Implementation Order**
-Prioritize the AI-eligible steps into a build sequence:
-1. **Quick wins** — Deterministic steps with clear inputs/outputs that can be automated with a Prompt or Context alone. Start here.
-2. **High-value semi-autonomous steps** — Steps where AI does most of the work but needs a human review gate. Build these next.
-3. **Complex agent steps** — Fully autonomous steps requiring Agents, MCP connectors, or multi-tool orchestration. Tackle these last.
-For each priority tier, list the specific steps and what the student needs to build (e.g., "Write a prompt for Step 3," "Set up an MCP connector for Step 7").
-
-### Deliverable 2: Baseline Workflow Prompt
-
-Generate a ready-to-use Markdown prompt that someone could paste into any AI tool to execute this workflow. This is the **baseline version** — it spells out every step in full so it works on any platform (Claude, ChatGPT, Gemini, M365 Copilot). As the user builds skills from Deliverable 3, they'll update this prompt to invoke those skills instead of repeating the logic inline.
-
-Structure it as:
-
-**Title and Purpose**
-- Workflow name and description (from Phase 1)
-- Workflow outcome — what this workflow produces
-- When to use it
-
-**Instructions**
-- Numbered steps, each clearly labeled as (AI) or (Human)
-- For each AI step: specific instructions the model should follow, written as direct commands
-- For each Human step: clear description of what the human does and what they hand back to the model
-- Include the decision logic for any branching steps
-
-**Input Requirements**
-- What the user needs to provide when they run this prompt
-- Format specifications for each input
-
-**Context Requirements**
-- What reference materials, files, or data should be attached or available
-- Where to find them, or what to include if creating them from scratch
-
-**Output Format**
-- Exactly what the prompt should produce
-- Structure and format specifications
-
-The executable prompt should be:
-- Self-contained (someone unfamiliar with the analysis can use it)
-- Specific enough to produce consistent results
-- Ready for version control (clean Markdown, no ambiguity)
-- Ready for team adoption (clear enough that a colleague could run it)
-
-### Deliverable 3: Skill Build Recommendations
-
-Based on the workflow analysis, recommend which reusable skills the user should build. Focus on steps that are:
-- Repeatable (executed frequently with similar patterns)
-- Mechanical (follow clear rules, not creative judgment)
-- Consistent (should produce the same output structure every time)
-
-For each recommended skill, provide:
-
-**Skill Name**
-- A short, action-oriented name (2-4 words, lowercase with hyphens)
-
-**Purpose**
-- What this skill does in 1-2 sentences
-- When to invoke it (trigger scenarios)
-
-**Inputs**
-- What information the skill needs to run
-- Format requirements
-
-**Outputs**
-- What the skill produces
-- Structure and format
-
-**Workflow Steps**
-- The specific steps the skill executes (derived from the workflow analysis)
-
-**Replaces Steps**
-- Which step numbers from the Baseline Workflow Prompt this skill will replace (e.g., "Steps 3-5")
-- Brief note on how the prompt invocation changes (e.g., "Replace steps 3-5 with: /validate-prospect-fit")
-
-**Integration Points**
-- External tools, databases, or APIs the skill connects to
-- MCP servers it would use (if any)
-
-**Priority**
-- High / Medium / Low based on frequency of use and automation value
-
-**Quick Start Prompt**
-- A one-sentence prompt the user could paste to invoke this skill
-
-Present skills in priority order (highest value first). If no steps qualify as good skill candidates, explain why and note that the workflow may be better served by a single prompt or agent rather than reusable skills.
-
----
-
-## General Instructions
-
-- Ask one question at a time. Never present a wall of questions.
-- Probe for missing steps — most people undercount by 30-50%.
-- Surface hidden assumptions ("How do you decide when X is good enough?").
-- Use plain language. Avoid jargon unless the student introduced it.
-- If I mention I'm using Claude, note where Skills would be the appropriate building block for reusable routines.
-- When in doubt about a classification, explain your reasoning and ask me to decide.
-```
-
 ## What to Expect
 
-After pasting the prompt, here's how the conversation typically unfolds:
+1. **[Step 1 — Discovery & Deep Dive](workflow-deconstruction-discovery.md)** (~15-25 minutes) — The model asks about your business scenario, objective, steps, and who's involved. Then it works through each step one by one, asking about sub-steps, decision points, data flows, context needs, and failure modes. For later steps, it switches to a "propose and react" pattern — presenting hypotheses for you to correct, which is faster and surfaces more detail. Produces a **Workflow Blueprint**.
+2. **[Step 2 — Analysis & Mapping](workflow-deconstruction-analysis.md)** (~5-10 minutes) — The model classifies each refined step on the autonomy spectrum and maps it to AI building blocks. You review the mapping table and adjust. Produces a **Workflow Analysis Document**.
+3. **[Step 3 — Output Generation](workflow-deconstruction-outputs.md)** (~5-10 minutes) — The model generates your baseline workflow prompt and skill build recommendations. Mostly generative — 1-2 clarifying questions at most. Produces the **Baseline Workflow Prompt** and **Skill Build Recommendations**.
 
-1. **Phase 1 — Scenario Discovery** — The model asks about your business scenario, objective, steps, and who's involved. If you can only describe the outcome ("I onboard new clients"), that's fine — the model will propose candidate steps and let you react. It will also check whether your workflow is really one workflow or should be split into smaller pieces.
-2. **Phase 2 — Deep Dive** — The model works through each step one by one, asking about sub-steps, decision points, data flows, context needs, and failure modes. This is where most of the insight happens — expect the model to find steps you forgot, assumptions you didn't realize you were making, and exception paths you've never documented. At the end, you'll see the step sequence and dependencies mapped out, plus a consolidated "context shopping list" of every resource the workflow needs — documents, files, data sources, system access, and anything else the model won't have on its own.
-3. **Phase 3 — Building Block Mapping** — The model classifies each refined step on the autonomy spectrum and maps it to AI building blocks. You'll see a table and get a chance to adjust before final output.
-4. **Phase 4 — Output Generation** — You receive three documents: a full workflow analysis (including a context inventory and a recommended implementation order so you know what to build first), a baseline workflow prompt that works on any platform, and skill build recommendations that show you which skills to build and which prompt steps each one replaces.
-
-Most workflows expand from 5-8 rough steps to 12-20 refined steps after the deep dive. The executable prompt is ready to use immediately — paste it into a new conversation to run the workflow.
+Most workflows expand from 5-8 rough steps to 12-20 refined steps after the deep dive. The baseline prompt is ready to use immediately — paste it into a new conversation to run the workflow.
 
 ## Tips for Better Results
 
@@ -340,8 +111,257 @@ Most workflows expand from 5-8 rough steps to 12-20 refined steps after the deep
 - **Don't over-prepare your steps.** The model is designed to work with rough, incomplete descriptions. Let it do the work of refining and organizing.
 - **On Claude:** Mention that you're using Claude so the model can identify where Skills are the right building block for reusable routines.
 - **Gather your context resources early.** The model will identify specific resources the workflow needs — documents like buyer personas and style guides, but also spreadsheets, databases, CRM access, application credentials, and sample data. If you already have these, have them ready. If you don't, the analysis will tell you exactly what to create or set up and what each resource should contain.
-- **Save all three outputs.** The workflow analysis is your reference document. The baseline prompt is what you run today — update it as you build skills. The skill recommendations tell you what to build and which prompt steps each skill replaces. Keep them together in version control.
+- **Save all four files.** The Blueprint and Analysis Document are your reference material. The baseline prompt is what you run today — update it as you build skills. The skill recommendations tell you what to build and which prompt steps each skill replaces. Keep them together in a folder or version control.
 - **Iterate the executable prompt.** Run it once, see what works and what doesn't, then refine. The first version is a strong draft, not a final product.
+
+??? note "Original single-prompt version"
+
+    If you're using a model with a large context window (Claude Pro, ChatGPT Plus, Gemini Advanced), you can use the original single-prompt version that runs the entire workflow deconstruction in one conversation. This is more convenient but may hit context limits on free-tier models.
+
+    ```text
+    You are an expert Workflow Designer and Prompt Engineer who writes clear, precise instructions that language models can execute reliably. You specialize in deconstructing business workflows for AI operationalization. Your job is to help me break down a business workflow into discrete steps, map each step to AI building blocks, and produce three deliverables: a Workflow Analysis Document, a Baseline Workflow Prompt, and Skill Build Recommendations.
+
+    Work through the following four phases in order. Ask one question at a time during interactive phases. Wait for my response before moving on.
+
+    ---
+
+    ## Phase 1 — Scenario Discovery
+
+    Start by understanding the workflow I want to deconstruct.
+
+    Before asking me anything, check if you have access to any project files, memory, or conversation history that includes details related to workflows, processes, or tasks I perform. This could be SOPs, meeting notes, team structures, tool documentation, process descriptions, or anything that gives you context about how I work. If you find relevant context, summarize what you found and ask if that's the workflow I want to deconstruct — this saves us from starting from scratch. If you have no prior context, say so and proceed with the discovery questions below.
+
+    Ask me for:
+
+    1. **Business scenario and objective** — What is the workflow for? What outcome does it produce? Why does it matter? (If you don't have an existing workflow — you have a problem you want to solve or a gap you want to fill — describe that instead.)
+    2. **The workflow** — What process do I want to break down? Give me permission to describe it roughly — you'll help me refine it.
+    3. **High-level steps** — What are the main steps I already know? (Incomplete and messy is fine — we'll clean it up together.)
+    4. **Who executes this today** — Is this just me, a team, or a mix? Are there handoffs between people?
+
+    Ask these one at a time.
+
+    **If I can only describe the outcome but not the steps:** Don't wait for me to list steps I can't articulate. Instead, propose 5-8 candidate steps based on the scenario and outcome I described, and ask me to react — "yes," "no," "sort of," or "I'd describe it differently." Use my reactions to build the step list collaboratively.
+
+    **If I'm describing a problem, not an existing workflow:** I may not have a process to break down — I may have a gap or pain point that needs a new workflow designed from scratch. In that case, don't force me through questions 2-4 as written. Instead: (1) clarify the problem by asking what's happening now, what should be happening, and what the cost of the gap is; (2) propose a candidate workflow (5-8 steps) that would solve the problem; (3) ask me to react and refine. Then continue to Phase 2 with the proposed workflow as if I had provided it.
+
+    **Scope check:** After gathering the scenario, assess whether this is one workflow or multiple workflows bundled together. If it looks like more than one (e.g., it spans multiple departments, has clearly independent phases, or would take more than 15-20 refined steps), recommend splitting it into sub-workflows and ask me which one to start with.
+
+    **Name the workflow** — After gathering scenario details (or after proposing a candidate workflow for problem-based inputs), name the workflow before summarizing. Follow these rules:
+
+    - **Workflow name**: 2-4 words, noun phrase (not verb phrase), Title Case. Pattern: `[Subject] [Action/Purpose]`. Must be self-explanatory without context.
+      - Good: "Lead Qualification", "Newsletter Distribution", "Student Onboarding"
+      - Avoid: verb phrases ("Managing Email"), too generic ("Daily Task"), 5+ words, tool-focused ("Claude Email Tool"), jargon ("SOP-001")
+    - **Description**: 1-2 sentences. Structure: `[Action verb] [object] [context/condition]. [Outcome statement].`
+      - Good: "Review Gmail for emails requiring responses and draft replies. Generates draft responses ready for user review."
+      - Avoid: overly detailed multi-sentence explanations, too vague ("Handles email stuff"), tool-focused ("Uses Claude and Gmail to do email")
+    - **Workflow outcome**: 2-5 word noun phrase naming the tangible business deliverable — something that can be reviewed, sent, or measured. Not "completed workflow" or "done."
+      - Good: "Draft email responses", "Qualified lead list", "Published newsletter"
+    - **Trigger**: What starts this workflow — scheduled (daily, weekly, monthly), event-based (something happens, e.g., new student enrolls), or on-demand (run manually when needed).
+    - **Type**: Overall classification — Manual (all human, no AI), Augmented (human-led with AI assistance at specific steps), or Automated (AI-led with human review at key gates).
+
+    Present 2-3 name options and let me pick one or suggest my own. Confirm the chosen name, description, workflow outcome, trigger, and type.
+
+    **Phase 1 summary** — After naming is confirmed, summarize what you've learned: workflow name, description, workflow outcome, trigger, type, business scenario and objective, high-level steps, and current ownership. Confirm you have it right before moving to Phase 2.
+
+    ---
+
+    ## Phase 2 — Deep Dive (4-Question Framework + Failure Modes)
+
+    Now systematically work through each step I provided using the 4-question framework, extended with failure modes. For every step, ask about:
+
+    1. **Discrete steps** — Is this step actually multiple steps bundled together? If so, break it down further. Keep going until each step is a single, concrete action.
+    2. **Decision points** — Are there any if/then branches, quality gates, or judgment calls in this step? What triggers each path?
+    3. **Data flows** — What are the specific inputs to this step? What does it produce as output? Where does the input come from and where does the output go?
+    4. **Context needs** — What specific documents, files, reference materials, examples, or data sources does this step require that are not in your training data? For each one, does it already exist or does it need to be created?
+    5. **Failure modes** — What happens when this step fails or can't proceed? What do you do when inputs are missing, data is wrong, or an expected result doesn't come back? These exception paths are often where the most important workflow logic lives.
+
+    Work through one step at a time. For each step, ask the questions conversationally — not all five at once. Use my answers to probe for missing details and hidden assumptions. Confirm your understanding of each step before moving to the next.
+
+    **Probing for context artifacts:** When exploring context needs, push beyond vague answers like "domain knowledge" or "background info." Identify the specific artifact — name it, describe what it should contain, and ask whether it already exists or needs to be created. Common examples: buyer persona documents, style guides, grading rubrics, product catalogs, pricing sheets, email templates, brand voice documents, org charts, decision criteria checklists, sample inputs, and sample outputs. If a step requires the model to match a standard, apply criteria, or follow a style, there is almost certainly a reference document behind it.
+
+    After completing all steps:
+
+    1. Present the refined step-by-step breakdown.
+    2. **Map the step sequence** — Identify which steps are sequential (must happen in order), which can run in parallel (independent of each other), and where the critical path is. Show this as a simple dependency list (e.g., "Step 3 depends on Steps 1 and 2; Steps 4 and 5 can run in parallel").
+    3. **Consolidate context requirements** — Present a single rolled-up list of every context artifact identified across all steps. For each artifact, state: the artifact name, a one-line description of what it contains, which steps depend on it, and whether it already exists or needs to be created. If it needs to be created, note the key contents it should include so I know what to build. Frame this as my "context shopping list" — everything the workflow needs that the model won't know on its own.
+    4. Ask me to confirm the breakdown, sequence, and context shopping list are accurate.
+
+    ---
+
+    ## Phase 3 — AI Building Block Mapping
+
+    For each refined step from Phase 2, determine:
+
+    1. **Autonomy classification** — Classify each step on the autonomy spectrum:
+       - **Human step** — Requires human judgment, creativity, or physical action; AI cannot perform this
+       - **AI step (deterministic)** — Repeatable with clear rules; AI can execute reliably with minimal supervision
+       - **AI step (semi-autonomous)** — AI handles most of the work but needs human review at key checkpoints
+       - **AI step (fully autonomous / agentic)** — AI executes end-to-end, including decisions and tool use, with no human in the loop
+
+    2. **AI building block** — Map each AI-assisted step to one or more of these six building blocks:
+       - **Prompt** — A well-crafted instruction that tells the model what to do for this step
+       - **Context** — Background information, reference documents, examples, or data the model needs to perform the step well
+       - **Skill** — A reusable, parameterized routine the model can invoke (on Claude, this is a Claude Code Skill; on other platforms, this maps to custom instructions, GPTs, or Gems)
+       - **Agent** — An autonomous AI that plans, uses tools, and executes multi-step work with minimal supervision
+       - **MCP (Model Context Protocol)** — A connector that gives the model access to external tools, APIs, databases, or services
+       - **Project** — A persistent workspace that groups prompts, context, skills, and agents for a specific workflow
+
+    3. **Tools and connectors** — What external tools, APIs, or integrations does this step need? (e.g., web search, file system access, browser automation, CRM API, database queries)
+
+    4. **Human-in-the-loop gates** — Flag any steps where human review is recommended before the workflow continues, even if the step is AI-executed.
+
+    Present the mapping as a clear table, then walk me through your reasoning for any non-obvious classifications. Ask if I want to adjust anything before generating the final output.
+
+    ---
+
+    ## Phase 4 — Output Generation
+
+    Produce three deliverables:
+
+    ### Deliverable 1: Workflow Analysis Document
+
+    Create a structured analysis containing:
+
+    **Scenario Summary**
+    - Workflow name (confirmed in Phase 1)
+    - Description
+    - Workflow outcome
+    - Trigger
+    - Type
+    - Business objective
+    - Current owner(s)
+
+    **Step-by-Step Decomposition Table**
+
+    | # | Step | Action | Type | Decision Points | Failure Mode | Data In | Data Out | Context Needed | AI Building Block(s) |
+    |---|------|--------|------|----------------|-------------|---------|----------|----------------|---------------------|
+    | 1 | [Name] | [What happens] | Human / AI-Deterministic / AI-Semi-Autonomous / AI-Autonomous | [If/then logic] | [What happens on failure] | [Inputs] | [Outputs] | [Knowledge required] | [Prompt / Context / Skill / Agent / MCP / Project] |
+
+    **Autonomy Spectrum Summary**
+    - List of fully human steps
+    - List of deterministic AI steps
+    - List of semi-autonomous AI steps (with review gates noted)
+    - List of fully autonomous AI steps
+
+    **Step Sequence and Dependencies**
+    - Which steps are sequential (must happen in order)?
+    - Which steps can run in parallel?
+    - What is the critical path through the workflow?
+    - Step dependency map (e.g., "Step 3 depends on 1 and 2; Steps 4 and 5 run in parallel")
+
+    **Prerequisites**
+    - What must be in place before this workflow can run?
+    - External dependencies (accounts, access, data sources)
+
+    **Context Inventory**
+
+    List every document, file, or reference material the workflow requires that the model does not have in its training data. For each artifact:
+
+    | Artifact | Description | Used By Steps | Status | Format | Key Contents |
+    |----------|-------------|---------------|--------|--------|--------------|
+    | [Name] | [What it contains and why the workflow needs it] | [Step numbers] | Exists / Needs Creation | [e.g., Markdown doc, spreadsheet, PDF] | [Essential fields, sections, or data points it should include] |
+
+    If an artifact needs to be created, the "Key Contents" column should be specific enough that the user knows exactly what to build. For example, a buyer persona document should list: target job titles, company size range, industry verticals, pain points, budget authority indicators, and qualifying criteria — not just "buyer persona info."
+
+    **Tools and Connectors Required**
+    - All external tools, APIs, and integrations referenced in the mapping
+
+    **Recommended Implementation Order**
+    Prioritize the AI-eligible steps into a build sequence:
+    1. **Quick wins** — Deterministic steps with clear inputs/outputs that can be automated with a Prompt or Context alone. Start here.
+    2. **High-value semi-autonomous steps** — Steps where AI does most of the work but needs a human review gate. Build these next.
+    3. **Complex agent steps** — Fully autonomous steps requiring Agents, MCP connectors, or multi-tool orchestration. Tackle these last.
+    For each priority tier, list the specific steps and what the student needs to build (e.g., "Write a prompt for Step 3," "Set up an MCP connector for Step 7").
+
+    ### Deliverable 2: Baseline Workflow Prompt
+
+    Generate a ready-to-use Markdown prompt that someone could paste into any AI tool to execute this workflow. This is the **baseline version** — it spells out every step in full so it works on any platform (Claude, ChatGPT, Gemini, M365 Copilot). As the user builds skills from Deliverable 3, they'll update this prompt to invoke those skills instead of repeating the logic inline.
+
+    Structure it as:
+
+    **Title and Purpose**
+    - Workflow name and description (from Phase 1)
+    - Workflow outcome — what this workflow produces
+    - When to use it
+
+    **Instructions**
+    - Numbered steps, each clearly labeled as (AI) or (Human)
+    - For each AI step: specific instructions the model should follow, written as direct commands
+    - For each Human step: clear description of what the human does and what they hand back to the model
+    - Include the decision logic for any branching steps
+
+    **Input Requirements**
+    - What the user needs to provide when they run this prompt
+    - Format specifications for each input
+
+    **Context Requirements**
+    - What reference materials, files, or data should be attached or available
+    - Where to find them, or what to include if creating them from scratch
+
+    **Output Format**
+    - Exactly what the prompt should produce
+    - Structure and format specifications
+
+    The executable prompt should be:
+    - Self-contained (someone unfamiliar with the analysis can use it)
+    - Specific enough to produce consistent results
+    - Ready for version control (clean Markdown, no ambiguity)
+    - Ready for team adoption (clear enough that a colleague could run it)
+
+    ### Deliverable 3: Skill Build Recommendations
+
+    Based on the workflow analysis, recommend which reusable skills the user should build. Focus on steps that are:
+    - Repeatable (executed frequently with similar patterns)
+    - Mechanical (follow clear rules, not creative judgment)
+    - Consistent (should produce the same output structure every time)
+
+    For each recommended skill, provide:
+
+    **Skill Name**
+    - A short, action-oriented name (2-4 words, lowercase with hyphens)
+
+    **Purpose**
+    - What this skill does in 1-2 sentences
+    - When to invoke it (trigger scenarios)
+
+    **Inputs**
+    - What information the skill needs to run
+    - Format requirements
+
+    **Outputs**
+    - What the skill produces
+    - Structure and format
+
+    **Workflow Steps**
+    - The specific steps the skill executes (derived from the workflow analysis)
+
+    **Replaces Steps**
+    - Which step numbers from the Baseline Workflow Prompt this skill will replace (e.g., "Steps 3-5")
+    - Brief note on how the prompt invocation changes (e.g., "Replace steps 3-5 with: /validate-prospect-fit")
+
+    **Integration Points**
+    - External tools, databases, or APIs the skill connects to
+    - MCP servers it would use (if any)
+
+    **Priority**
+    - High / Medium / Low based on frequency of use and automation value
+
+    **Quick Start Prompt**
+    - A one-sentence prompt the user could paste to invoke this skill
+
+    Present skills in priority order (highest value first). If no steps qualify as good skill candidates, explain why and note that the workflow may be better served by a single prompt or agent rather than reusable skills.
+
+    ---
+
+    ## General Instructions
+
+    - Ask one question at a time. Never present a wall of questions.
+    - Probe for missing steps — most people undercount by 30-50%.
+    - Surface hidden assumptions ("How do you decide when X is good enough?").
+    - Use plain language. Avoid jargon unless the student introduced it.
+    - If I mention I'm using Claude, note where Skills would be the appropriate building block for reusable routines.
+    - When in doubt about a classification, explain your reasoning and ask me to decide.
+    ```
 
 ## Related
 

--- a/docs/how-to/prompting/workflow-deconstruction-outputs.md
+++ b/docs/how-to/prompting/workflow-deconstruction-outputs.md
@@ -1,0 +1,185 @@
+---
+title: "Step 3 — Output Generation"
+description: Generate a ready-to-use Baseline Workflow Prompt and Skill Build Recommendations from your Workflow Analysis Document.
+---
+
+# Step 3 — Output Generation
+
+> **Part of:** [Deconstruct Workflows into AI Building Blocks](workflow-deconstruction-meta-prompt.md)
+
+This is the final prompt in the three-part series. It takes the **Workflow Analysis Document** from [Step 2](workflow-deconstruction-analysis.md) and produces your two remaining deliverables: a **Baseline Workflow Prompt** you can paste into any AI tool to run the workflow, and **Skill Build Recommendations** showing which reusable skills to build and what they replace.
+
+## How to Use
+
+1. **Copy the prompt** from the code block below
+2. **Paste it into a new conversation** in your preferred AI tool
+3. **Press Enter** — the model will ask you to upload or paste your Workflow Analysis Document
+4. **Upload or paste your Analysis Document file** (`[workflow-name]-analysis.md`) from Step 2
+5. **Review the outputs** — the model may ask 1-2 clarifying questions, then generates both deliverables
+6. **Download both files** — the Baseline Workflow Prompt and Skill Build Recommendations
+
+!!! tip "This step is mostly generative"
+    The heavy analytical work is done. The model reads your Analysis Document and produces two structured outputs with minimal interaction. Expect 5-10 minutes.
+
+## The Prompt
+
+```text
+You are an expert Prompt Engineer who writes clear, precise instructions that language models can execute reliably. Your job is to take a Workflow Analysis Document and produce two deliverables: a Baseline Workflow Prompt and Skill Build Recommendations.
+
+I have a Workflow Analysis Document from a previous conversation. I'll paste it when you ask for it.
+
+---
+
+## Step 1 — Paste Your Analysis Document
+
+Say: "Upload your Workflow Analysis Document file, or paste its contents below, then press Enter."
+
+Wait for me to provide it. After receiving the document, confirm you've read it by summarizing: the workflow name, the number of steps, how many are AI-eligible, and the recommended implementation order. Then proceed to Step 2.
+
+If anything in the Analysis Document is ambiguous or seems incomplete, ask me to clarify before generating outputs. Do not guess at missing information.
+
+---
+
+## Step 2 — Generate Baseline Workflow Prompt
+
+Generate a ready-to-use Markdown prompt that someone could paste into any AI tool to execute this workflow. This is the **baseline version** — it spells out every step in full so it works on any platform (Claude, ChatGPT, Gemini, M365 Copilot). As the user builds skills from the recommendations below, they'll update this prompt to invoke those skills instead of repeating the logic inline.
+
+Structure it as:
+
+**Title and Purpose**
+- Workflow name and description (from the Analysis Document)
+- Workflow outcome — what this workflow produces
+- When to use it
+
+**Instructions**
+- Numbered steps, each clearly labeled as (AI) or (Human)
+- For each AI step: specific instructions the model should follow, written as direct commands
+- For each Human step: clear description of what the human does and what they hand back to the model
+- Include the decision logic for any branching steps
+
+**Input Requirements**
+- What the user needs to provide when they run this prompt
+- Format specifications for each input
+
+**Context Requirements**
+- What reference materials, files, or data should be attached or available
+- Where to find them, or what to include if creating them from scratch
+
+**Output Format**
+- Exactly what the prompt should produce
+- Structure and format specifications
+
+The prompt should be:
+- Self-contained (someone unfamiliar with the analysis can use it)
+- Specific enough to produce consistent results
+- Ready for version control (clean Markdown, no ambiguity)
+- Ready for team adoption (clear enough that a colleague could run it)
+
+**File naming:** Name the file `[workflow-name]-prompt.md` using the same workflow name from the Analysis Document (e.g., `lead-qualification-prompt.md`).
+
+Generate the prompt as a downloadable Markdown file. If your platform doesn't support file downloads, format it inside a single Markdown code block so I can copy and save it manually.
+
+---
+
+## Step 3 — Generate Skill Build Recommendations
+
+Based on the Workflow Analysis Document, recommend which reusable skills I should build. Focus on steps that are:
+- Repeatable (executed frequently with similar patterns)
+- Mechanical (follow clear rules, not creative judgment)
+- Consistent (should produce the same output structure every time)
+
+For each recommended skill, provide:
+
+**Skill Name**
+- A short, action-oriented name (2-4 words, lowercase with hyphens)
+
+**Purpose**
+- What this skill does in 1-2 sentences
+- When to invoke it (trigger scenarios)
+
+**Inputs**
+- What information the skill needs to run
+- Format requirements
+
+**Outputs**
+- What the skill produces
+- Structure and format
+
+**Workflow Steps**
+- The specific steps the skill executes (derived from the workflow analysis)
+
+**Replaces Steps**
+- Which step numbers from the Baseline Workflow Prompt this skill will replace (e.g., "Steps 3-5")
+- Brief note on how the prompt invocation changes (e.g., "Replace steps 3-5 with: /validate-prospect-fit")
+
+**Integration Points**
+- External tools, databases, or APIs the skill connects to
+- MCP servers it would use (if any)
+
+**Priority**
+- High / Medium / Low based on frequency of use and automation value
+
+**Quick Start Prompt**
+- A one-sentence prompt the user could paste to invoke this skill
+
+Present skills in priority order (highest value first). If no steps qualify as good skill candidates, explain why and note that the workflow may be better served by a single prompt or agent rather than reusable skills.
+
+**File naming:** Name the file `[workflow-name]-skill-recs.md` using the same workflow name (e.g., `lead-qualification-skill-recs.md`).
+
+Generate the recommendations as a downloadable Markdown file. If your platform doesn't support file downloads, format it inside a single Markdown code block so I can copy and save it manually.
+
+---
+
+After presenting both files, summarize what I now have:
+
+> **Workflow deconstruction complete.** You now have four files:
+>
+> 1. `[workflow-name]-blueprint.md` — your Workflow Blueprint (from Step 1)
+> 2. `[workflow-name]-analysis.md` — your Workflow Analysis Document (from Step 2)
+> 3. `[workflow-name]-prompt.md` — your Baseline Workflow Prompt (ready to use)
+> 4. `[workflow-name]-skill-recs.md` — your Skill Build Recommendations (what to build next)
+>
+> Start by running the baseline prompt on a real scenario. Then build skills in priority order from the recommendations.
+
+---
+
+## General Instructions
+
+- If I mention I'm using Claude, note where Claude Code Skills are the appropriate implementation. On other platforms, map to custom instructions, GPTs, or Gems.
+- Use plain language. Avoid jargon unless the student introduced it.
+- If anything is ambiguous in the Analysis Document, ask me before generating.
+```
+
+## What This Prompt Produces
+
+### Baseline Workflow Prompt (Deliverable 2)
+
+A ready-to-paste prompt that works on any AI platform. Every step is spelled out in full — no skills or shortcuts required. This is your starting point. As you build skills from the recommendations, you'll update this prompt to call those skills instead of repeating the logic inline.
+
+### Skill Build Recommendations (Deliverable 3)
+
+Actionable specs for each recommended skill, including:
+
+- **Name and purpose** — what the skill does and when to use it
+- **Inputs and outputs** — what goes in, what comes out
+- **Which steps it replaces** — exactly which parts of the baseline prompt each skill absorbs
+- **Integration points** — external tools and connectors needed
+- **Priority** — what to build first based on frequency and automation value
+- **Quick start prompt** — a one-liner to invoke the skill
+
+## What's Next
+
+You now have four Markdown files from the full workflow deconstruction:
+
+| File | What it is | What to do with it |
+|------|-----------|-------------------|
+| `[name]-blueprint.md` | Workflow Blueprint (Step 1) | Reference — the raw decomposition you can revisit |
+| `[name]-analysis.md` | Workflow Analysis Document (Step 2) | Reference — the full analysis with building block mapping |
+| `[name]-prompt.md` | Baseline Workflow Prompt (Step 3) | **Use this** — paste it into a new conversation to run the workflow |
+| `[name]-skill-recs.md` | Skill Build Recommendations (Step 3) | **Build from this** — your roadmap for reusable skills |
+
+Start by running the baseline prompt on a real scenario. See what works, refine what doesn't, then build skills in priority order. Each skill you build makes the baseline prompt shorter and more reliable.
+
+Keep all four files together — in a folder, a repo, or wherever you store your workflow documentation. You can share any of these with your instructor or team for feedback.
+
+For more on building skills and agents, see [Agents & Tools Overview](../../fundamentals/agents-and-tools/README.md).

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -141,11 +141,62 @@ Document, name, register, and sync AI operational workflows and skills.
 
 ---
 
+## :material-sitemap: Workflow Deconstruction
+
+Deconstruct business workflows into AI building blocks. Includes an orchestrator agent and a three-skill chain that walks you through discovery, analysis, and output generation — producing a Workflow Blueprint, Analysis Document, Baseline Prompt, and Skill Recommendations.
+
+```bash
+/plugin install workflow-deconstruction@handsonai
+```
+
+???+ agents "Agents included"
+
+    | Agent | What it does |
+    |-------|-------------|
+    | [`workflow-deconstructor`](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/workflow-deconstruction/agents/workflow-deconstructor.md) | Orchestrates the full three-step workflow deconstruction process. Runs discovery, analysis, and output generation sequentially with file-based handoffs between stages. |
+
+???+ skills "Skills included"
+
+    | Skill | What it does |
+    |-------|-------------|
+    | [`workflow-discovery`](https://github.com/jamesgray-ai/handsonai/tree/main/plugins/workflow-deconstruction/skills/workflow-discovery/) | Interactively discovers and decomposes a business workflow into a structured Workflow Blueprint using the 4-question framework + failure modes. |
+    | [`workflow-analysis`](https://github.com/jamesgray-ai/handsonai/tree/main/plugins/workflow-deconstruction/skills/workflow-analysis/) | Classifies workflow steps on the autonomy spectrum, maps them to AI building blocks, and produces a Workflow Analysis Document. |
+    | [`workflow-output-generation`](https://github.com/jamesgray-ai/handsonai/tree/main/plugins/workflow-deconstruction/skills/workflow-output-generation/) | Generates a ready-to-use Baseline Workflow Prompt and Skill Build Recommendations from a Workflow Analysis Document. |
+
+???+ usage "Example usage"
+
+    ```
+    "I want to deconstruct my client onboarding workflow"
+    → workflow-deconstructor walks you through the full process
+
+    "Help me figure out which parts of my reporting process could be automated with AI"
+    → workflow-deconstructor decomposes the process and maps AI building blocks
+
+    "People keep dropping off during enrollment. Help me build a workflow for that."
+    → workflow-deconstructor designs a workflow from the problem and produces deliverables
+    ```
+
+    You can also invoke skills individually if you prefer to work step-by-step across separate conversations:
+
+    ```
+    "Use workflow-discovery to break down my expense reporting process"
+    → Produces outputs/expense-reporting-blueprint.md
+
+    "Use workflow-analysis on my blueprint"
+    → Reads the blueprint, produces outputs/expense-reporting-analysis.md
+
+    "Use workflow-output-generation on my analysis"
+    → Produces the baseline prompt and skill recommendations
+    ```
+
+---
+
 ## Quick Reference
 
 | Plugin | Agents | Skills | Install command |
 |--------|--------|--------|----------------|
 | `course-examples` | 7 | 2 | `/plugin install course-examples@handsonai` |
 | `ai-registry` | 0 | 5 | `/plugin install ai-registry@handsonai` |
+| `workflow-deconstruction` | 1 | 3 | `/plugin install workflow-deconstruction@handsonai` |
 
 All plugins are maintained in the [handsonai GitHub repository](https://github.com/jamesgray-ai/handsonai).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,7 +138,11 @@ nav:
     - Prompting:
       - how-to/prompting/README.md
       - Find AI Workflow Opportunities: how-to/prompting/ai-workflow-opportunity-finder.md
-      - Deconstruct Workflows into AI Building Blocks: how-to/prompting/workflow-deconstruction-meta-prompt.md
+      - Deconstruct Workflows:
+        - Overview: how-to/prompting/workflow-deconstruction-meta-prompt.md
+        - "Step 1 — Discovery & Deep Dive": how-to/prompting/workflow-deconstruction-discovery.md
+        - "Step 2 — Analysis & Mapping": how-to/prompting/workflow-deconstruction-analysis.md
+        - "Step 3 — Output Generation": how-to/prompting/workflow-deconstruction-outputs.md
       - Write Custom Workspace Instructions: how-to/prompting/workspace-instructions-meta-prompt.md
     - Workflows:
       - Overview: how-to/workflow-examples/README.md

--- a/plugins/workflow-deconstruction/.claude-plugin/plugin.json
+++ b/plugins/workflow-deconstruction/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "workflow-deconstruction",
+  "description": "Deconstruct business workflows into AI building blocks. Includes three skills (discovery, analysis, output generation) and an orchestrator agent that runs the full process with file-based handoffs.",
+  "version": "1.0.0",
+  "author": {
+    "name": "James Gray"
+  },
+  "homepage": "https://handsonai.info/plugins/",
+  "license": "MIT",
+  "keywords": ["workflow", "deconstruction", "building-blocks", "prompt-engineering", "analysis", "automation", "skills", "agents"]
+}

--- a/plugins/workflow-deconstruction/agents/workflow-deconstructor.md
+++ b/plugins/workflow-deconstruction/agents/workflow-deconstructor.md
@@ -1,0 +1,69 @@
+---
+name: workflow-deconstructor
+description: "Use this agent when the user wants to deconstruct a business workflow into AI building blocks. This agent orchestrates the full three-step workflow deconstruction process: discovery, analysis, and output generation. It runs interactively — the user describes their workflow, the agent decomposes it, maps AI building blocks, and produces a baseline prompt plus skill recommendations.\n\nExamples:\n\n<example>\nContext: User wants to break down a business process for AI automation\nuser: \"I want to deconstruct my client onboarding workflow\"\nassistant: \"I'll use the workflow deconstructor agent to walk you through the full deconstruction — from discovery through to your executable prompt and skill recommendations.\"\n<Task tool call to workflow-deconstructor agent>\n</example>\n\n<example>\nContext: User has a problem they want to turn into a workflow\nuser: \"People keep dropping off during our course enrollment. Help me build a workflow for that.\"\nassistant: \"Let me launch the workflow deconstructor agent to help you design and analyze a workflow for enrollment drop-off recovery.\"\n<Task tool call to workflow-deconstructor agent>\n</example>\n\n<example>\nContext: User wants to map a process to AI building blocks\nuser: \"Can you help me figure out which parts of my weekly reporting process could be automated with AI?\"\nassistant: \"I'll use the workflow deconstructor agent to systematically break down your reporting process and map each step to AI building blocks.\"\n<Task tool call to workflow-deconstructor agent>\n</example>"
+model: sonnet
+color: purple
+---
+
+You are an expert Workflow Deconstruction Orchestrator. Your job is to guide the user through the complete three-step workflow deconstruction process, producing structured deliverables at each stage.
+
+## Your Process
+
+You run three skills sequentially, using files as handoffs between stages:
+
+### Step 1 — Discovery & Deep Dive
+**Skill:** `workflow-discovery`
+
+Interactively discover the user's workflow and decompose every step. This is the longest phase — you'll ask about the business scenario, help refine steps, then systematically probe each step using the 4-question framework + failure modes.
+
+**Produces:** `outputs/[name]-blueprint.md`
+
+After the Blueprint is complete, tell the user you're moving to Step 2 and proceed automatically.
+
+### Step 2 — Analysis & Mapping
+**Skill:** `workflow-analysis`
+
+Read the Blueprint file, classify each step on the autonomy spectrum, map to AI building blocks, and produce the Workflow Analysis Document.
+
+**Reads:** `outputs/[name]-blueprint.md`
+**Produces:** `outputs/[name]-analysis.md`
+
+Present the mapping table to the user for review. After confirmation, generate the Analysis Document and proceed to Step 3.
+
+### Step 3 — Output Generation
+**Skill:** `workflow-output-generation`
+
+Read the Analysis Document and generate the Baseline Workflow Prompt and Skill Build Recommendations.
+
+**Reads:** `outputs/[name]-analysis.md`
+**Produces:** `outputs/[name]-prompt.md` + `outputs/[name]-skill-recs.md`
+
+## File Conventions
+
+- All output files go in `outputs/` relative to the current working directory
+- Create the `outputs/` directory if it doesn't exist
+- Use kebab-case workflow names for file names (e.g., `lead-qualification`)
+- The workflow name is determined during Step 1 discovery
+
+## Important Guidelines
+
+- This is an interactive process — the user is your primary source of information
+- Ask one question at a time during discovery and deep dive phases
+- Use the "propose and react" pattern from Step 4 onward in the deep dive (propose a hypothesis across all dimensions, ask what's right/wrong/missing)
+- Probe for missing steps — most people undercount by 30-50%
+- Surface hidden assumptions
+- Use plain language; avoid jargon unless the user introduced it
+- If you hit context limits mid-conversation, tell the user they can invoke the remaining skills individually in new conversations — the file-based handoffs still work
+
+## Completion
+
+After all three steps, present a summary:
+
+> **Workflow deconstruction complete.** Here are your deliverables:
+>
+> 1. **Workflow Blueprint** — `outputs/[name]-blueprint.md`
+> 2. **Workflow Analysis Document** — `outputs/[name]-analysis.md`
+> 3. **Baseline Workflow Prompt** — `outputs/[name]-prompt.md`
+> 4. **Skill Build Recommendations** — `outputs/[name]-skill-recs.md`
+>
+> Start by running the baseline prompt on a real scenario. Then build skills in priority order from the recommendations.

--- a/plugins/workflow-deconstruction/skills/workflow-analysis/SKILL.md
+++ b/plugins/workflow-deconstruction/skills/workflow-analysis/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: workflow-analysis
+description: >
+  Classify workflow steps on the autonomy spectrum, map them to AI building blocks, and produce
+  a Workflow Analysis Document. Use when the user has a Workflow Blueprint and wants to analyze
+  it for AI operationalization. This is Step 2 of 3 in the workflow deconstruction series.
+---
+
+# Workflow Analysis
+
+Take a Workflow Blueprint, classify each step on the autonomy spectrum, map to AI building blocks, and produce a complete Workflow Analysis Document.
+
+## Workflow
+
+1. **Load Blueprint** — Read the Blueprint file from `outputs/[workflow-name]-blueprint.md`. If the user specifies a file path, use that. Otherwise, look for the most recent Blueprint in `outputs/`.
+2. **Confirm understanding** — Summarize the workflow name, step count, and outcome. Ask the user to confirm before proceeding.
+3. **Classify each step** — For every refined step, determine:
+   - **Autonomy level**: Human / AI-Deterministic / AI-Semi-Autonomous / AI-Autonomous
+   - **AI building block(s)**: Prompt, Context, Skill, Agent, MCP, Project
+   - **Tools and connectors**: External tools, APIs, integrations needed
+   - **Human-in-the-loop gates**: Where human review is recommended
+4. **Present mapping** — Show the classification as a clear table. Walk through reasoning for non-obvious classifications. Ask the user if they want to adjust anything.
+5. **Generate Analysis Document** — After confirmation, produce the complete Workflow Analysis Document and write it to the output file.
+
+## Output
+
+Write the Workflow Analysis Document to `outputs/[workflow-name]-analysis.md` using the same workflow name from the Blueprint.
+
+The Analysis Document must include:
+
+### Scenario Summary
+- Workflow name, description, outcome, trigger, type, business objective, current owner(s)
+
+### Step-by-Step Decomposition Table
+
+| # | Step | Action | Type | Decision Points | Failure Mode | Data In | Data Out | Context Needed | AI Building Block(s) |
+|---|------|--------|------|----------------|-------------|---------|----------|----------------|---------------------|
+
+### Autonomy Spectrum Summary
+- Human steps, deterministic AI steps, semi-autonomous AI steps (with review gates), fully autonomous AI steps
+
+### Step Sequence and Dependencies
+- Sequential steps, parallel steps, critical path, dependency map
+
+### Prerequisites
+- What must be in place before the workflow can run
+- External dependencies (accounts, access, data sources)
+
+### Context Inventory
+
+| Artifact | Description | Used By Steps | Status | Format | Key Contents |
+|----------|-------------|---------------|--------|--------|--------------|
+
+### Tools and Connectors Required
+
+### Recommended Implementation Order
+1. **Quick wins** — Deterministic steps automatable with Prompt or Context alone
+2. **High-value semi-autonomous steps** — AI does most work, human review gate
+3. **Complex agent steps** — Fully autonomous, requiring Agents/MCP/multi-tool orchestration
+
+## Guidelines
+
+- If the Blueprint is missing information needed for classification, ask the user to clarify
+- If the user mentions they're using Claude, note where Skills are the appropriate building block
+- Explain reasoning for non-obvious classifications
+- After writing the Analysis Document, tell the user: "Analysis saved to `outputs/[name]-analysis.md`. Ready for Step 3 — Output Generation."

--- a/plugins/workflow-deconstruction/skills/workflow-discovery/SKILL.md
+++ b/plugins/workflow-deconstruction/skills/workflow-discovery/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: workflow-discovery
+description: >
+  Interactively discover and decompose a business workflow into a structured Workflow Blueprint.
+  Use when the user wants to deconstruct a workflow, break down a business process, or start
+  the workflow deconstruction process. This is Step 1 of 3 in the workflow deconstruction series.
+---
+
+# Workflow Discovery
+
+Interactively discover a business workflow and decompose every step into a structured Workflow Blueprint using the 4-question framework + failure modes.
+
+## Workflow
+
+1. **Scenario discovery** — Ask about the business scenario, objective, high-level steps, and ownership. One question at a time. If the user describes a problem instead of a workflow, propose a candidate workflow for them to react to.
+2. **Scope check** — Assess whether this is one workflow or multiple bundled together. If multiple, recommend splitting and ask which to start with.
+3. **Name the workflow** — Present 2-3 name options following naming conventions (2-4 word noun phrase, Title Case). Confirm name, description, outcome, trigger, and type.
+4. **Deep dive** — Work through each step using the 4-question framework + failure modes:
+   - Discrete steps (is this actually multiple steps?)
+   - Decision points (if/then branches, quality gates)
+   - Data flows (inputs, outputs, sources, destinations)
+   - Context needs (specific documents, files, reference materials)
+   - Failure modes (what happens when this step fails)
+5. **Propose and react** — For steps 4+, propose a hypothesis across all 5 dimensions and ask "What's right, what's wrong, what am I missing?" instead of asking each question individually.
+6. **Map sequence** — After all steps, identify sequential vs. parallel steps and the critical path.
+7. **Consolidate context** — Present a rolled-up "context shopping list" of every artifact the workflow needs.
+8. **Generate Blueprint** — Produce the structured Workflow Blueprint and write it to the output file.
+
+## Output
+
+Write the Workflow Blueprint to `outputs/[workflow-name]-blueprint.md` where `[workflow-name]` is the kebab-case workflow name (e.g., `lead-qualification`).
+
+The Blueprint must include:
+
+### Scenario Metadata
+- Workflow name, description, outcome, trigger, type, business objective, current owner(s)
+
+### Refined Steps
+For each step: number, name, action, sub-steps, decision points, data in/out, context needs, failure modes
+
+### Step Sequence and Dependencies
+- Sequential steps, parallel steps, critical path, dependency map
+
+### Context Shopping List
+For each artifact: name, description, used by steps, status (Exists/Needs Creation), key contents
+
+## Guidelines
+
+- Ask one question at a time — never present a wall of questions
+- Probe for missing steps — most people undercount by 30-50%
+- Surface hidden assumptions ("How do you decide when X is good enough?")
+- Use plain language; avoid jargon unless the user introduced it
+- Push beyond vague context answers like "domain knowledge" — identify the specific artifact
+- After writing the Blueprint file, tell the user: "Blueprint saved to `outputs/[name]-blueprint.md`. Ready for Step 2 — Analysis & Mapping."

--- a/plugins/workflow-deconstruction/skills/workflow-output-generation/SKILL.md
+++ b/plugins/workflow-deconstruction/skills/workflow-output-generation/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: workflow-output-generation
+description: >
+  Generate a Baseline Workflow Prompt and Skill Build Recommendations from a Workflow Analysis
+  Document. Use when the user has a completed Analysis Document and wants the final deliverables.
+  This is Step 3 of 3 in the workflow deconstruction series.
+---
+
+# Workflow Output Generation
+
+Take a Workflow Analysis Document and produce two deliverables: a Baseline Workflow Prompt and Skill Build Recommendations.
+
+## Workflow
+
+1. **Load Analysis Document** — Read the Analysis Document from `outputs/[workflow-name]-analysis.md`. If the user specifies a file path, use that. Otherwise, look for the most recent Analysis Document in `outputs/`.
+2. **Confirm understanding** — Summarize the workflow name, step count, how many are AI-eligible, and the recommended implementation order. Ask the user to confirm before proceeding.
+3. **Clarify if needed** — If anything in the Analysis Document is ambiguous, ask before generating. Maximum 1-2 clarifying questions.
+4. **Generate Baseline Workflow Prompt** — Produce a ready-to-use prompt and write it to the output file.
+5. **Generate Skill Build Recommendations** — Produce skill specs and write them to the output file.
+
+## Outputs
+
+Write two files:
+
+### `outputs/[workflow-name]-prompt.md` — Baseline Workflow Prompt
+
+Structure:
+- **Title and Purpose** — Workflow name, description, outcome, when to use
+- **Instructions** — Numbered steps, each labeled (AI) or (Human). AI steps get direct commands. Human steps describe what the human does and hands back. Include branching logic.
+- **Input Requirements** — What the user provides when running the prompt, with format specs
+- **Context Requirements** — Reference materials, files, or data to attach
+- **Output Format** — What the prompt produces, with structure specs
+
+The prompt must be: self-contained, specific, version-control ready, team-adoption ready.
+
+### `outputs/[workflow-name]-skill-recs.md` — Skill Build Recommendations
+
+For each recommended skill:
+- **Skill Name** — 2-4 words, lowercase with hyphens
+- **Purpose** — What it does, when to invoke it
+- **Inputs** — What it needs, format requirements
+- **Outputs** — What it produces, structure and format
+- **Workflow Steps** — Specific steps it executes
+- **Replaces Steps** — Which baseline prompt step numbers it replaces, how the invocation changes
+- **Integration Points** — External tools, APIs, MCP servers
+- **Priority** — High / Medium / Low
+- **Quick Start Prompt** — One-sentence invocation
+
+Present skills in priority order. If no steps qualify as good skill candidates, explain why.
+
+## Guidelines
+
+- If the user mentions Claude, note where Claude Code Skills are the appropriate implementation
+- Use plain language; avoid jargon unless the user introduced it
+- After writing both files, tell the user: "Outputs saved to `outputs/[name]-prompt.md` and `outputs/[name]-skill-recs.md`. Your workflow deconstruction is complete."
+- Summarize the three files produced across all three steps so the user has a clear inventory of their deliverables


### PR DESCRIPTION
## Summary

- Split the monolithic workflow deconstruction meta-prompt into three focused prompts that each produce a downloadable Markdown file, solving token-limit issues on free-tier models
- Added a Claude Code plugin (`workflow-deconstruction`) with three skills and an orchestrator agent for file-based automation
- Refactored the existing overview page as a hub with the original prompt preserved in a collapsible block

## What changed

### Track 1 — Platform-agnostic prompts (all students)
- **Step 1: Discovery & Deep Dive** — Scenario discovery + deep dive with "propose and react" pattern. Produces `[name]-blueprint.md`
- **Step 2: Analysis & Mapping** — AI building block classification and autonomy mapping. Produces `[name]-analysis.md`
- **Step 3: Output Generation** — Baseline workflow prompt + skill build recommendations. Produces `[name]-prompt.md` and `[name]-skill-recs.md`
- **Overview page** — Refactored into hub with three-prompt approach explanation, file naming convention, and original monolithic prompt in collapsible admonition
- **mkdocs.yml** — Nested nav section: Deconstruct Workflows > Overview + Steps 1/2/3

### Track 2 — Claude Code skills + agent
- Three skills in `.claude/skills/`: `workflow-discovery`, `workflow-analysis`, `workflow-output-generation`
- Orchestrator agent: `.claude/agents/workflow-deconstructor.md`
- Plugin bundle: `plugins/workflow-deconstruction/` with plugin.json
- Marketplace manifest updated, plugin docs page updated with agent/skill tables

## Test plan

- [ ] Run `mkdocs serve` and verify all four pages render correctly with working navigation
- [ ] Verify all cross-page links resolve (overview ↔ steps, step ↔ step)
- [ ] Copy Step 1 prompt into ChatGPT/Claude and verify it produces a well-structured Blueprint as a downloadable file
- [ ] Paste Blueprint into Step 2 prompt in a new conversation — verify it classifies and produces Analysis Document
- [ ] Paste Analysis Document into Step 3 prompt — verify it generates both deliverables
- [ ] Verify collapsible original prompt on overview page expands correctly
- [ ] Verify plugin docs page renders the new workflow-deconstruction section

🤖 Generated with [Claude Code](https://claude.com/claude-code)