### PR TITLE
Add plugin detail pages with full component documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,8 +56,9 @@ The `.claude/` directory is the **development/local** copy (used for repo-local 
 2. Copy into `plugins/<plugin-name>/agents/` (or `skills/`)
 3. Bump `version` in `plugins/<plugin-name>/.claude-plugin/plugin.json` (MINOR for new, PATCH for update)
 4. Bump `version` for that plugin in `.claude-plugin/marketplace.json`
-5. Update the plugin's section on `docs/plugins/index.md` — add the agent/skill to the table with a GitHub link (see linking convention below)
-6. Commit and push
+5. Update the plugin's section on `docs/plugins/index.md` — add the agent/skill to the table with a link to the detail page anchor
+6. Update the plugin's detail page (`docs/plugins/<plugin-name>.md`) — add the agent/skill section following the existing component format
+7. Commit and push
 
 ### Creating a new plugin
 
@@ -75,17 +76,19 @@ The `.claude/` directory is the **development/local** copy (used for repo-local 
    ```
 3. Write `plugin.json` with name, description, version, author, keywords
 4. Add a new entry to `.claude-plugin/marketplace.json`
-5. Add a grid card + collapsible detail section to `docs/plugins/index.md` — include GitHub links for every agent and skill (see linking convention below)
-6. Commit and push
+5. Add a grid card + collapsible detail section to `docs/plugins/index.md` — include links to the detail page anchors for every agent and skill
+6. Create a detail page at `docs/plugins/<plugin-name>.md` following the template used by existing detail pages (see `docs/plugins/course-examples.md` for reference)
+7. Add the detail page to the `nav:` section in `mkdocs.yml` under Plugins
+8. Commit and push
 
 ### Catalog page linking convention
 
-Every agent and skill name in the `docs/plugins/index.md` tables **must** link to its source on GitHub so students can read the full details:
+Every agent and skill name in the `docs/plugins/index.md` tables **must** link to the corresponding section on the plugin's detail page:
 
-- **Agents** → link to the `.md` file: `[`agent-name`](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/<plugin>/agents/<agent>.md)`
-- **Skills** → link to the skill directory: `[`skill-name`](https://github.com/jamesgray-ai/handsonai/tree/main/plugins/<plugin>/skills/<skill>/)`
+- **Agents** → link to the detail page anchor: `[`agent-name`](<plugin-name>.md#<agent-name>)`
+- **Skills** → link to the detail page anchor: `[`skill-name`](<plugin-name>.md#<skill-name>)`
 
-This applies every time an agent or skill is added to the marketplace.
+This directs users to human-readable documentation instead of raw source code. Every time an agent or skill is added to the marketplace, add both the catalog table entry and the detail page section.
 
 ### Versioning convention
 

--- a/docs/plugins/ai-registry.md
+++ b/docs/plugins/ai-registry.md
@@ -1,0 +1,247 @@
+---
+title: AI Registry
+description: Document, name, register, and sync AI operational workflows and skills in Notion
+---
+
+# AI Registry
+
+Skills for building a structured registry of your AI workflows and skills. This plugin gives Claude the conventions for naming workflows, writing documentation (SOPs and process guides), registering skills in Notion, and syncing everything to GitHub. Use it to build an organized, searchable inventory of your AI operations.
+
+!!! note "Prerequisites"
+    This plugin requires a **Notion account** and the **Notion MCP connector**. Without it, Claude can follow the naming and documentation conventions but cannot save entries to Notion. See [Notion Registry Setup](../fundamentals/developer-setup/notion-registry-setup.md) for configuration instructions.
+
+## Install
+
+```bash
+/plugin install ai-registry@handsonai
+```
+
+## Components
+
+### Skills
+
+---
+
+#### `naming-workflows`
+
+**What it does:** Generates consistent, outcome-focused names and descriptions for business workflows, then creates entries in your Notion Workflows database. Follows domain-specific naming patterns so your registry stays organized as it grows.
+
+**When to use it:** Use this when you have a new workflow to document, need to standardize existing workflow names, or want to add a workflow entry to Notion. Also useful when you're not sure what to call a workflow.
+
+**How it works:**
+
+1. You describe the workflow (what it does, what domain it's in)
+2. Claude identifies the domain (Sales, Marketing, Product, Education, Operations, etc.)
+3. Claude generates 2-3 name options following the naming pattern for that domain
+4. Claude writes a 1-2 sentence description (action + outcome) and suggests a process outcome (the concrete deliverable)
+5. Claude searches your Notion Business Processes database to suggest where the workflow fits
+6. After you confirm, Claude creates the entry in Notion with all properties filled in
+
+**Naming conventions:**
+
+| Domain | Pattern | Examples |
+|--------|---------|----------|
+| Sales | [Prospect Type] [Action] | Student Enrollment, Lead Qualification |
+| Marketing | [Content Type] [Action/Purpose] | Newsletter Distribution, Content Repurposing |
+| Product | [Deliverable] [Action] | Lesson Content Creation, Exercise Development |
+| Education | [Student/Cohort] [Activity] | Student Onboarding, Live Session Delivery |
+| Operations | [Function] [Process] | Email Response Drafting, Calendar Management |
+
+Names are always 2-4 words, noun phrases (not verb phrases), in Title Case.
+
+**Example prompts:**
+
+    "Name a workflow for drafting email responses"
+    → Suggests options like "Email Response Drafting" with description
+      and process outcome, then creates the Notion entry
+
+    "I need to name a workflow for turning lesson recordings into
+    social media content"
+    → Suggests "Content Repurposing" (Marketing pattern), writes the
+      description, and creates the entry
+
+**What you'll get:** A named workflow entry in your Notion Workflows database with: name, description, process outcome, business process link, sequence number, status, type, and trigger.
+
+**Platform compatibility:** Claude Code &#10003; | Claude.ai &#10003; (Notion MCP required)
+
+---
+
+#### `writing-workflow-sops`
+
+**What it does:** Writes Standard Operating Procedure documentation for workflows and saves it directly to the Notion workflow page body. Adapts the SOP template based on whether the workflow is Manual, Augmented, or Automated.
+
+**When to use it:** Use this when you have a workflow entry in Notion and need to document how it's actually executed — step-by-step procedures, prerequisites, quality checks, and troubleshooting guidance.
+
+**How it works:**
+
+1. Claude fetches the workflow from Notion to get context (name, description, type, trigger, apps, assets used)
+2. Claude asks clarifying questions about the procedure details
+3. Claude writes the SOP using a template adapted for the workflow type:
+    - **Manual**: Detailed human steps with time estimates and exact UI paths
+    - **Augmented**: Steps marked as (AI) or (Human) with clear handoff points
+    - **Automated**: Focus on monitoring, intervention points, and error handling
+4. After your review and approval, Claude updates the workflow page body in Notion
+
+**SOP sections:**
+
+| Section | Purpose |
+|---------|---------|
+| Overview | 1-2 sentence summary |
+| Prerequisites | Access, data, and tools needed |
+| Trigger | When and how the workflow starts |
+| Procedure | Step-by-step instructions (action verbs, one action per step) |
+| Outputs | Deliverables with destinations |
+| Quality Checks | How to verify success |
+| Troubleshooting | Common problems and fixes |
+| Automation Notes | For Augmented/Automated types only |
+
+**Example prompts:**
+
+    "Write an SOP for the Email Response Drafting workflow"
+    → Fetches the workflow from Notion, asks about procedure details,
+      produces a complete SOP, and saves it to the workflow page
+
+    "Document how the Student Onboarding workflow works"
+    → Walks through the SOP writing process, produces Manual-type
+      documentation with detailed steps and time estimates
+
+**What you'll get:** A complete SOP saved directly to your Notion workflow page body, with all sections filled in and adapted for the workflow type.
+
+**Platform compatibility:** Claude Code &#10003; | Claude.ai &#10003; (Notion MCP required)
+
+---
+
+#### `writing-process-guides`
+
+**What it does:** Writes Business Process Guide documentation that explains the strategic context and rhythm of a complete business process — when to execute it, why it matters, and how its component workflows fit together. This is the strategic companion to the tactical SOPs.
+
+**When to use it:** Use this when you need to document how multiple workflows connect into a larger business process. Process guides answer "when, why, and what order" while SOPs answer "how."
+
+**How it works:**
+
+1. Claude fetches the business process from Notion to get context and linked workflows
+2. Claude fetches each linked workflow for sequence and trigger details
+3. Claude asks clarifying questions about timing and decision points
+4. Claude writes the Process Guide using a structured template
+5. After your review, Claude updates the business process page body in Notion
+
+**Process Guide sections:**
+
+| Section | Purpose |
+|---------|---------|
+| Purpose | Why this process exists and its business impact |
+| When to Execute | Triggers, frequency, timing |
+| Process Overview | Visual flow of workflows in sequence |
+| Workflow Sequence | Each workflow with trigger, duration, and output |
+| Decision Points | Key choices during the process |
+| Success Criteria | How to know the process worked |
+| Common Pitfalls | What typically goes wrong |
+
+**Example prompts:**
+
+    "Write a process guide for the Email Management business process"
+    → Fetches the process and its workflows from Notion, documents
+      the end-to-end flow, decision points, and success criteria
+
+    "How do the Student Enrollment and Student Onboarding workflows
+    connect? Document the full process."
+    → Creates a process guide showing the workflow sequence,
+      handoffs, and timing
+
+**What you'll get:** A complete Business Process Guide saved to your Notion business process page body. Scannable in 2 minutes, focused on the strategic "when/why/what order" rather than tactical how-to details.
+
+**Platform compatibility:** Claude Code &#10003; | Claude.ai &#10003; (Notion MCP required)
+
+---
+
+#### `registering-skills`
+
+**What it does:** Registers or updates Claude Skills in your Notion AI Assets database. Extracts metadata from the skill's SKILL.md file, generates a Quick Start Prompt, checks for duplicates, and creates or updates the registry entry.
+
+**When to use it:** Use this immediately after creating, packaging, or updating any Claude Skill to keep your AI Assets database current. Also useful for batch-registering multiple skills at once.
+
+**How it works:**
+
+1. Claude reads the SKILL.md frontmatter to extract the skill name and description
+2. Claude generates a Quick Start Prompt — a single, copy-paste-ready sentence that demonstrates the skill's primary use case
+3. Claude searches your Notion AI Assets database for an existing entry with the exact same name (to prevent duplicates)
+4. If found: updates the existing entry with the latest description and Quick Start Prompt
+5. If not found: creates a new entry with name, description, asset type (Skill), platform (Claude), and Quick Start Prompt
+
+For batch registration, Claude searches for each skill individually first, builds separate update and create lists, then processes them.
+
+**Example prompts:**
+
+    "Register the email-response-drafting skill in Notion"
+    → Reads the SKILL.md, generates a Quick Start Prompt, checks for
+      duplicates, and creates or updates the AI Assets entry
+
+    "Register all skills in the ~/.claude/skills/ directory"
+    → Batch processes every skill, reporting X created and Y updated
+
+**What you'll get:** An entry (or updated entry) in your Notion AI Assets database with: name, description, asset type, platform, Quick Start Prompt, and GitHub URL (if applicable).
+
+**Platform compatibility:** Claude Code &#10003; | Claude.ai &#10003; (Notion MCP required)
+
+---
+
+#### `syncing-skills-to-github`
+
+**What it does:** Syncs Claude Skills from your local `~/.claude/skills/` directory to a GitHub repository. Detects changes, generates semantic commit messages, pushes to remote, and updates Notion AI Assets with GitHub URLs.
+
+**When to use it:** Use this after creating or updating skills locally, after exporting skills from cloud to local, or as part of a weekly batch sync. This is Part 2 of the export-to-sync workflow (Part 1 is exporting skills from the cloud to your local machine).
+
+**How it works:**
+
+1. **Detect** changes in `~/.claude/skills/` using git status
+2. **Review** what changed — new files, modifications, deletions
+3. **Identify** which skill directories are affected
+4. **Generate** semantic commit messages with prefixes: `[CREATE]`, `[UPDATE]`, `[FIX]`, `[SYNC]`, `[RETIRE]`
+5. **Commit** changes to the local git repository
+6. **Push** to GitHub remote
+7. **Update** Notion AI Assets database with GitHub URLs and set status to "Deployed"
+8. **Regenerate** the README.md skill index
+
+**Three usage modes:**
+
+- **Single skill sync** — "Sync the writing-linkedin-posts skill to GitHub" — commits and pushes just that skill
+- **Batch sync** — "Sync all changed skills to GitHub" — detects all changes, commits everything, updates Notion for each
+- **Dry run** — "Show what would sync to GitHub" — previews changes and commit message without actually committing
+
+**Example prompts:**
+
+    "Sync all changed skills to GitHub"
+    → Detects 3 changes (1 new, 2 modified), generates a batch
+      commit message, pushes, updates Notion for all 3 skills,
+      and regenerates the README
+
+    "Show what would sync to GitHub"
+    → Previews the changes and generated commit message, asks for
+      confirmation before proceeding
+
+**What you'll get:** Skills committed and pushed to GitHub with descriptive commit messages, Notion AI Assets entries updated with GitHub URLs, and an auto-generated README index.
+
+**Platform compatibility:** Claude Code &#10003; (requires terminal access and git credentials)
+
+---
+
+## Recommended Workflow
+
+These skills work best in sequence, building from naming through to version control:
+
+1. **Name your workflow** — Use `naming-workflows` to create a consistent entry in Notion
+2. **Document the procedure** — Use `writing-workflow-sops` to write the SOP for the workflow
+3. **Connect workflows** — Use `writing-process-guides` to document how workflows fit together in a business process
+4. **Register your skills** — Use `registering-skills` to track Claude Skills in the AI Assets database
+5. **Version control everything** — Use `syncing-skills-to-github` to push skills to GitHub with Notion tracking
+
+## FAQ
+
+**Do I need all five skills?**
+No. Each skill works independently. Start with `naming-workflows` if you're building a registry from scratch, or `registering-skills` if you just want to track your existing Claude Skills.
+
+**What if I don't have Notion set up?**
+Claude will still follow the naming conventions, SOP templates, and documentation patterns — it just won't save to Notion. See [Notion Registry Setup](../fundamentals/developer-setup/notion-registry-setup.md) to configure the MCP connector.
+
+**What's the difference between a Process Guide and an SOP?**
+A Process Guide is strategic: when to execute, why it matters, what order the workflows go in. An SOP is tactical: step-by-step instructions for executing a single workflow. Think of the Process Guide as the playbook and SOPs as the play pages.

--- a/docs/plugins/course-examples.md
+++ b/docs/plugins/course-examples.md
@@ -1,0 +1,252 @@
+---
+title: Course Examples
+description: Working examples of Claude Code agents and skills from the Hands-on AI cohort courses
+---
+
+# Course Examples
+
+Working examples of agents and skills built during Hands-on AI cohort courses. This plugin demonstrates how to package domain expertise — writing standards, research processes, editorial criteria — into reusable components that Claude activates automatically. Install it to get a ready-made content creation and research toolkit, or study the components as blueprints for building your own.
+
+## Install
+
+```bash
+/plugin install course-examples@handsonai
+```
+
+## Components
+
+### Agents
+
+---
+
+#### `tech-executive-writer`
+
+**What it does:** Writes business-focused content about AI and technology, translating complex technical concepts for non-technical audiences. Combines deep technical understanding with executive-level communication skills.
+
+**When to use it:** Use this when you need to write LinkedIn posts, magazine articles, executive briefs, or thought leadership pieces about AI topics. Especially useful when you need to explain technical concepts (like RAG, fine-tuning, or agentic AI) to business leaders.
+
+**How it works:** Claude adopts the persona of a seasoned technology executive with 20+ years of experience and published articles in HBR and MIT Sloan Management Review. It first clarifies your audience, platform, length, and core message, then outlines an approach before drafting. Every piece is optimized for the target format — LinkedIn posts get strong hooks and hashtags, magazine articles get executive summaries and frameworks, executive briefs lead with recommendations.
+
+**Example prompts:**
+
+    "Write a LinkedIn post about how RAG is transforming enterprise search"
+    → Drafts a 1,200-1,500 character post with a strong opening hook,
+      plain-language explanation of RAG, business implications, and
+      engagement prompt
+
+    "Turn this technical documentation about our ML pipeline into an
+    article suitable for Harvard Business Review"
+    → Produces a 2,000-4,000 word article with executive summary,
+      concrete analogies, named case studies, and actionable takeaways
+
+    "Prepare talking points about generative AI's impact on enterprise
+    operations for a board presentation"
+    → Delivers a one-page brief with recommendations first, bullet-point
+      findings, and clear next steps
+
+**What you'll get:** Polished content tailored to your target platform and audience — ready to publish or use as a strong first draft. LinkedIn posts include hashtag suggestions. Articles include framework structures. Briefs lead with actionable recommendations.
+
+---
+
+#### `hbr-editor`
+
+**What it does:** Reviews business articles against Harvard Business Review editorial standards. Provides prescriptive feedback — not just what's wrong, but exactly how to fix it.
+
+**When to use it:** Use this when you have a draft article intended for a professional business audience and want publication-quality editorial feedback. Works for thought leadership pieces, feature articles, essays, and book chapters.
+
+**How it works:** Claude adopts the persona of a senior HBR editor with 20+ years of experience. It reads your complete draft, then evaluates it against HBR's specific standards: the "Big Idea" test (is the central argument clear and compelling?), audience alignment, structure and flow, evidence quality, and voice. The agent loads the `editing-hbr-articles` skill for detailed editorial criteria, then provides structured feedback with line-level edits.
+
+**Example prompts:**
+
+    "Review this article for HBR quality"
+    → Reads the full piece, provides an overall assessment, evaluates
+      the central argument, identifies structural issues, flags weak
+      evidence, and delivers line-level edits with before/after examples
+
+    "Does this section on stakeholder capitalism make a strong argument?"
+    → Evaluates argument strength, identifies gaps in evidence, suggests
+      specific improvements, and provides rewritten passages
+
+**What you'll get:** A structured editorial review with: overall assessment, Big Idea evaluation, structure and flow analysis, evidence gaps, voice and language feedback, line-level edits (original → suggested → rationale), and a prioritized list of the 3-5 most important revisions.
+
+---
+
+#### `hbr-publisher`
+
+**What it does:** Formats finalized articles for web publication and PDF distribution. Handles SEO metadata, social media snippets, and professional layout.
+
+**When to use it:** Use this after your article has been through writing and editing stages and is ready for publication. It's the final step in the content pipeline: write → edit → publish.
+
+**How it works:** Claude validates that the content is complete (title, author, abstract, body, citations), then produces two outputs. For web, it structures content with proper HTML-semantic headings, creates meta descriptions, suggests tags, adds pull quotes, and writes social media snippets for LinkedIn and X. For PDF, it creates a professionally formatted document with HBR-style headers, title page, typography hierarchy, page numbers, and proper citations.
+
+**Example prompts:**
+
+    "The article on leadership trends is edited and ready. Prepare it
+    for publication."
+    → Validates completeness, formats for web with SEO metadata and
+      social snippets, creates PDF-ready document with professional
+      layout
+
+    "Take this whitepaper and get it ready for our website and also
+    make a downloadable PDF"
+    → Produces web-ready Markdown with heading structure, meta
+      description, and tags, plus a PDF-formatted document
+
+**What you'll get:** Two deliverables: (1) web-ready Markdown with SEO metadata, structured headings, pull quotes, and social media snippets; (2) a PDF-ready document with professional formatting, title page, and citations.
+
+---
+
+#### `ai-news-researcher`
+
+**What it does:** Scans news outlets, blogs, YouTube channels, podcasts, and communities for the latest AI developments. Categorizes findings by significance and topic.
+
+**When to use it:** Use this when you want to stay current on AI industry news — product releases, research papers, company updates, regulatory changes, and notable community discussions. Works as a daily briefing or for targeted research on specific topics.
+
+**How it works:** Claude systematically searches across multiple source tiers: major tech news outlets (TechCrunch, The Verge, Wired), AI-specific publications (The Decoder, Import AI), official company blogs, social media, newsletters (The Batch, Ben's Bites, TLDR AI), community discussions (Hacker News, Reddit), product aggregators, podcasts (Latent Space, Practical AI), and YouTube channels. Each finding is categorized and rated by significance (Major, Notable, Minor).
+
+**Example prompts:**
+
+    "What's new in AI today?"
+    → Produces a categorized news summary covering product releases,
+      research papers, company updates, YouTube content, podcasts,
+      and community highlights
+
+    "Has Anthropic released anything new lately?"
+    → Focused research on Anthropic announcements, Claude updates,
+      API changes, and related coverage
+
+    "Find me some recent videos about Claude Code"
+    → Searches AI-focused YouTube channels for tutorials, reviews,
+      and demos
+
+**What you'll get:** A categorized news report saved as a Markdown file in `ai-news-reports/`. Sections include: Product Releases & Updates, Research & Papers, Company Updates (with Anthropic/Claude highlighted), YouTube Content, Podcasts, Community Highlights, and Key Takeaways.
+
+---
+
+#### `ai-productivity-researcher`
+
+**What it does:** Finds documented case studies of companies using AI for productivity gains. Prioritizes HBR-caliber sources with quantified outcomes — suitable for articles, presentations, and executive briefings.
+
+**When to use it:** Use this when you need credible, data-backed examples of enterprise AI adoption for business writing, presentations, or research. Especially useful when building the evidence base for thought leadership pieces.
+
+**How it works:** Claude conducts research across a tiered source hierarchy: Tier 1 (HBR, McKinsey, peer-reviewed journals, earnings calls), Tier 2 (WSJ, FT, TechCrunch, company newsrooms), and Tier 3 (conference presentations, verified LinkedIn posts). For each case study, it captures the company profile, specific AI implementation, quantified outcomes with timeframes, source attribution, and a credibility assessment.
+
+**Example prompts:**
+
+    "Find examples of companies using AI agents for customer support"
+    → Researches documented implementations with specific metrics,
+      company contexts, and credible source citations
+
+    "What are some documented productivity gains from companies
+    implementing AI tools?"
+    → Compiles quantified results across industries with source
+      validation and credibility ratings
+
+**What you'll get:** Structured case study briefs with: company profile, AI implementation details, measurable outcomes, full source citations, credibility assessment, and relevance tags. Output format adapts to your need — executive summary, case study brief, comparative analysis, data table, or annotated bibliography.
+
+---
+
+#### `claude-research-daily`
+
+**What it does:** Produces a daily brief on Anthropic, Claude, Claude Code, and Cowork. Covers official announcements, tech news, video content, tutorials, and community discussions from the last 24 hours.
+
+**When to use it:** Use this as a morning briefing to stay current on the Claude ecosystem. Also useful when you need to check if Anthropic has made any recent announcements or when looking for new Claude-related content.
+
+**How it works:** Claude searches official channels first (anthropic.com, GitHub releases), then news sites (TechCrunch, The Verge, Hacker News), community sources (Reddit, developer forums), video content (YouTube channels like AI Explained, Fireship, Matt Wolfe), and newsletters. It strictly filters for content from the last 24 hours — quiet days are reported as such rather than padded with older content.
+
+**Example prompts:**
+
+    "What's the latest news about Claude and Anthropic?"
+    → Produces a structured daily brief covering top headlines,
+      product updates, notable videos, tutorials, and community buzz
+
+    "Have there been any new Claude Code features released recently?"
+    → Focused search on Claude Code updates, new capabilities, and
+      related documentation changes
+
+**What you'll get:** A daily brief saved as `outputs/claude-research-daily-YYYY-MM-DD.md`. Sections include: Top Headlines, Product Updates, Notable Videos, Examples & Tutorials, Research & Technical, Quick Links, and Brief Info (sources checked, coverage window).
+
+---
+
+#### `meeting-prep-researcher`
+
+**What it does:** Researches meeting attendees and companies, then produces a structured prep brief with profiles, talking points, and suggested questions.
+
+**When to use it:** Use this before any meeting where you need context on the people or company — sales calls, partnership discussions, interviews, or client meetings. Especially valuable when meeting someone for the first time.
+
+**How it works:** Claude gathers meeting details (who, what company, meeting type, your goal), then researches attendees (LinkedIn, recent posts, public statements, decision-making authority) and the company (recent news, strategic direction, competitive landscape, leadership changes). Findings are synthesized into a scannable brief designed to be read in under 5 minutes. The agent loads the `meeting-prep-research` skill for the structured research workflow.
+
+**Example prompts:**
+
+    "I have a meeting with Sarah Chen from Acme Corp tomorrow.
+    Help me prepare."
+    → Researches Sarah's role, recent activity, and conversation
+      starters, plus Acme Corp's recent news, strategy, and
+      competitive position
+
+    "Put together a prep doc for my 2pm call with the marketing
+    team at Rivian"
+    → Produces a brief with attendee profiles, company snapshot,
+      talking points, questions to ask, and potential watch-outs
+
+**What you'll get:** A Meeting Prep Brief with: attendee profiles (background, recent activity, conversation starters), company snapshot (what they do, size, recent news, strategic priorities), suggested talking points with rationale, questions that demonstrate preparation and advance your goals, and watch-outs (sensitive topics, potential objections).
+
+---
+
+### Skills
+
+---
+
+#### `editing-hbr-articles`
+
+**What it does:** Teaches Claude specific editorial criteria for editing articles to HBR publication quality. Loaded automatically by the `hbr-editor` agent, but can also be invoked directly.
+
+**When to use it:** Use this when you want Claude to make direct, prescriptive edits to an article rather than just providing feedback. The skill focuses on hands-on editing rather than review.
+
+**How it works:**
+
+1. Read the article completely before making any edits
+2. Assess against HBR editorial criteria (structure, evidence, voice, length)
+3. Make direct edits to the file, prioritizing highest-impact issues first:
+    - **Structure** — Does the opening hook? Is the thesis clear by paragraph 3?
+    - **Evidence** — Are claims supported with specific data, named companies, credible sources?
+    - **Redundancy** — Cut repeated points, excessive examples, conclusions that rehash the intro
+    - **Voice** — Remove hedging, jargon, promotional language; strengthen to active voice
+    - **Length** — Target 2,500-3,500 words for features, 1,500-2,500 for thought leadership
+4. Provide an editorial summary: major changes, tightening metrics (word count before → after), and remaining considerations
+
+**Example prompts:**
+
+    "Edit this article to HBR quality"
+    → Makes direct edits to the file following the priority order,
+      then provides a summary of changes and word count reduction
+
+**What you'll get:** Your article file edited in place, plus an editorial summary with major changes listed, word count reduction percentage, and optional improvements for the author to consider.
+
+**Platform compatibility:** Claude Code &#10003;
+
+---
+
+#### `meeting-prep-research`
+
+**What it does:** Provides a structured research workflow for meeting preparation. Loaded automatically by the `meeting-prep-researcher` agent, but can also be invoked directly.
+
+**When to use it:** Use this when you want the step-by-step meeting research process without the full agent persona — useful when you want more control over the research flow.
+
+**How it works:**
+
+1. Gather meeting details — attendee name(s), company, meeting type, and your goal
+2. Research attendees — LinkedIn profiles, recent posts, public activity
+3. Research company — recent news (last 90 days), strategic direction, relevant context
+4. Synthesize into a formatted Meeting Prep Brief
+5. Refine with you — ask if any section needs more depth or adjustment
+
+**Example prompts:**
+
+    "Research John Park from Stripe before my call on Thursday"
+    → Walks through the 5-step workflow, producing a scannable brief
+      with profiles, company snapshot, talking points, and questions
+
+**What you'll get:** A structured Meeting Prep Brief (same format as the agent output) with attendee profiles, company snapshot, talking points, questions to ask, and watch-outs.
+
+**Platform compatibility:** Claude Code &#10003; | Claude.ai &#10003;

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -51,20 +51,20 @@ Working examples of agents and skills from the Hands-on AI cohort courses.
 
     | Agent | What it does |
     |-------|-------------|
-    | [`tech-executive-writer`](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/agents/tech-executive-writer.md) | Writes business-focused content about AI and technology. LinkedIn posts, magazine articles, executive briefs, and thought leadership pieces. Translates complex technical concepts for non-technical audiences. |
-    | [`hbr-editor`](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/agents/hbr-editor.md) | Reviews drafts against HBR editorial standards. Provides prescriptive feedback on structure, evidence quality, voice, and argument strength. |
-    | [`hbr-publisher`](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/agents/hbr-publisher.md) | Formats finalized articles for web publication and PDF distribution. Handles SEO metadata, social snippets, and professional layout. |
-    | [`ai-news-researcher`](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/agents/ai-news-researcher.md) | Scans news outlets, blogs, YouTube channels, podcasts, and communities for the latest AI developments. Categorizes findings by product releases, research, company updates, and community highlights. |
-    | [`ai-productivity-researcher`](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/agents/ai-productivity-researcher.md) | Finds documented case studies of companies using AI for productivity gains. Prioritizes HBR-caliber sources with quantified outcomes. Outputs structured case study briefs. |
-    | [`claude-research-daily`](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/agents/claude-research-daily.md) | Produces a daily brief on Anthropic, Claude, Claude Code, and Cowork. Covers official announcements, tech news, video content, tutorials, and community discussions from the last 24 hours. |
-    | [`meeting-prep-researcher`](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/course-examples/agents/meeting-prep-researcher.md) | Researches meeting attendees and companies, then produces a structured prep brief with profiles, talking points, and suggested questions. |
+    | [`tech-executive-writer`](course-examples.md#tech-executive-writer) | Writes business-focused content about AI and technology. LinkedIn posts, magazine articles, executive briefs, and thought leadership pieces. Translates complex technical concepts for non-technical audiences. |
+    | [`hbr-editor`](course-examples.md#hbr-editor) | Reviews drafts against HBR editorial standards. Provides prescriptive feedback on structure, evidence quality, voice, and argument strength. |
+    | [`hbr-publisher`](course-examples.md#hbr-publisher) | Formats finalized articles for web publication and PDF distribution. Handles SEO metadata, social snippets, and professional layout. |
+    | [`ai-news-researcher`](course-examples.md#ai-news-researcher) | Scans news outlets, blogs, YouTube channels, podcasts, and communities for the latest AI developments. Categorizes findings by product releases, research, company updates, and community highlights. |
+    | [`ai-productivity-researcher`](course-examples.md#ai-productivity-researcher) | Finds documented case studies of companies using AI for productivity gains. Prioritizes HBR-caliber sources with quantified outcomes. Outputs structured case study briefs. |
+    | [`claude-research-daily`](course-examples.md#claude-research-daily) | Produces a daily brief on Anthropic, Claude, Claude Code, and Cowork. Covers official announcements, tech news, video content, tutorials, and community discussions from the last 24 hours. |
+    | [`meeting-prep-researcher`](course-examples.md#meeting-prep-researcher) | Researches meeting attendees and companies, then produces a structured prep brief with profiles, talking points, and suggested questions. |
 
 ???+ skills "Skills included"
 
     | Skill | What it does |
     |-------|-------------|
-    | [`editing-hbr-articles`](https://github.com/jamesgray-ai/handsonai/tree/main/plugins/course-examples/skills/editing-hbr-articles/) | Loads HBR editorial criteria for article editing. Used by the `hbr-editor` agent to apply specific standards for openings, evidence, voice, and length. Includes a reference file with cut/replace patterns and source quality hierarchy. |
-    | [`meeting-prep-research`](https://github.com/jamesgray-ai/handsonai/tree/main/plugins/course-examples/skills/meeting-prep-research/) | Step-by-step research workflow for meeting preparation. Guides the meeting-prep-researcher agent through attendee research, company analysis, and prep brief generation. |
+    | [`editing-hbr-articles`](course-examples.md#editing-hbr-articles) | Loads HBR editorial criteria for article editing. Used by the `hbr-editor` agent to apply specific standards for openings, evidence, voice, and length. Includes a reference file with cut/replace patterns and source quality hierarchy. |
+    | [`meeting-prep-research`](course-examples.md#meeting-prep-research) | Step-by-step research workflow for meeting preparation. Guides the meeting-prep-researcher agent through attendee research, company analysis, and prep brief generation. |
 
 ???+ usage "Example usage"
 
@@ -108,11 +108,11 @@ Document, name, register, and sync AI operational workflows and skills.
 
     | Skill | What it does |
     |-------|-------------|
-    | [`naming-workflows`](https://github.com/jamesgray-ai/handsonai/tree/main/plugins/ai-registry/skills/naming-workflows/) | Generates consistent, outcome-focused names and descriptions for business workflows. Follows domain-specific naming patterns (Sales, Marketing, Product, etc.) and creates entries in the Notion Workflows database. |
-    | [`writing-workflow-sops`](https://github.com/jamesgray-ai/handsonai/tree/main/plugins/ai-registry/skills/writing-workflow-sops/) | Writes Standard Operating Procedure documentation for workflows. Adapts SOP templates for Manual, Augmented, and Automated workflow types. Saves SOPs to Notion workflow page bodies. |
-    | [`writing-process-guides`](https://github.com/jamesgray-ai/handsonai/tree/main/plugins/ai-registry/skills/writing-process-guides/) | Writes Business Process Guide documentation explaining when, why, and how to execute a complete business process with its component workflows. Covers strategic context while linking to individual SOPs for tactical details. |
-    | [`registering-skills`](https://github.com/jamesgray-ai/handsonai/tree/main/plugins/ai-registry/skills/registering-skills/) | Registers or updates Claude Skills in the Notion AI Assets database. Extracts metadata from SKILL.md frontmatter, generates Quick Start Prompts, and handles duplicate detection. |
-    | [`syncing-skills-to-github`](https://github.com/jamesgray-ai/handsonai/tree/main/plugins/ai-registry/skills/syncing-skills-to-github/) | Syncs skills from `~/.claude/skills/` to a GitHub repository. Detects changes, generates semantic commit messages, pushes to remote, and updates Notion AI Assets with GitHub URLs. |
+    | [`naming-workflows`](ai-registry.md#naming-workflows) | Generates consistent, outcome-focused names and descriptions for business workflows. Follows domain-specific naming patterns (Sales, Marketing, Product, etc.) and creates entries in the Notion Workflows database. |
+    | [`writing-workflow-sops`](ai-registry.md#writing-workflow-sops) | Writes Standard Operating Procedure documentation for workflows. Adapts SOP templates for Manual, Augmented, and Automated workflow types. Saves SOPs to Notion workflow page bodies. |
+    | [`writing-process-guides`](ai-registry.md#writing-process-guides) | Writes Business Process Guide documentation explaining when, why, and how to execute a complete business process with its component workflows. Covers strategic context while linking to individual SOPs for tactical details. |
+    | [`registering-skills`](ai-registry.md#registering-skills) | Registers or updates Claude Skills in the Notion AI Assets database. Extracts metadata from SKILL.md frontmatter, generates Quick Start Prompts, and handles duplicate detection. |
+    | [`syncing-skills-to-github`](ai-registry.md#syncing-skills-to-github) | Syncs skills from `~/.claude/skills/` to a GitHub repository. Detects changes, generates semantic commit messages, pushes to remote, and updates Notion AI Assets with GitHub URLs. |
 
 ??? workflow "Recommended workflow"
 
@@ -153,15 +153,15 @@ Deconstruct business workflows into AI building blocks. Includes an orchestrator
 
     | Agent | What it does |
     |-------|-------------|
-    | [`workflow-deconstructor`](https://github.com/jamesgray-ai/handsonai/blob/main/plugins/workflow-deconstruction/agents/workflow-deconstructor.md) | Orchestrates the full three-step workflow deconstruction process. Runs discovery, analysis, and output generation sequentially with file-based handoffs between stages. |
+    | [`workflow-deconstructor`](workflow-deconstruction.md#workflow-deconstructor) | Orchestrates the full three-step workflow deconstruction process. Runs discovery, analysis, and output generation sequentially with file-based handoffs between stages. |
 
 ???+ skills "Skills included"
 
     | Skill | What it does |
     |-------|-------------|
-    | [`workflow-discovery`](https://github.com/jamesgray-ai/handsonai/tree/main/plugins/workflow-deconstruction/skills/workflow-discovery/) | Interactively discovers and decomposes a business workflow into a structured Workflow Blueprint using the 4-question framework + failure modes. |
-    | [`workflow-analysis`](https://github.com/jamesgray-ai/handsonai/tree/main/plugins/workflow-deconstruction/skills/workflow-analysis/) | Classifies workflow steps on the autonomy spectrum, maps them to AI building blocks, and produces a Workflow Analysis Document. |
-    | [`workflow-output-generation`](https://github.com/jamesgray-ai/handsonai/tree/main/plugins/workflow-deconstruction/skills/workflow-output-generation/) | Generates a ready-to-use Baseline Workflow Prompt and Skill Build Recommendations from a Workflow Analysis Document. |
+    | [`workflow-discovery`](workflow-deconstruction.md#workflow-discovery) | Interactively discovers and decomposes a business workflow into a structured Workflow Blueprint using the 4-question framework + failure modes. |
+    | [`workflow-analysis`](workflow-deconstruction.md#workflow-analysis) | Classifies workflow steps on the autonomy spectrum, maps them to AI building blocks, and produces a Workflow Analysis Document. |
+    | [`workflow-output-generation`](workflow-deconstruction.md#workflow-output-generation) | Generates a ready-to-use Baseline Workflow Prompt and Skill Build Recommendations from a Workflow Analysis Document. |
 
 ???+ usage "Example usage"
 

--- a/docs/plugins/workflow-deconstruction.md
+++ b/docs/plugins/workflow-deconstruction.md
@@ -1,0 +1,218 @@
+---
+title: Workflow Deconstruction
+description: Deconstruct business workflows into AI building blocks with guided discovery, analysis, and output generation
+---
+
+# Workflow Deconstruction
+
+Deconstruct any business workflow into AI building blocks. This plugin walks you through a three-step process — discovery, analysis, and output generation — that turns a verbal description of how you work into a structured blueprint, an AI readiness analysis, and a ready-to-use prompt with skill recommendations. Use it when you want to figure out which parts of a workflow can be automated, augmented, or left as-is.
+
+## Install
+
+```bash
+/plugin install workflow-deconstruction@handsonai
+```
+
+## Components
+
+### Agents
+
+---
+
+#### `workflow-deconstructor`
+
+**What it does:** Orchestrates the full three-step workflow deconstruction process. Runs discovery, analysis, and output generation sequentially, with file-based handoffs between stages so you can also run each step individually in separate conversations.
+
+**When to use it:** Use this when you want to go through the entire deconstruction process in one session. The agent manages the flow between steps, saves intermediate files, and keeps you involved at each stage. If you prefer to work step-by-step across separate conversations, invoke the individual skills instead.
+
+**How it works:** The agent runs three skills in sequence:
+
+1. **Discovery** (`workflow-discovery`) — Interactive conversation where you describe your workflow. The agent probes for missing steps, decision points, data flows, and failure modes. Produces a Workflow Blueprint.
+2. **Analysis** (`workflow-analysis`) — Reads the Blueprint, classifies each step on an autonomy spectrum (Human → AI-Deterministic → AI-Semi-Autonomous → AI-Autonomous), and maps to AI building blocks. Produces a Workflow Analysis Document.
+3. **Output Generation** (`workflow-output-generation`) — Reads the Analysis Document and generates a ready-to-use prompt plus recommendations for which steps should become dedicated skills. Produces the Baseline Prompt and Skill Recommendations.
+
+Files are saved to `outputs/` using kebab-case workflow names (e.g., `outputs/lead-qualification-blueprint.md`).
+
+**Example prompts:**
+
+    "I want to deconstruct my client onboarding workflow"
+    → Walks you through all three steps, asking questions during
+      discovery, presenting the analysis for review, and generating
+      the final deliverables
+
+    "People keep dropping off during enrollment. Help me build
+    a workflow for that."
+    → Starts from a problem description, proposes a candidate
+      workflow, then deconstructs it into building blocks
+
+    "Help me figure out which parts of my weekly reporting process
+    could be automated with AI"
+    → Decomposes the reporting process, classifies each step by
+      autonomy level, and identifies quick wins vs. complex
+      automation opportunities
+
+**What you'll get:** Four files in `outputs/`:
+
+1. **Workflow Blueprint** — `[name]-blueprint.md` — structured decomposition of every step
+2. **Workflow Analysis Document** — `[name]-analysis.md` — autonomy classification and AI building block mapping
+3. **Baseline Workflow Prompt** — `[name]-prompt.md` — ready-to-use prompt with numbered steps
+4. **Skill Build Recommendations** — `[name]-skill-recs.md` — specs for which steps should become dedicated skills
+
+---
+
+### Skills
+
+---
+
+#### `workflow-discovery`
+
+**What it does:** Interactively discovers and decomposes a business workflow into a structured Workflow Blueprint. This is Step 1 of 3 in the workflow deconstruction series.
+
+**When to use it:** Use this when you want to thoroughly document a workflow before analyzing it for AI readiness. Also useful standalone when you just need a structured breakdown of a complex process — even without planning to automate it.
+
+**How it works:**
+
+1. **Scenario discovery** — Claude asks about the business scenario, objective, high-level steps, and ownership. One question at a time. If you describe a problem instead of a workflow, Claude proposes a candidate workflow for you to react to.
+2. **Scope check** — Claude assesses whether this is one workflow or multiple bundled together. If multiple, it recommends splitting and asks which to start with.
+3. **Name the workflow** — Claude presents 2-3 name options (2-4 word noun phrases, Title Case) and confirms name, description, outcome, trigger, and type.
+4. **Deep dive** — For each step, Claude probes five dimensions:
+    - Discrete steps (is this actually multiple steps?)
+    - Decision points (if/then branches, quality gates)
+    - Data flows (inputs, outputs, sources, destinations)
+    - Context needs (specific documents, files, reference materials)
+    - Failure modes (what happens when this step fails)
+5. **Propose and react** — From step 4 onward, Claude proposes a hypothesis across all five dimensions and asks "What's right, what's wrong, what am I missing?"
+6. **Map sequence** — Claude identifies sequential vs. parallel steps and the critical path
+7. **Consolidate context** — Claude presents a rolled-up "context shopping list" of every artifact the workflow needs
+8. **Generate Blueprint** — Claude writes the structured Blueprint to the output file
+
+**Example prompts:**
+
+    "Use workflow-discovery to break down my expense reporting process"
+    → Interactive discovery session producing
+      outputs/expense-reporting-blueprint.md
+
+    "I need to document how our team handles customer escalations"
+    → Walks through the discovery process, probing for hidden steps
+      and decision points
+
+**What you'll get:** A Workflow Blueprint file (`outputs/[name]-blueprint.md`) containing: scenario metadata, refined steps (with sub-steps, decision points, data flows, context needs, and failure modes for each), step sequence and dependencies, and a context shopping list.
+
+**Platform compatibility:** Claude Code &#10003; | Claude.ai &#10003;
+
+---
+
+#### `workflow-analysis`
+
+**What it does:** Classifies workflow steps on the autonomy spectrum, maps them to AI building blocks, and produces a Workflow Analysis Document. This is Step 2 of 3 in the workflow deconstruction series.
+
+**When to use it:** Use this when you have a Workflow Blueprint (from Step 1) and want to analyze which steps can be automated, which need human oversight, and what AI tools are required.
+
+**How it works:**
+
+1. **Load Blueprint** — Claude reads the Blueprint file from `outputs/`
+2. **Confirm understanding** — Claude summarizes the workflow and asks you to confirm before proceeding
+3. **Classify each step** — For every step, Claude determines:
+    - **Autonomy level**: Human / AI-Deterministic / AI-Semi-Autonomous / AI-Autonomous
+    - **AI building block(s)**: Prompt, Context, Skill, Agent, MCP, Project
+    - **Tools and connectors**: External tools, APIs, and integrations needed
+    - **Human-in-the-loop gates**: Where human review is recommended
+4. **Present mapping** — Claude shows the classification as a table and walks through reasoning for non-obvious decisions. You can adjust classifications.
+5. **Generate Analysis Document** — After your confirmation, Claude produces the complete document
+
+**Autonomy spectrum:**
+
+| Level | Description |
+|-------|-------------|
+| Human | Must be done by a person — judgment, relationship, creativity |
+| AI-Deterministic | Follows fixed rules — template filling, data lookups, formatting |
+| AI-Semi-Autonomous | AI does most work, human reviews before final output |
+| AI-Autonomous | AI handles end-to-end without human intervention |
+
+**Example prompts:**
+
+    "Use workflow-analysis on my blueprint"
+    → Reads the most recent Blueprint, classifies each step, presents
+      the mapping table, and generates the Analysis Document
+
+    "Analyze the lead-qualification blueprint for AI readiness"
+    → Reads outputs/lead-qualification-blueprint.md and produces
+      the analysis
+
+**What you'll get:** A Workflow Analysis Document (`outputs/[name]-analysis.md`) containing: scenario summary, step-by-step decomposition table (with autonomy level and AI building blocks for each step), autonomy spectrum summary, step sequence and dependencies, prerequisites, context inventory, tools and connectors required, and recommended implementation order (quick wins first).
+
+**Platform compatibility:** Claude Code &#10003; | Claude.ai &#10003;
+
+---
+
+#### `workflow-output-generation`
+
+**What it does:** Generates a ready-to-use Baseline Workflow Prompt and Skill Build Recommendations from a Workflow Analysis Document. This is Step 3 of 3 in the workflow deconstruction series.
+
+**When to use it:** Use this when you have a completed Analysis Document (from Step 2) and want the final, actionable deliverables — a prompt you can run immediately and specs for which steps should become dedicated skills.
+
+**How it works:**
+
+1. **Load Analysis Document** — Claude reads the Analysis Document from `outputs/`
+2. **Confirm understanding** — Claude summarizes the workflow, step count, AI-eligible steps, and implementation order. You confirm before proceeding.
+3. **Generate Baseline Workflow Prompt** — A self-contained, ready-to-use prompt with:
+    - Title, purpose, and when to use it
+    - Numbered steps, each labeled (AI) or (Human)
+    - Input requirements with format specifications
+    - Context requirements (what to attach when running the prompt)
+    - Output format with structure specifications
+4. **Generate Skill Build Recommendations** — For each step that should become a dedicated skill:
+    - Skill name, purpose, inputs, outputs
+    - Which baseline prompt steps it replaces
+    - Integration points (external tools, APIs, MCP servers)
+    - Priority level (High / Medium / Low)
+    - Quick Start Prompt for invoking the skill
+
+**Example prompts:**
+
+    "Use workflow-output-generation on my analysis"
+    → Reads the most recent Analysis Document, generates the prompt
+      and skill recommendations
+
+    "Generate the deliverables for expense-reporting"
+    → Reads outputs/expense-reporting-analysis.md and produces both
+      output files
+
+**What you'll get:** Two files:
+
+1. **Baseline Workflow Prompt** (`outputs/[name]-prompt.md`) — A self-contained prompt you can run immediately. Steps are labeled (AI) or (Human), includes all input/context/output requirements.
+2. **Skill Build Recommendations** (`outputs/[name]-skill-recs.md`) — Specs for each recommended skill, in priority order, with Quick Start Prompts.
+
+**Platform compatibility:** Claude Code &#10003; | Claude.ai &#10003;
+
+---
+
+## Recommended Workflow
+
+The three skills form a pipeline, each building on the previous step's output:
+
+1. **Discover** — Run `workflow-discovery` to interactively decompose your workflow into a Blueprint
+2. **Analyze** — Run `workflow-analysis` to classify each step and map AI building blocks
+3. **Generate** — Run `workflow-output-generation` to produce your ready-to-use prompt and skill specs
+
+Use the `workflow-deconstructor` agent to run all three in one session, or invoke each skill individually across separate conversations — the file-based handoffs work either way.
+
+**After deconstruction:**
+
+- Start by running the Baseline Workflow Prompt on a real scenario
+- Build skills in priority order from the recommendations
+- Each skill you build replaces steps in the baseline prompt, making the workflow progressively more automated
+
+## FAQ
+
+**Can I start from a problem instead of a workflow?**
+Yes. Tell the `workflow-deconstructor` agent about your problem (e.g., "people keep dropping off during enrollment") and it will propose a candidate workflow for you to refine during discovery.
+
+**What if I lose context mid-conversation?**
+The file-based handoffs mean you can continue in a new conversation. Just invoke the next skill and point it at the file from the previous step (e.g., "Use workflow-analysis on outputs/lead-qualification-blueprint.md").
+
+**What are AI building blocks?**
+The categories used during analysis: Prompt (single instruction), Context (reference material), Skill (multi-step workflow), Agent (autonomous personality), MCP (external tool connection), and Project (workspace configuration). Each step gets mapped to one or more of these.
+
+**How long does the full process take?**
+Discovery is the longest phase — typically 15-30 minutes of interactive conversation depending on workflow complexity. Analysis and output generation are faster since they work from the written Blueprint. The full process usually takes 30-45 minutes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,9 @@ nav:
     - Marketplace: plugins/index.md
     - Getting Started: plugins/getting-started.md
     - Using Plugins: plugins/using-plugins.md
+    - Course Examples: plugins/course-examples.md
+    - AI Registry: plugins/ai-registry.md
+    - Workflow Deconstruction: plugins/workflow-deconstruction.md
   - Fundamentals:
     - Overview: fundamentals/index.md
     - Agents & Tools:


### PR DESCRIPTION
## Summary

- Added dedicated detail pages for all 3 plugins (`course-examples`, `ai-registry`, `workflow-deconstruction`) documenting every agent and skill with what it does, when to use it, how it works, example prompts, and expected output
- Updated catalog page (`docs/plugins/index.md`) links to point to detail page anchors instead of raw GitHub source
- Added 3 new nav entries in `mkdocs.yml` under Plugins
- Updated `CLAUDE.md` plugin checklists to include detail page maintenance steps

## Test plan

- [ ] Run `mkdocs serve` and verify all 3 detail pages render correctly
- [ ] Verify navigation shows new entries under Plugins
- [ ] Click component name links in the catalog page and confirm they navigate to the correct detail page sections
- [ ] Spot-check that `registering-skills` section conveys enough detail for a new user to understand purpose, workflow, and output

🤖 Generated with [Claude Code](https://claude.com/claude-code)