### PR TITLE
Add 'What This Is' sections to framework phase pages

### DIFF
--- a/docs/how-to/prompting/ai-workflow-opportunity-finder.md
+++ b/docs/how-to/prompting/ai-workflow-opportunity-finder.md
@@ -10,6 +10,16 @@ description: Use this prompt template to discover where AI can help automate, au
 !!! info "Business-First AI Framework — Phase 1: Discover"
     This guide is **Phase 1** of the [Business-First AI Framework](../../business-first-ai-framework.md) — discovering where AI fits in your workflows.
 
+## What This Is
+
+A structured audit that helps you find where AI fits in your work. The AI scans what it already knows about you, interviews you about your workflows, then analyzes the results to surface opportunities you'd miss on your own.
+
+| | |
+|---|---|
+| **What you'll do** | Walk through a guided conversation covering your role, tasks, and pain points |
+| **What you'll get** | A prioritized report of AI opportunities across three levels — Collaborative AI, Deterministic Workflows, and Multi-Agent Systems — with concrete next steps for each |
+| **Time** | ~20–30 minutes for the full conversation |
+
 ## Why This Matters
 
 Most people adopt AI by reacting to problems — they reach for ChatGPT when they're stuck on an email or ask Claude to summarize a document. That's useful, but it misses the bigger picture.
@@ -67,11 +77,11 @@ Both options follow the same three-step process and produce the same structured 
 ```text
 You are an AI Workflow Strategist with deep expertise in business process optimization and AI capabilities. Your job is to help me discover concrete opportunities where AI can improve my workflows.
 
-Work through the following three phases in order.
+Work through the following three steps in order.
 
 ---
 
-## Phase 1 — Memory & History Scan
+## Step 1 — Memory & History Scan
 
 Before asking me anything, review everything you already know about me from our conversation history, your memory, project files, or any other context available to you.
 
@@ -83,13 +93,13 @@ From that context, identify and list:
 - Tools and platforms I use regularly
 - Any goals or priorities I've shared
 
-Present your findings as a brief summary so I can confirm or correct them before we continue. If you have no prior context about me, say so and move directly to Phase 2.
+Present your findings as a brief summary so I can confirm or correct them before we continue. If you have no prior context about me, say so and move directly to Step 2.
 
 ---
 
-## Phase 2 — Targeted Discovery Interview
+## Step 2 — Targeted Discovery Interview
 
-Based on gaps in your understanding (or starting from scratch if Phase 1 had no context), ask me focused questions to build a complete picture. Cover these areas:
+Based on gaps in your understanding (or starting from scratch if Step 1 had no context), ask me focused questions to build a complete picture. Cover these areas:
 
 1. **Role & responsibilities** — What is your role? What are you accountable for?
 2. **Repetitive tasks** — What tasks do you perform daily or weekly that feel repetitive, tedious, or low-value?
@@ -103,7 +113,7 @@ Ask these questions conversationally — not all at once. Use my answers to ask 
 
 ---
 
-## Phase 3 — Opportunity Analysis & Report
+## Step 3 — Opportunity Analysis & Report
 
 Once you have sufficient context, produce a structured report.
 
@@ -156,9 +166,9 @@ Group the detailed cards by category. Within each category, order opportunities 
 
 After pasting the prompt, here's what typically happens:
 
-1. **Phase 1** — The AI reviews what it knows about you and presents a summary. Correct anything that's wrong and fill in gaps.
-2. **Phase 2** — The AI asks you a series of questions. Answer as specifically as you can — concrete examples produce better recommendations than general descriptions.
-3. **Phase 3** — You receive a structured report with a summary table and detailed cards for each opportunity, grouped by category.
+1. **Step 1** — The AI reviews what it knows about you and presents a summary. Correct anything that's wrong and fill in gaps.
+2. **Step 2** — The AI asks you a series of questions. Answer as specifically as you can — concrete examples produce better recommendations than general descriptions.
+3. **Step 3** — You receive a structured report with a summary table and detailed cards for each opportunity, grouped by category.
 
 Most people discover 5–15 opportunities across the three categories. Don't try to pursue all of them — pick 1–2 from the "Getting started" suggestions and pilot those first.
 

--- a/docs/how-to/prompting/workflow-deconstruction-analysis.md
+++ b/docs/how-to/prompting/workflow-deconstruction-analysis.md
@@ -47,15 +47,15 @@ I have a Workflow Blueprint from a previous conversation. I'll paste it when you
 
 ---
 
-## Step 1 — Paste Your Blueprint
+## Part 1 — Paste Your Blueprint
 
 Say: "Upload your Workflow Blueprint file, or paste its contents below, then press Enter."
 
-Wait for me to provide it. After receiving the Blueprint, confirm you've read it by summarizing: the workflow name, the number of steps, and the workflow outcome. Then proceed to Step 2.
+Wait for me to provide it. After receiving the Blueprint, confirm you've read it by summarizing: the workflow name, the number of steps, and the workflow outcome. Then proceed to Part 2.
 
 ---
 
-## Step 2 — AI Building Block Mapping
+## Part 2 — AI Building Block Mapping
 
 For each refined step from the Blueprint, determine:
 
@@ -81,7 +81,7 @@ Present the mapping as a clear table, then walk me through your reasoning for an
 
 ---
 
-## Step 3 — Generate Workflow Analysis Document
+## Part 3 — Generate Workflow Analysis Document
 
 After I confirm the mapping, produce the complete **Workflow Analysis Document** as a Markdown file.
 

--- a/docs/how-to/prompting/workflow-deconstruction-discovery.md
+++ b/docs/how-to/prompting/workflow-deconstruction-discovery.md
@@ -42,11 +42,11 @@ Use the `discovering-workflows` skill from the [Business First AI plugin](../../
 ```text
 You are an expert Workflow Designer who specializes in deconstructing business workflows for AI operationalization. Your job is to help me discover and deeply analyze a business workflow, then produce a structured Workflow Blueprint that captures everything needed for AI building block mapping.
 
-Work through the following two phases in order. Ask one question at a time during interactive sections. Wait for my response before moving on.
+Work through the following two parts in order. Ask one question at a time during interactive sections. Wait for my response before moving on.
 
 ---
 
-## Phase 1 — Scenario Discovery
+## Part 1 — Scenario Discovery
 
 Start by understanding the workflow I want to deconstruct.
 
@@ -63,7 +63,7 @@ Ask these one at a time.
 
 **If I can only describe the outcome but not the steps:** Don't wait for me to list steps I can't articulate. Instead, propose 5-8 candidate steps based on the scenario and outcome I described, and ask me to react — "yes," "no," "sort of," or "I'd describe it differently." Use my reactions to build the step list collaboratively.
 
-**If I'm describing a problem, not an existing workflow:** I may not have a process to break down — I may have a gap or pain point that needs a new workflow designed from scratch. In that case, don't force me through questions 2-4 as written. Instead: (1) clarify the problem by asking what's happening now, what should be happening, and what the cost of the gap is; (2) propose a candidate workflow (5-8 steps) that would solve the problem; (3) ask me to react and refine. Then continue to Phase 2 with the proposed workflow as if I had provided it.
+**If I'm describing a problem, not an existing workflow:** I may not have a process to break down — I may have a gap or pain point that needs a new workflow designed from scratch. In that case, don't force me through questions 2-4 as written. Instead: (1) clarify the problem by asking what's happening now, what should be happening, and what the cost of the gap is; (2) propose a candidate workflow (5-8 steps) that would solve the problem; (3) ask me to react and refine. Then continue to Part 2 with the proposed workflow as if I had provided it.
 
 **Scope check:** After gathering the scenario, assess whether this is one workflow or multiple workflows bundled together. If it looks like more than one (e.g., it spans multiple departments, has clearly independent phases, or would take more than 15-20 refined steps), recommend splitting it into sub-workflows and ask me which one to start with.
 
@@ -82,11 +82,11 @@ Ask these one at a time.
 
 Present 2-3 name options and let me pick one or suggest my own. Confirm the chosen name, description, workflow outcome, trigger, and type.
 
-**Phase 1 summary** — After naming is confirmed, summarize what you've learned: workflow name, description, workflow outcome, trigger, type, business scenario and objective, high-level steps, and current ownership. Confirm you have it right before moving to Phase 2.
+**Part 1 summary** — After naming is confirmed, summarize what you've learned: workflow name, description, workflow outcome, trigger, type, business scenario and objective, high-level steps, and current ownership. Confirm you have it right before moving to Part 2.
 
 ---
 
-## Phase 2 — Deep Dive (5-Question Framework)
+## Part 2 — Deep Dive (5-Question Framework)
 
 Now systematically work through each step I provided using the 5-question framework. For every step, you need to understand:
 
@@ -120,9 +120,9 @@ After completing all steps:
 
 ## Output — Workflow Blueprint
 
-After I confirm the breakdown is accurate, produce the **Workflow Blueprint** as a Markdown file. This is a structured document that captures everything from Phases 1 and 2.
+After I confirm the breakdown is accurate, produce the **Workflow Blueprint** as a Markdown file. This is a structured document that captures everything from Parts 1 and 2.
 
-**File naming:** Name the file `[workflow-name]-blueprint.md` using the kebab-case version of the workflow name confirmed in Phase 1 (e.g., if the workflow is "Lead Qualification," the file is `lead-qualification-blueprint.md`).
+**File naming:** Name the file `[workflow-name]-blueprint.md` using the kebab-case version of the workflow name confirmed in Part 1 (e.g., if the workflow is "Lead Qualification," the file is `lead-qualification-blueprint.md`).
 
 Generate the Blueprint as a downloadable Markdown file. If your platform doesn't support file downloads, format it inside a single Markdown code block so I can copy and save it manually.
 

--- a/docs/how-to/prompting/workflow-deconstruction-meta-prompt.md
+++ b/docs/how-to/prompting/workflow-deconstruction-meta-prompt.md
@@ -10,6 +10,16 @@ description: Use this three-prompt series to break down any business workflow in
 !!! info "Business-First AI Framework — Phase 2: Deconstruct"
     This guide is **Phase 2** of the [Business-First AI Framework](../../business-first-ai-framework.md) — deconstructing workflows into AI building blocks.
 
+## What This Is
+
+A three-conversation series that breaks down a business workflow into discrete steps, maps each step to AI building blocks, and generates ready-to-use outputs.
+
+| | |
+|---|---|
+| **What you'll do** | Work through three focused prompts — discovering and decomposing your workflow, classifying each step and mapping AI capabilities, then generating executable outputs |
+| **What you'll get** | Four Markdown files — a Workflow Blueprint, a Workflow Analysis Document, a Baseline Workflow Prompt (ready to paste and run), and Skill Build Recommendations |
+| **Time** | ~30–45 minutes across three conversations |
+
 ## Why This Matters
 
 You can't operationalize AI on a process you don't understand. Before you can build an AI-powered workflow, you need to break it down into discrete steps, identify the decision points and data flows, and map each step to the right level of AI assistance.
@@ -156,11 +166,11 @@ Most workflows expand from 5-8 rough steps to 12-20 refined steps after the deep
     ```text
     You are an expert Workflow Designer and Prompt Engineer who writes clear, precise instructions that language models can execute reliably. You specialize in deconstructing business workflows for AI operationalization. Your job is to help me break down a business workflow into discrete steps, map each step to AI building blocks, and produce three deliverables: a Workflow Analysis Document, a Baseline Workflow Prompt, and Skill Build Recommendations.
 
-    Work through the following four phases in order. Ask one question at a time during interactive phases. Wait for my response before moving on.
+    Work through the following four parts in order. Ask one question at a time during interactive parts. Wait for my response before moving on.
 
     ---
 
-    ## Phase 1 — Scenario Discovery
+    ## Part 1 — Scenario Discovery
 
     Start by understanding the workflow I want to deconstruct.
 
@@ -177,7 +187,7 @@ Most workflows expand from 5-8 rough steps to 12-20 refined steps after the deep
 
     **If I can only describe the outcome but not the steps:** Don't wait for me to list steps I can't articulate. Instead, propose 5-8 candidate steps based on the scenario and outcome I described, and ask me to react — "yes," "no," "sort of," or "I'd describe it differently." Use my reactions to build the step list collaboratively.
 
-    **If I'm describing a problem, not an existing workflow:** I may not have a process to break down — I may have a gap or pain point that needs a new workflow designed from scratch. In that case, don't force me through questions 2-4 as written. Instead: (1) clarify the problem by asking what's happening now, what should be happening, and what the cost of the gap is; (2) propose a candidate workflow (5-8 steps) that would solve the problem; (3) ask me to react and refine. Then continue to Phase 2 with the proposed workflow as if I had provided it.
+    **If I'm describing a problem, not an existing workflow:** I may not have a process to break down — I may have a gap or pain point that needs a new workflow designed from scratch. In that case, don't force me through questions 2-4 as written. Instead: (1) clarify the problem by asking what's happening now, what should be happening, and what the cost of the gap is; (2) propose a candidate workflow (5-8 steps) that would solve the problem; (3) ask me to react and refine. Then continue to Part 2 with the proposed workflow as if I had provided it.
 
     **Scope check:** After gathering the scenario, assess whether this is one workflow or multiple workflows bundled together. If it looks like more than one (e.g., it spans multiple departments, has clearly independent phases, or would take more than 15-20 refined steps), recommend splitting it into sub-workflows and ask me which one to start with.
 
@@ -196,11 +206,11 @@ Most workflows expand from 5-8 rough steps to 12-20 refined steps after the deep
 
     Present 2-3 name options and let me pick one or suggest my own. Confirm the chosen name, description, workflow outcome, trigger, and type.
 
-    **Phase 1 summary** — After naming is confirmed, summarize what you've learned: workflow name, description, workflow outcome, trigger, type, business scenario and objective, high-level steps, and current ownership. Confirm you have it right before moving to Phase 2.
+    **Part 1 summary** — After naming is confirmed, summarize what you've learned: workflow name, description, workflow outcome, trigger, type, business scenario and objective, high-level steps, and current ownership. Confirm you have it right before moving to Part 2.
 
     ---
 
-    ## Phase 2 — Deep Dive (5-Question Framework)
+    ## Part 2 — Deep Dive (5-Question Framework)
 
     Now systematically work through each step I provided using the 5-question framework. For every step, ask about:
 
@@ -223,9 +233,9 @@ Most workflows expand from 5-8 rough steps to 12-20 refined steps after the deep
 
     ---
 
-    ## Phase 3 — AI Building Block Mapping
+    ## Part 3 — AI Building Block Mapping
 
-    For each refined step from Phase 2, determine:
+    For each refined step from Part 2, determine:
 
     1. **Autonomy classification** — Classify each step on the autonomy spectrum:
        - **Human step** — Requires human judgment, creativity, or physical action; AI cannot perform this
@@ -249,7 +259,7 @@ Most workflows expand from 5-8 rough steps to 12-20 refined steps after the deep
 
     ---
 
-    ## Phase 4 — Output Generation
+    ## Part 4 — Output Generation
 
     Produce three deliverables:
 
@@ -258,7 +268,7 @@ Most workflows expand from 5-8 rough steps to 12-20 refined steps after the deep
     Create a structured analysis containing:
 
     **Scenario Summary**
-    - Workflow name (confirmed in Phase 1)
+    - Workflow name (confirmed in Part 1)
     - Description
     - Workflow outcome
     - Trigger
@@ -315,7 +325,7 @@ Most workflows expand from 5-8 rough steps to 12-20 refined steps after the deep
     Structure it as:
 
     **Title and Purpose**
-    - Workflow name and description (from Phase 1)
+    - Workflow name and description (from Part 1)
     - Workflow outcome — what this workflow produces
     - When to use it
 

--- a/docs/how-to/prompting/workflow-deconstruction-outputs.md
+++ b/docs/how-to/prompting/workflow-deconstruction-outputs.md
@@ -46,17 +46,17 @@ I have a Workflow Analysis Document from a previous conversation. I'll paste it 
 
 ---
 
-## Step 1 — Paste Your Analysis Document
+## Part 1 — Paste Your Analysis Document
 
 Say: "Upload your Workflow Analysis Document file, or paste its contents below, then press Enter."
 
-Wait for me to provide it. After receiving the document, confirm you've read it by summarizing: the workflow name, the number of steps, how many are AI-eligible, and the recommended implementation order. Then proceed to Step 2.
+Wait for me to provide it. After receiving the document, confirm you've read it by summarizing: the workflow name, the number of steps, how many are AI-eligible, and the recommended implementation order. Then proceed to Part 2.
 
 If anything in the Analysis Document is ambiguous or seems incomplete, ask me to clarify before generating outputs. Do not guess at missing information.
 
 ---
 
-## Step 2 — Generate Baseline Workflow Prompt
+## Part 2 — Generate Baseline Workflow Prompt
 
 Generate a ready-to-use Markdown prompt that someone could paste into any AI tool to execute this workflow. This is the **baseline version** — it spells out every step in full so it works on any platform (Claude, ChatGPT, Gemini, M365 Copilot). As the user builds skills from the recommendations below, they'll update this prompt to invoke those skills instead of repeating the logic inline.
 
@@ -97,7 +97,7 @@ Generate the prompt as a downloadable Markdown file. If your platform doesn't su
 
 ---
 
-## Step 3 — Generate Skill Build Recommendations
+## Part 3 — Generate Skill Build Recommendations
 
 Based on the Workflow Analysis Document, recommend which reusable skills I should build. Focus on steps that are:
 - Repeatable (executed frequently with similar patterns)

--- a/docs/how-to/workflow-examples/README.md
+++ b/docs/how-to/workflow-examples/README.md
@@ -12,6 +12,16 @@ Not all AI workflows are created equal. The right level of AI involvement depend
 
 These three examples show the spectrum in practice. Each includes a real-world scenario, working building blocks you can install and use, and guidance on when to apply the pattern to your own work.
 
+## What This Is
+
+Worked examples showing complete AI-powered workflows at three levels of the autonomy spectrum — deterministic automation, AI collaborative, and autonomous agent.
+
+| | |
+|---|---|
+| **What you'll find** | Three fully built workflow examples, each showing the complete set of building blocks (prompts, context, skills, agents, MCP connectors) that make it work |
+| **What you'll do** | Study these examples to understand how the building blocks from Phase 2 come together, then use them as templates for building your own workflows |
+| **Time** | Self-paced reference (no guided conversation) |
+
 ## Why This Matters
 
 Most people start using AI the same way: paste something into a chat, get a response, use it or don't. That works for simple tasks, but it misses the bigger picture. AI can operate at different levels of autonomy, and matching the right level to the right task is what separates "I use ChatGPT sometimes" from "AI is integrated into how I work."


### PR DESCRIPTION
## Summary

- Adds a concise "What This Is" section to each of the three Business-First AI Framework phase pages (Discover, Deconstruct, Build) so readers immediately understand what the phase does, what they'll get, and how long it takes
- Each new section follows a consistent format: short paragraph + summary table (What you'll do / What you'll get / Time)
- Renames internal prompt headings from "Phase/Step" to "Part" for consistency across the three-prompt series
- All pages now follow **What → Why → How** ordering

## Test plan

- [ ] `mkdocs build` passes with no new warnings
- [ ] Each phase page shows What → Why → How section order
- [ ] New sections are concise (~10–15 lines each including table)
- [ ] No content was removed from existing sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)