### PR TITLE
Restructure framework pages under /business-first-ai-framework/ URL path

### DIFF
--- a/docs/business-first-ai-framework/build/ai-collaborative.md
+++ b/docs/business-first-ai-framework/build/ai-collaborative.md
@@ -113,5 +113,5 @@ To adapt: identify tasks where you spend significant time gathering information 
 
 - [Deterministic Automation Workflow Example](./deterministic-automation.md) — when AI follows fixed rules with no judgment needed
 - [Autonomous Agent Workflow Example](./autonomous-agent.md) — when AI executes end-to-end with minimal supervision
-- [Find AI Workflow Opportunities](../prompting/ai-workflow-opportunity-finder.md) — discover which workflows are candidates for AI collaboration
-- [Deconstruct Workflows into AI Building Blocks](../prompting/workflow-deconstruction-meta-prompt.md) — break down workflows into AI-ready steps
+- [Discover AI Workflow Opportunities](../discover.md) — discover which workflows are candidates for AI collaboration
+- [Deconstruct Workflows](../deconstruct/index.md) — break down workflows into AI-ready steps

--- a/docs/business-first-ai-framework/build/autonomous-agent.md
+++ b/docs/business-first-ai-framework/build/autonomous-agent.md
@@ -161,7 +161,7 @@ To adapt: identify the distinct phases of your workflow and the specialist exper
 
 - [Deterministic Automation Workflow Example](./deterministic-automation.md) — when AI follows fixed rules with no judgment needed
 - [AI Collaborative Workflow Example](./ai-collaborative.md) — when AI and human iterate together
-- [Find AI Workflow Opportunities](../prompting/ai-workflow-opportunity-finder.md) — discover which workflows are candidates for autonomous agents
-- [Deconstruct Workflows into AI Building Blocks](../prompting/workflow-deconstruction-meta-prompt.md) — break down workflows into agent-ready steps
+- [Discover AI Workflow Opportunities](../discover.md) — discover which workflows are candidates for autonomous agents
+- [Deconstruct Workflows](../deconstruct/index.md) — break down workflows into agent-ready steps
 - [Plugin Marketplace](../../plugins/index.md) — browse all agents and skills used in this pipeline
 - [Claude Code Subagents Documentation](https://code.claude.com/docs/en/sub-agents) — official guide to creating and using subagents in Claude Code

--- a/docs/business-first-ai-framework/build/deterministic-automation.md
+++ b/docs/business-first-ai-framework/build/deterministic-automation.md
@@ -136,5 +136,5 @@ To adapt: identify the **input criteria** (the persona equivalent), the **evalua
 
 - [AI Collaborative Workflow Example](./ai-collaborative.md) — when AI needs to research, reason, and iterate with a human
 - [Autonomous Agent Workflow Example](./autonomous-agent.md) — when AI executes end-to-end with minimal supervision
-- [Find AI Workflow Opportunities](../prompting/ai-workflow-opportunity-finder.md) — discover which of your workflows are candidates for automation
-- [Deconstruct Workflows into AI Building Blocks](../prompting/workflow-deconstruction-meta-prompt.md) — break down complex workflows into automatable steps
+- [Discover AI Workflow Opportunities](../discover.md) — discover which of your workflows are candidates for automation
+- [Deconstruct Workflows](../deconstruct/index.md) — break down complex workflows into automatable steps

--- a/docs/business-first-ai-framework/build/index.md
+++ b/docs/business-first-ai-framework/build/index.md
@@ -1,12 +1,12 @@
 ---
-title: Workflow Examples
+title: Build Workflows
 description: Three worked examples showing the spectrum of AI involvement in workflows — from deterministic automation to fully autonomous agents.
 ---
 
-# Workflow Examples
+# Build Workflows
 
 !!! info "Business-First AI Framework — Phase 3: Build"
-    These examples are **Phase 3** of the [Business-First AI Framework](../../business-first-ai-framework.md) — building AI workflows from your deconstruction outputs. More build guides are coming — this section will grow with content on building prompts, skills, agents, and multi-agent workflows.
+    These examples are **Phase 3** of the [Business-First AI Framework](../index.md) — building AI workflows from your deconstruction outputs. More build guides are coming — this section will grow with content on building prompts, skills, agents, and multi-agent workflows.
 
 Not all AI workflows are created equal. The right level of AI involvement depends on the task — some workflows need rigid, repeatable automation; others need AI that can research, reason, and iterate with a human; and some work best when an agent handles everything end-to-end.
 
@@ -85,6 +85,6 @@ These are the working building blocks included across all three examples. Each o
 
 ## Related
 
-- [Find AI Workflow Opportunities](../prompting/ai-workflow-opportunity-finder.md) — discover which of your workflows are candidates for AI
-- [Deconstruct Workflows into AI Building Blocks](../prompting/workflow-deconstruction-meta-prompt.md) — break down workflows into automatable steps
+- [Discover AI Workflow Opportunities](../discover.md) — discover which of your workflows are candidates for AI
+- [Deconstruct Workflows](../deconstruct/index.md) — break down workflows into automatable steps
 - [Plugin Marketplace](../../plugins/index.md) — browse all available plugins

--- a/docs/business-first-ai-framework/deconstruct/analysis.md
+++ b/docs/business-first-ai-framework/deconstruct/analysis.md
@@ -5,9 +5,9 @@ description: Classify workflow steps on the autonomy spectrum, map them to AI bu
 
 # Step 2 — Analysis & Mapping
 
-> **Part of:** [Deconstruct Workflows into AI Building Blocks](workflow-deconstruction-meta-prompt.md)
+> **Part of:** [Deconstruct Workflows](index.md)
 
-This is the second of three prompts. It takes the **Workflow Blueprint** file from [Step 1](workflow-deconstruction-discovery.md), classifies each step on the autonomy spectrum, maps it to AI building blocks, and produces a complete **Workflow Analysis Document** — the first major deliverable. You'll save that document and use it as input for [Step 3](workflow-deconstruction-outputs.md).
+This is the second of three prompts. It takes the **Workflow Blueprint** file from [Step 1](discovery.md), classifies each step on the autonomy spectrum, maps it to AI building blocks, and produces a complete **Workflow Analysis Document** — the first major deliverable. You'll save that document and use it as input for [Step 3](outputs.md).
 
 ## How to Use This
 
@@ -144,7 +144,7 @@ For each priority tier, list the specific steps and what the student needs to bu
 
 After presenting the Workflow Analysis Document, tell me:
 
-> **Next step:** Download (or copy and save) the Workflow Analysis Document file. Then go to [Step 3 — Output Generation](https://handsonai.info/how-to/prompting/workflow-deconstruction-outputs/), copy that prompt into a new conversation, and upload or paste the Analysis Document when the model asks for it.
+> **Next step:** Download (or copy and save) the Workflow Analysis Document file. Then go to [Step 3 — Output Generation](https://handsonai.info/business-first-ai-framework/deconstruct/outputs/), copy that prompt into a new conversation, and upload or paste the Analysis Document when the model asks for it.
 
 ---
 
@@ -169,4 +169,4 @@ The **Workflow Analysis Document** (Deliverable 1) contains:
 - **Tools and connectors** — external integrations required
 - **Recommended implementation order** — prioritized build sequence (quick wins first, complex agent steps last)
 
-This Analysis Document is the input for [Step 3 — Output Generation](workflow-deconstruction-outputs.md), where the model generates your ready-to-use workflow prompt and skill build recommendations.
+This Analysis Document is the input for [Step 3 — Output Generation](outputs.md), where the model generates your ready-to-use workflow prompt and skill build recommendations.

--- a/docs/business-first-ai-framework/deconstruct/discovery.md
+++ b/docs/business-first-ai-framework/deconstruct/discovery.md
@@ -5,9 +5,9 @@ description: Interactively discover and decompose a business workflow into a str
 
 # Step 1 — Discovery & Deep Dive
 
-> **Part of:** [Deconstruct Workflows into AI Building Blocks](workflow-deconstruction-meta-prompt.md)
+> **Part of:** [Deconstruct Workflows](index.md)
 
-This is the first of three prompts that break down a business workflow so you can power it with AI. This prompt handles **scenario discovery** (understanding your workflow) and the **deep dive** (decomposing each step using the 5-question framework). It produces a **Workflow Blueprint** — a Markdown file you'll save and use as input for [Step 2](workflow-deconstruction-analysis.md).
+This is the first of three prompts that break down a business workflow so you can power it with AI. This prompt handles **scenario discovery** (understanding your workflow) and the **deep dive** (decomposing each step using the 5-question framework). It produces a **Workflow Blueprint** — a Markdown file you'll save and use as input for [Step 2](analysis.md).
 
 ## How to Use This
 
@@ -166,7 +166,7 @@ For each artifact:
 
 After presenting the Blueprint, tell me:
 
-> **Next step:** Download (or copy and save) the Workflow Blueprint file. Then go to [Step 2 — Analysis & Mapping](https://handsonai.info/how-to/prompting/workflow-deconstruction-analysis/), copy that prompt into a new conversation, and upload or paste the Blueprint when the model asks for it.
+> **Next step:** Download (or copy and save) the Workflow Blueprint file. Then go to [Step 2 — Analysis & Mapping](https://handsonai.info/business-first-ai-framework/deconstruct/analysis/), copy that prompt into a new conversation, and upload or paste the Blueprint when the model asks for it.
 
 ---
 
@@ -188,4 +188,4 @@ The Workflow Blueprint captures:
 - **Step sequence and dependencies** — what's sequential, what's parallel, where the critical path is
 - **Context shopping list** — every artifact the workflow needs, with status and key contents
 
-This Blueprint is the input for [Step 2 — Analysis & Mapping](workflow-deconstruction-analysis.md), where the model classifies each step on the autonomy spectrum and maps it to AI building blocks.
+This Blueprint is the input for [Step 2 — Analysis & Mapping](analysis.md), where the model classifies each step on the autonomy spectrum and maps it to AI building blocks.

--- a/docs/business-first-ai-framework/deconstruct/index.md
+++ b/docs/business-first-ai-framework/deconstruct/index.md
@@ -1,14 +1,14 @@
 ---
-title: How to Deconstruct Workflows into AI Building Blocks
+title: Deconstruct Workflows
 description: Use this three-prompt series to break down any business workflow into discrete steps, map AI building blocks, and generate an executable workflow prompt.
 ---
 
-# How to Deconstruct Workflows into AI Building Blocks
+# Deconstruct Workflows
 
 > **Platforms:** `claude` `openai` `gemini` `m365-copilot`
 
 !!! info "Business-First AI Framework — Phase 2: Deconstruct"
-    This guide is **Phase 2** of the [Business-First AI Framework](../../business-first-ai-framework.md) — deconstructing workflows into AI building blocks.
+    This guide is **Phase 2** of the [Business-First AI Framework](../index.md) — deconstructing workflows into AI building blocks.
 
 ## What This Is
 
@@ -30,7 +30,7 @@ This series of prompts walks you through that deconstruction interactively. You 
 2. A **Baseline Workflow Prompt** — a ready-to-use prompt that works on any platform; this is your starting point that will evolve as you build skills
 3. **Skill Build Recommendations** — actionable specs for reusable skills you can build to automate recurring steps
 
-This builds directly on the concepts from the course lessons on workflow deconstruction and AI building blocks. If terms like the "5-question framework" or "six building blocks" are new to you, review the [Key Concepts section of the Business-First AI Framework](../../business-first-ai-framework.md#key-concepts) for quick definitions before starting.
+This builds directly on the concepts from the course lessons on workflow deconstruction and AI building blocks. If terms like the "5-question framework" or "six building blocks" are new to you, review the [Key Concepts section of the Business-First AI Framework](../index.md#key-concepts) for quick definitions before starting.
 
 ## The Three-Prompt Approach
 
@@ -38,9 +38,9 @@ The workflow deconstruction is split into three focused prompts. Each prompt pro
 
 | Step | Prompt | What it does | Produces |
 |------|--------|-------------|----------|
-| 1 | [Discovery & Deep Dive](workflow-deconstruction-discovery.md) | Discover the workflow, decompose every step | **Workflow Blueprint** |
-| 2 | [Analysis & Mapping](workflow-deconstruction-analysis.md) | Classify steps, map AI building blocks | **Workflow Analysis Document** |
-| 3 | [Output Generation](workflow-deconstruction-outputs.md) | Generate the executable prompt and skill specs | **Baseline Prompt** + **Skill Recommendations** |
+| 1 | [Discovery & Deep Dive](discovery.md) | Discover the workflow, decompose every step | **Workflow Blueprint** |
+| 2 | [Analysis & Mapping](analysis.md) | Classify steps, map AI building blocks | **Workflow Analysis Document** |
+| 3 | [Output Generation](outputs.md) | Generate the executable prompt and skill specs | **Baseline Prompt** + **Skill Recommendations** |
 
 **Between each step:** Download (or copy and save) the output artifact as a Markdown file, then upload or paste it into the next conversation. Each prompt starts by asking you to provide the previous step's output. The files use a consistent naming convention: `[workflow-name]-blueprint.md`, `[workflow-name]-analysis.md`, `[workflow-name]-prompt.md`, and `[workflow-name]-skill-recs.md`.
 
@@ -58,11 +58,11 @@ There are two ways to run Phase 2, depending on which tools you use:
 
 Use this if you're working in Claude, ChatGPT, Gemini, or M365 Copilot. Copy each prompt into a new conversation and work through the three steps sequentially.
 
-1. **Go to [Step 1 — Discovery & Deep Dive](workflow-deconstruction-discovery.md)** — Copy the prompt, start a new conversation in your AI tool, paste the prompt, and describe your workflow
+1. **Go to [Step 1 — Discovery & Deep Dive](discovery.md)** — Copy the prompt, start a new conversation in your AI tool, paste the prompt, and describe your workflow
 2. **Save the Workflow Blueprint** — Download the `.md` file the model produces (or copy the output and save it as `[workflow-name]-blueprint.md`)
-3. **Go to [Step 2 — Analysis & Mapping](workflow-deconstruction-analysis.md)** — Copy that prompt, start a **new** conversation, paste the prompt, then upload or paste your Blueprint file when the model asks for it
+3. **Go to [Step 2 — Analysis & Mapping](analysis.md)** — Copy that prompt, start a **new** conversation, paste the prompt, then upload or paste your Blueprint file when the model asks for it
 4. **Save the Workflow Analysis Document** — Download `[workflow-name]-analysis.md`
-5. **Go to [Step 3 — Output Generation](workflow-deconstruction-outputs.md)** — Copy that prompt, start a **new** conversation, paste the prompt, then upload or paste your Analysis Document when the model asks for it
+5. **Go to [Step 3 — Output Generation](outputs.md)** — Copy that prompt, start a **new** conversation, paste the prompt, then upload or paste your Analysis Document when the model asks for it
 6. **Save your final deliverables** — Download `[workflow-name]-prompt.md` and `[workflow-name]-skill-recs.md`
 
 !!! tip "Start with a workflow you actually do"
@@ -143,9 +143,9 @@ You don't need to know all the steps before you start — that's what the prompt
 
 ## What to Expect
 
-1. **[Step 1 — Discovery & Deep Dive](workflow-deconstruction-discovery.md)** (~15-25 minutes) — The model asks about your business scenario, objective, steps, and who's involved. Then it works through each step one by one, asking about sub-steps, decision points, data flows, context needs, and failure modes. For later steps, it switches to a "propose and react" pattern — presenting hypotheses for you to correct, which is faster and surfaces more detail. Produces a **Workflow Blueprint**.
-2. **[Step 2 — Analysis & Mapping](workflow-deconstruction-analysis.md)** (~5-10 minutes) — The model classifies each refined step on the autonomy spectrum and maps it to AI building blocks. You review the mapping table and adjust. Produces a **Workflow Analysis Document**.
-3. **[Step 3 — Output Generation](workflow-deconstruction-outputs.md)** (~5-10 minutes) — The model generates your baseline workflow prompt and skill build recommendations. Mostly generative — 1-2 clarifying questions at most. Produces the **Baseline Workflow Prompt** and **Skill Build Recommendations**.
+1. **[Step 1 — Discovery & Deep Dive](discovery.md)** (~15-25 minutes) — The model asks about your business scenario, objective, steps, and who's involved. Then it works through each step one by one, asking about sub-steps, decision points, data flows, context needs, and failure modes. For later steps, it switches to a "propose and react" pattern — presenting hypotheses for you to correct, which is faster and surfaces more detail. Produces a **Workflow Blueprint**.
+2. **[Step 2 — Analysis & Mapping](analysis.md)** (~5-10 minutes) — The model classifies each refined step on the autonomy spectrum and maps it to AI building blocks. You review the mapping table and adjust. Produces a **Workflow Analysis Document**.
+3. **[Step 3 — Output Generation](outputs.md)** (~5-10 minutes) — The model generates your baseline workflow prompt and skill build recommendations. Mostly generative — 1-2 clarifying questions at most. Produces the **Baseline Workflow Prompt** and **Skill Build Recommendations**.
 
 Most workflows expand from 5-8 rough steps to 12-20 refined steps after the deep dive. The baseline prompt is ready to use immediately — paste it into a new conversation to run the workflow.
 
@@ -410,8 +410,8 @@ Most workflows expand from 5-8 rough steps to 12-20 refined steps after the deep
 
 ## Related
 
-- **Previous step:** Not sure which workflow to deconstruct? Start with the [AI Workflow Opportunity Finder](ai-workflow-opportunity-finder.md) (Phase 1) to identify your best candidates.
-- **Next step:** Ready to build? See the [Workflow Examples](../workflow-examples/README.md) (Phase 3) for worked examples across the autonomy spectrum.
-- [Business-First AI Framework](../../business-first-ai-framework.md) — the full three-phase methodology
+- **Previous step:** Not sure which workflow to deconstruct? Start with the [Discover AI Workflow Opportunities](../discover.md) (Phase 1) to identify your best candidates.
+- **Next step:** Ready to build? See the [Build Workflows](../build/index.md) (Phase 3) for worked examples across the autonomy spectrum.
+- [Business-First AI Framework](../index.md) — the full three-phase methodology
 - [Prompt Engineering Fundamentals](../../fundamentals/prompt-engineering/README.md)
 - [Agents & Tools Overview](../../fundamentals/agents-and-tools/README.md)

--- a/docs/business-first-ai-framework/deconstruct/outputs.md
+++ b/docs/business-first-ai-framework/deconstruct/outputs.md
@@ -5,9 +5,9 @@ description: Generate a ready-to-use Baseline Workflow Prompt and Skill Build Re
 
 # Step 3 — Output Generation
 
-> **Part of:** [Deconstruct Workflows into AI Building Blocks](workflow-deconstruction-meta-prompt.md)
+> **Part of:** [Deconstruct Workflows](index.md)
 
-This is the final prompt in the three-part series. It takes the **Workflow Analysis Document** from [Step 2](workflow-deconstruction-analysis.md) and produces your two remaining deliverables: a **Baseline Workflow Prompt** you can paste into any AI tool to run the workflow, and **Skill Build Recommendations** showing which reusable skills to build and what they replace.
+This is the final prompt in the three-part series. It takes the **Workflow Analysis Document** from [Step 2](analysis.md) and produces your two remaining deliverables: a **Baseline Workflow Prompt** you can paste into any AI tool to run the workflow, and **Skill Build Recommendations** showing which reusable skills to build and what they replace.
 
 ## How to Use This
 

--- a/docs/business-first-ai-framework/discover.md
+++ b/docs/business-first-ai-framework/discover.md
@@ -1,14 +1,14 @@
 ---
-title: How to Find AI Workflow Opportunities
+title: Discover AI Workflow Opportunities
 description: Use this prompt template to discover where AI can help automate, augment, or orchestrate your workflows.
 ---
 
-# How to Find AI Workflow Opportunities
+# Discover AI Workflow Opportunities
 
 > **Platforms:** `claude` `openai` `gemini`
 
 !!! info "Business-First AI Framework — Phase 1: Discover"
-    This guide is **Phase 1** of the [Business-First AI Framework](../../business-first-ai-framework.md) — discovering where AI fits in your workflows.
+    This guide is **Phase 1** of the [Business-First AI Framework](index.md) — discovering where AI fits in your workflows.
 
 ## What This Is
 
@@ -47,7 +47,7 @@ Use this if you're working in Claude, ChatGPT, Gemini, or M365 Copilot.
 
 ### Option B: Claude skill
 
-Use this if you're on the Claude platform (Claude Code, Claude.ai, or Cowork). The `finding-ai-opportunities` skill from the [Business First AI plugin](../../plugins/business-first-ai.md) runs the same process interactively.
+Use this if you're on the Claude platform (Claude Code, Claude.ai, or Cowork). The `finding-ai-opportunities` skill from the [Business First AI plugin](../plugins/business-first-ai.md) runs the same process interactively.
 
 **Claude Code or Cowork** — install the plugin and the skill is available immediately:
 
@@ -65,7 +65,7 @@ Use this if you're on the Claude platform (Claude Code, Claude.ai, or Cowork). T
 2. **Upload it** in Claude.ai under **Settings > Capabilities > Upload skill**
 3. **Start a new chat** with the same prompt above — Claude uses the skill automatically
 
-For detailed upload instructions, see [Using Skills in Claude.ai](../../plugins/using-plugins.md#using-skills-in-claudeai-web).
+For detailed upload instructions, see [Using Skills in Claude.ai](../plugins/using-plugins.md#using-skills-in-claudeai-web).
 
 Both options follow the same three-step process and produce the same structured report. Choose whichever fits your workflow.
 
@@ -187,7 +187,7 @@ Most people discover 5–15 opportunities across the three categories. Don't try
 
 ## Related
 
-- **Next step:** Ready to act on an opportunity? Use the [Workflow Deconstruction guide](workflow-deconstruction-meta-prompt.md) (Phase 2) to break it into AI building blocks.
-- [Business-First AI Framework](../../business-first-ai-framework.md) — the full three-phase methodology
-- [Prompt Engineering Fundamentals](../../fundamentals/prompt-engineering/README.md)
-- [Agents & Tools Overview](../../fundamentals/agents-and-tools/README.md)
+- **Next step:** Ready to act on an opportunity? Use the [Deconstruct Workflows guide](deconstruct/index.md) (Phase 2) to break it into AI building blocks.
+- [Business-First AI Framework](index.md) — the full three-phase methodology
+- [Prompt Engineering Fundamentals](../fundamentals/prompt-engineering/README.md)
+- [Agents & Tools Overview](../fundamentals/agents-and-tools/README.md)

--- a/docs/business-first-ai-framework/index.md
+++ b/docs/business-first-ai-framework/index.md
@@ -27,8 +27,8 @@ The audit uses a three-step process: scan what AI already knows about your work,
 
 **Two ways to run Phase 1:**
 
-- **Any AI tool** — Copy the [AI Workflow Opportunity Finder](how-to/prompting/ai-workflow-opportunity-finder.md) prompt into Claude, ChatGPT, Gemini, or M365 Copilot
-- **Claude platform** — Use the `finding-ai-opportunities` skill from the [Business First AI plugin](plugins/business-first-ai.md) in Claude Code, Claude.ai, or Cowork ([setup guide](plugins/using-plugins.md))
+- **Any AI tool** — Copy the [Discover AI Workflow Opportunities](discover.md) prompt into Claude, ChatGPT, Gemini, or M365 Copilot
+- **Claude platform** — Use the `finding-ai-opportunities` skill from the [Business First AI plugin](../plugins/business-first-ai.md) in Claude Code, Claude.ai, or Cowork ([setup guide](../plugins/using-plugins.md))
 
 ---
 
@@ -54,8 +54,8 @@ Each step gets mapped to one or more of the **six AI building blocks**: Prompt, 
 
 **Two ways to run Phase 2:**
 
-- **Any AI tool** — Copy the [Workflow Deconstruction](how-to/prompting/workflow-deconstruction-meta-prompt.md) prompts into Claude, ChatGPT, Gemini, or M365 Copilot
-- **Claude platform** — Use the `workflow-deconstructor` agent or individual deconstruction skills from the [Business First AI plugin](plugins/business-first-ai.md) in Claude Code, Claude.ai, or Cowork ([setup guide](plugins/using-plugins.md))
+- **Any AI tool** — Copy the [Deconstruct Workflows](deconstruct/index.md) prompts into Claude, ChatGPT, Gemini, or M365 Copilot
+- **Claude platform** — Use the `workflow-deconstructor` agent or individual deconstruction skills from the [Business First AI plugin](../plugins/business-first-ai.md) in Claude Code, Claude.ai, or Cowork ([setup guide](../plugins/using-plugins.md))
 
 ---
 
@@ -65,11 +65,11 @@ Turn your deconstruction outputs into working AI workflows.
 
 Phase 2 produces two actionable deliverables: a Baseline Workflow Prompt you can run immediately, and Skill Build Recommendations that tell you what to build next. Phase 3 is where those become real.
 
-The [Workflow Examples](how-to/workflow-examples/README.md) show three worked examples across the autonomy spectrum — from deterministic automation to collaborative workflows to fully autonomous multi-agent pipelines. Each includes working building blocks you can install and study.
+The [Build Workflows](build/index.md) examples show three worked examples across the autonomy spectrum — from deterministic automation to collaborative workflows to fully autonomous multi-agent pipelines. Each includes working building blocks you can install and study.
 
 This section will grow with guides on building prompts, skills, agents, and multi-agent workflows from deconstruction output.
 
-**[See Phase 3 — Workflow Examples](how-to/workflow-examples/README.md)**
+**[See Phase 3 — Build Workflows](build/index.md)**
 
 ---
 
@@ -117,15 +117,15 @@ Used to decompose each workflow step:
 
 ## Getting Started
 
-1. **Start with the [Opportunity Finder](how-to/prompting/ai-workflow-opportunity-finder.md)** to identify your best candidates
+1. **Start with the [Opportunity Finder](discover.md)** to identify your best candidates
 2. **Pick your highest-impact opportunity** — don't try to pursue everything at once
-3. **Run it through the [Deconstruction process](how-to/prompting/workflow-deconstruction-meta-prompt.md)** to break it into AI building blocks
+3. **Run it through the [Deconstruction process](deconstruct/index.md)** to break it into AI building blocks
 4. **Test the Baseline Prompt** on a real scenario — paste the generated prompt into any AI tool and run the workflow
 5. **Build skills in priority order** from the Skill Build Recommendations — each skill you build replaces steps in the baseline prompt, making the workflow progressively more automated
 
 ## Tools
 
-For Claude platform users (Claude Code, Claude.ai, or Cowork), the [Business First AI plugin](plugins/business-first-ai.md) implements all three phases as executable skills you can run interactively:
+For Claude platform users (Claude Code, Claude.ai, or Cowork), the [Business First AI plugin](../plugins/business-first-ai.md) implements all three phases as executable skills you can run interactively:
 
 ```bash
 /plugin install business-first-ai@handsonai

--- a/docs/fundamentals/developer-setup/notion-registry-setup.md
+++ b/docs/fundamentals/developer-setup/notion-registry-setup.md
@@ -169,8 +169,8 @@ See the [AI Registry plugin page](../../plugins/index.md#ai-registry) for full d
 
 - **Add your first process** — Start with one business domain you know well
 - **Document existing workflows** — Capture what you're already doing before adding AI
-- **Find AI opportunities** — Use the [AI Workflow Opportunity Finder](../../how-to/prompting/ai-workflow-opportunity-finder.md) to identify where AI can add value
-- **Deconstruct workflows** — Break workflows into AI building blocks with the [Workflow Deconstruction Meta-Prompt](../../how-to/prompting/workflow-deconstruction-meta-prompt.md)
+- **Find AI opportunities** — Use the [Discover AI Workflow Opportunities](../../business-first-ai-framework/discover.md) guide to identify where AI can add value
+- **Deconstruct workflows** — Break workflows into AI building blocks with the [Deconstruct Workflows](../../business-first-ai-framework/deconstruct/index.md) guide
 - **Install the plugin** — Set up the [AI Registry plugin](../../plugins/index.md#ai-registry) to automate registry updates
 - **Explore other setup guides** — Continue with [Claude Code Installation](claude-code-install.md) if you haven't already
 

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -14,7 +14,7 @@ Problem-focused guides that help you accomplish specific tasks.
 | [Prompting](./prompting/) | Prompt engineering techniques |
 | [Agents](./agents/) | Agent and tool use guides |
 | [Integrations](./integrations/) | Platform integration guides |
-| [Workflow Examples](./workflow-examples/) | Worked examples across the AI automation spectrum |
+| [Build Workflows](../business-first-ai-framework/build/index.md) | Worked examples across the AI automation spectrum |
 
 ## All Guides
 

--- a/docs/how-to/prompting/README.md
+++ b/docs/how-to/prompting/README.md
@@ -9,7 +9,7 @@ Guides for prompt engineering techniques and best practices.
 
 ## Guides
 
-- [How to Find AI Workflow Opportunities](./ai-workflow-opportunity-finder.md) — Discover where AI can automate, augment, or orchestrate your workflows
+- [Discover AI Workflow Opportunities](../../business-first-ai-framework/discover.md) — Discover where AI can automate, augment, or orchestrate your workflows
 
 ## Topics Covered
 

--- a/docs/how-to/prompting/workspace-instructions-meta-prompt.md
+++ b/docs/how-to/prompting/workspace-instructions-meta-prompt.md
@@ -211,5 +211,5 @@ Most students go from "I'm not sure what I want" to finished instructions in 10-
 
 - [Set Up Claude Projects](../../platforms/claude/projects/claude-projects-setup.md) — How to create and configure Claude Projects
 - [What Is a System Prompt?](../../questions/prompting/what-is-a-system-prompt.md) — Understanding how custom instructions work under the hood
-- [Deconstruct Workflows into AI Building Blocks](./workflow-deconstruction-meta-prompt.md) — Break down workflows before building workspaces for them
+- [Deconstruct Workflows](../../business-first-ai-framework/deconstruct/index.md) — Break down workflows before building workspaces for them
 - [Prompt Engineering Fundamentals](../../fundamentals/prompt-engineering/README.md)

--- a/docs/platforms/claude/skills/skills-discovery-meta-prompt.md
+++ b/docs/platforms/claude/skills/skills-discovery-meta-prompt.md
@@ -277,7 +277,7 @@ You now have evaluated skill candidates ranked by value. Here's what to do with 
 
 ## Related
 
-- [Find AI Workflow Opportunities](../../../how-to/prompting/ai-workflow-opportunity-finder.md) — Discover which workflows have the highest AI potential
-- [Deconstruct Workflows into AI Building Blocks](../../../how-to/prompting/workflow-deconstruction-meta-prompt.md) — Break down complex workflows into discrete, automatable steps
+- [Discover AI Workflow Opportunities](../../../business-first-ai-framework/discover.md) — Discover which workflows have the highest AI potential
+- [Deconstruct Workflows](../../../business-first-ai-framework/deconstruct/index.md) — Break down complex workflows into discrete, automatable steps
 - [Write Custom Workspace Instructions](../../../how-to/prompting/workspace-instructions-meta-prompt.md) — Set up Claude Projects with tailored instructions
 - [Claude Projects Setup](../projects/claude-projects-setup.md) — Set up Claude Projects for recurring work

--- a/docs/plugins/business-first-ai.md
+++ b/docs/plugins/business-first-ai.md
@@ -5,7 +5,7 @@ description: The Business-First AI Framework as executable Claude Code skills â€
 
 # Business First AI
 
-This plugin implements the [Business-First AI Framework](../business-first-ai-framework.md) as executable Claude Code skills. It covers all three phases: discover where AI fits in your workflows, deconstruct those workflows into AI building blocks, and build with worked examples across the autonomy spectrum. Install it to get a complete toolkit for going from "where should I use AI?" to working AI workflows.
+This plugin implements the [Business-First AI Framework](../business-first-ai-framework/index.md) as executable Claude Code skills. It covers all three phases: discover where AI fits in your workflows, deconstruct those workflows into AI building blocks, and build with worked examples across the autonomy spectrum. Install it to get a complete toolkit for going from "where should I use AI?" to working AI workflows.
 
 ## Install
 

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -41,7 +41,7 @@ For the full details on how marketplaces and plugin installation work, see the o
 
 ## :material-rocket-launch: Business First AI
 
-The [Business-First AI Framework](../business-first-ai-framework.md) as executable Claude Code skills. Discover AI workflow opportunities (Phase 1), deconstruct workflows into AI building blocks (Phase 2), and build with worked examples across the autonomy spectrum (Phase 3).
+The [Business-First AI Framework](../business-first-ai-framework/index.md) as executable Claude Code skills. Discover AI workflow opportunities (Phase 1), deconstruct workflows into AI building blocks (Phase 2), and build with worked examples across the autonomy spectrum (Phase 3).
 
 ```bash
 /plugin install business-first-ai@handsonai

--- a/docs/questions/strategy/README.md
+++ b/docs/questions/strategy/README.md
@@ -16,5 +16,5 @@ Questions about AI strategy, workflow analysis, opportunity identification, and 
 
 ## Related Resources
 
-- [AI Workflow Opportunity Finder](../../how-to/prompting/ai-workflow-opportunity-finder.md)
-- [Workflow Deconstruction Meta-Prompt](../../how-to/prompting/workflow-deconstruction-meta-prompt.md)
+- [Discover AI Workflow Opportunities](../../business-first-ai-framework/discover.md)
+- [Deconstruct Workflows](../../business-first-ai-framework/deconstruct/index.md)

--- a/docs/questions/strategy/how-do-i-find-workflows-worth-applying-ai-to.md
+++ b/docs/questions/strategy/how-do-i-find-workflows-worth-applying-ai-to.md
@@ -13,20 +13,20 @@ author: James Gray
 
 ## The Full Answer
 
-Most people adopt AI reactively — they reach for ChatGPT when stuck on an email or ask Claude to summarize a document. That's useful, but it misses the bigger picture. The [Business-First AI Framework](../../business-first-ai-framework.md) provides a structured three-phase approach to this question — discover where AI fits, deconstruct those workflows into building blocks, then build.
+Most people adopt AI reactively — they reach for ChatGPT when stuck on an email or ask Claude to summarize a document. That's useful, but it misses the bigger picture. The [Business-First AI Framework](../../business-first-ai-framework/index.md) provides a structured three-phase approach to this question — discover where AI fits, deconstruct those workflows into building blocks, then build.
 
 A proactive, structured audit of your workflows will reveal opportunities you'd never notice in the moment: repetitive tasks that could run on autopilot, decisions that benefit from an AI collaborator, and multi-step processes that could be orchestrated end-to-end.
 
 The key is thinking in three categories. **Collaborative AI** covers tasks where you and AI work together in real time — drafting, brainstorming, reviewing, analyzing. **Deterministic workflows** are repeatable processes with clear inputs and outputs that AI can execute reliably with little supervision — formatting reports, processing forms, generating routine communications. **Multi-agent systems** are complex workflows where multiple AI agents coordinate across steps — research-to-report pipelines, intake-to-triage systems, monitoring-to-response workflows.
 
-To run the audit, use the [AI Workflow Opportunity Finder](../../how-to/prompting/ai-workflow-opportunity-finder.md) — a meta prompt that guides an AI through a three-phase process: scanning what it already knows about your work, interviewing you to fill gaps, then producing a categorized report with specific opportunities and actionable first steps.
+To run the audit, use the [Discover AI Workflow Opportunities](../../business-first-ai-framework/discover.md) — a meta prompt that guides an AI through a three-phase process: scanning what it already knows about your work, interviewing you to fill gaps, then producing a categorized report with specific opportunities and actionable first steps.
 
-Once you've identified opportunities, use the [Workflow Deconstruction Meta-Prompt](../../how-to/prompting/workflow-deconstruction-meta-prompt.md) to break individual workflows into AI building blocks and understand exactly where automation fits.
+Once you've identified opportunities, use the [Deconstruct Workflows](../../business-first-ai-framework/deconstruct/index.md) to break individual workflows into AI building blocks and understand exactly where automation fits.
 
 ## How to Get Started
 
 1. **Enable memory** in your AI tool of choice (Claude, ChatGPT, or Gemini) so the AI can draw on what it already knows about your work
-2. **Copy the prompt** from the [AI Workflow Opportunity Finder](../../how-to/prompting/ai-workflow-opportunity-finder.md)
+2. **Copy the prompt** from the [Discover AI Workflow Opportunities](../../business-first-ai-framework/discover.md)
 3. **Paste it into any conversation** — the AI will scan its context, interview you, and produce a structured report
 4. **Pick 1-2 opportunities** to pilot first — don't try to pursue everything at once
 
@@ -37,7 +37,7 @@ Once you've identified opportunities, use the [Workflow Deconstruction Meta-Prom
 
 - Don't wait for problems — proactively audit your workflows to find AI opportunities
 - Think in three categories: collaborative AI, deterministic workflows, and multi-agent systems
-- Use the [AI Workflow Opportunity Finder](../../how-to/prompting/ai-workflow-opportunity-finder.md) meta prompt to run a structured audit
+- Use the [Discover AI Workflow Opportunities](../../business-first-ai-framework/discover.md) meta prompt to run a structured audit
 - The richer context your AI has about your work, the better the recommendations
 - Start small — pick 1-2 opportunities and pilot them before scaling
 

--- a/docs/questions/strategy/how-do-i-identify-the-right-ai-tools-for-a-workflow.md
+++ b/docs/questions/strategy/how-do-i-identify-the-right-ai-tools-for-a-workflow.md
@@ -13,7 +13,7 @@ author: James Gray
 
 ## The Full Answer
 
-You can't choose the right AI tools for a workflow you don't fully understand. The [Business-First AI Framework](../../business-first-ai-framework.md) addresses this with a structured approach: discover opportunities first, then deconstruct workflows into building blocks before selecting tools.
+You can't choose the right AI tools for a workflow you don't fully understand. The [Business-First AI Framework](../../business-first-ai-framework/index.md) addresses this with a structured approach: discover opportunities first, then deconstruct workflows into building blocks before selecting tools.
 
 Most people jump straight to tool selection — "Should I use an agent? Do I need an API?" — before they've properly decomposed what the workflow actually involves. The result is over-engineered solutions for simple problems, or under-powered tools for complex ones.
 
@@ -34,7 +34,7 @@ Not every step needs AI. The deconstruction also classifies each step on an auto
 
 ## How to Get Started
 
-Use the [Workflow Deconstruction Meta-Prompt](../../how-to/prompting/workflow-deconstruction-meta-prompt.md) to run through this process interactively. Paste it into any AI tool and it will:
+Use the [Deconstruct Workflows](../../business-first-ai-framework/deconstruct/index.md) to run through this process interactively. Paste it into any AI tool and it will:
 
 1. **Discover your scenario** — understand the workflow objective and rough steps
 2. **Deep dive into each step** — apply the 5-question framework
@@ -50,7 +50,7 @@ Use the [Workflow Deconstruction Meta-Prompt](../../how-to/prompting/workflow-de
 - Use the 5-question framework: discrete steps, decision points, data flows, context needs, and failure modes
 - Map each step to one of six building blocks: Prompt, Context, Skill, Agent, MCP, or Project
 - Not every step needs AI — the autonomy classification helps you see which steps are candidates and which should stay manual
-- Use the [Workflow Deconstruction Meta-Prompt](../../how-to/prompting/workflow-deconstruction-meta-prompt.md) to run through this process interactively
+- Use the [Deconstruct Workflows](../../business-first-ai-framework/deconstruct/index.md) to run through this process interactively
 
 ## Related Questions
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,7 +49,16 @@ plugins:
       enable_creation_date: true
       fallback_to_build_date: true
   - redirects:
-      redirect_maps: {}
+      redirect_maps:
+        how-to/prompting/ai-workflow-opportunity-finder.md: business-first-ai-framework/discover.md
+        how-to/prompting/workflow-deconstruction-meta-prompt.md: business-first-ai-framework/deconstruct/index.md
+        how-to/prompting/workflow-deconstruction-discovery.md: business-first-ai-framework/deconstruct/discovery.md
+        how-to/prompting/workflow-deconstruction-analysis.md: business-first-ai-framework/deconstruct/analysis.md
+        how-to/prompting/workflow-deconstruction-outputs.md: business-first-ai-framework/deconstruct/outputs.md
+        how-to/workflow-examples/README.md: business-first-ai-framework/build/index.md
+        how-to/workflow-examples/deterministic-automation.md: business-first-ai-framework/build/deterministic-automation.md
+        how-to/workflow-examples/ai-collaborative.md: business-first-ai-framework/build/ai-collaborative.md
+        how-to/workflow-examples/autonomous-agent.md: business-first-ai-framework/build/autonomous-agent.md
 
 markdown_extensions:
   - admonition
@@ -73,18 +82,18 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Business-First AI Framework:
-    - Overview: business-first-ai-framework.md
-    - "Phase 1 — Discover": how-to/prompting/ai-workflow-opportunity-finder.md
+    - Overview: business-first-ai-framework/index.md
+    - "Phase 1 — Discover": business-first-ai-framework/discover.md
     - "Phase 2 — Deconstruct":
-      - Overview: how-to/prompting/workflow-deconstruction-meta-prompt.md
-      - "Step 1 — Discovery & Deep Dive": how-to/prompting/workflow-deconstruction-discovery.md
-      - "Step 2 — Analysis & Mapping": how-to/prompting/workflow-deconstruction-analysis.md
-      - "Step 3 — Output Generation": how-to/prompting/workflow-deconstruction-outputs.md
+      - Overview: business-first-ai-framework/deconstruct/index.md
+      - "Step 1 — Discovery & Deep Dive": business-first-ai-framework/deconstruct/discovery.md
+      - "Step 2 — Analysis & Mapping": business-first-ai-framework/deconstruct/analysis.md
+      - "Step 3 — Output Generation": business-first-ai-framework/deconstruct/outputs.md
     - "Phase 3 — Build":
-      - Overview: how-to/workflow-examples/README.md
-      - Deterministic Automation: how-to/workflow-examples/deterministic-automation.md
-      - AI Collaborative: how-to/workflow-examples/ai-collaborative.md
-      - Autonomous Agent: how-to/workflow-examples/autonomous-agent.md
+      - Overview: business-first-ai-framework/build/index.md
+      - Deterministic Automation: business-first-ai-framework/build/deterministic-automation.md
+      - AI Collaborative: business-first-ai-framework/build/ai-collaborative.md
+      - Autonomous Agent: business-first-ai-framework/build/autonomous-agent.md
   - Platforms:
     - Overview: platforms/index.md
     - Claude:


### PR DESCRIPTION
## Summary

- Move all 10 Business-First AI Framework pages under a unified `/business-first-ai-framework/` URL path with discover/deconstruct/build hierarchy
- Add 301 redirects for all 9 moved URLs (overview URL unchanged) via mkdocs-redirects plugin
- Update nav section in mkdocs.yml to point to new file locations
- Fix cross-references in all 10 framework pages and 11 external pages that link into the framework
- Update link text to match new page titles (Discover/Deconstruct/Build)

## Test plan

- [ ] `mkdocs build` passes with no new warnings
- [ ] All 9 old URLs redirect correctly (verify redirect_maps syntax)
- [ ] Every relative link in framework pages resolves (no broken links in build output)
- [ ] Every external reference resolves (no broken links in build output)
- [ ] Page titles show correctly in nav and on pages
- [ ] `git diff --stat` confirms all 10 files show as renames

🤖 Generated with [Claude Code](https://claude.com/claude-code)