### PR TITLE
Add Cowork tab and clarify platform options across plugin docs

### DIFF
--- a/docs/business-first-ai-framework/deconstruct/analysis.md
+++ b/docs/business-first-ai-framework/deconstruct/analysis.md
@@ -25,7 +25,7 @@ There are two ways to run Step 2, depending on which tools you use:
 
 ### Option B: Claude skill
 
-Use the `analyzing-workflows` skill from the [Business First AI plugin](../../plugins/business-first-ai.md). It reads the Blueprint from Step 1, runs the analysis, and saves the Workflow Analysis Document automatically.
+Use the `analyzing-workflows` skill from the [Business-First AI plugin](../../plugins/business-first-ai.md). It reads the Blueprint from Step 1, runs the analysis, and saves the Workflow Analysis Document automatically.
 
 - **Claude Code or Cowork** — install the plugin (`/plugin install business-first-ai@handsonai`) and start with:
     ```

--- a/docs/business-first-ai-framework/deconstruct/discovery.md
+++ b/docs/business-first-ai-framework/deconstruct/discovery.md
@@ -24,7 +24,7 @@ There are two ways to run Step 1, depending on which tools you use:
 
 ### Option B: Claude skill
 
-Use the `discovering-workflows` skill from the [Business First AI plugin](../../plugins/business-first-ai.md). It runs the same discovery and deep dive process and saves the Blueprint to a file automatically.
+Use the `discovering-workflows` skill from the [Business-First AI plugin](../../plugins/business-first-ai.md). It runs the same discovery and deep dive process and saves the Blueprint to a file automatically.
 
 - **Claude Code or Cowork** — install the plugin (`/plugin install business-first-ai@handsonai`) and start with:
     ```

--- a/docs/business-first-ai-framework/deconstruct/index.md
+++ b/docs/business-first-ai-framework/deconstruct/index.md
@@ -52,50 +52,73 @@ Splitting into three prompts keeps each conversation comfortably under 15K token
 
 ## How to Use This
 
-There are two ways to run Phase 2, depending on which tools you use:
+There are four ways to run Phase 2, depending on which tools you use:
 
-### Option A: Prompt templates (any AI tool)
+=== "Any AI Tool"
 
-Use this if you're working in Claude, ChatGPT, Gemini, or M365 Copilot. Copy each prompt into a new conversation and work through the three steps sequentially.
+    Use this if you're working in ChatGPT, Gemini, M365 Copilot, or any AI chat tool. Copy each prompt into a new conversation and work through the three steps sequentially.
 
-1. **Go to [Step 1 — Discovery & Deep Dive](discovery.md)** — Copy the prompt, start a new conversation in your AI tool, paste the prompt, and describe your workflow
-2. **Save the Workflow Blueprint** — Download the `.md` file the model produces (or copy the output and save it as `[workflow-name]-blueprint.md`)
-3. **Go to [Step 2 — Analysis & Mapping](analysis.md)** — Copy that prompt, start a **new** conversation, paste the prompt, then upload or paste your Blueprint file when the model asks for it
-4. **Save the Workflow Analysis Document** — Download `[workflow-name]-analysis.md`
-5. **Go to [Step 3 — Output Generation](outputs.md)** — Copy that prompt, start a **new** conversation, paste the prompt, then upload or paste your Analysis Document when the model asks for it
-6. **Save your final deliverables** — Download `[workflow-name]-prompt.md` and `[workflow-name]-skill-recs.md`
+    1. **Go to [Step 1 — Discovery & Deep Dive](discovery.md)** — Copy the prompt, start a new conversation, paste the prompt, and describe your workflow
+    2. **Save the Workflow Blueprint** — Download the `.md` file the model produces (or copy the output and save it as `[workflow-name]-blueprint.md`)
+    3. **Go to [Step 2 — Analysis & Mapping](analysis.md)** — Copy that prompt, start a **new** conversation, paste the prompt, then upload or paste your Blueprint file
+    4. **Save the Workflow Analysis Document** — Download `[workflow-name]-analysis.md`
+    5. **Go to [Step 3 — Output Generation](outputs.md)** — Copy that prompt, start a **new** conversation, paste the prompt, then upload or paste your Analysis Document
+    6. **Save your final deliverables** — Download `[workflow-name]-prompt.md` and `[workflow-name]-skill-recs.md`
+
+=== "Claude Code"
+
+    Use this if you have Claude Code installed. The `workflow-deconstructor` **agent** from the [Business-First AI plugin](../../plugins/business-first-ai.md) orchestrates all three steps automatically — running discovery, analysis, and output generation in sequence with file-based handoffs between stages.
+
+    1. **Install the plugin** — `/plugin install business-first-ai@handsonai`
+    2. **Start with this prompt:**
+        ```
+        I want to deconstruct my [workflow name] workflow into AI building
+        blocks. Walk me through the full process.
+        ```
+        The `workflow-deconstructor` agent activates and walks you through all three steps.
+    3. **Review the outputs** — deliverables are saved to the `outputs/` directory
+
+    You can also run individual steps using the skills directly: `discovering-workflows`, `analyzing-workflows`, `generating-workflow-outputs`.
+
+=== "Cowork"
+
+    Use this if you have Claude Desktop on macOS. The `workflow-deconstructor` agent works in Cowork the same way it does in Claude Code — orchestrating all three steps automatically through a visual interface.
+
+    1. **Add the plugin to Cowork** — click the **+** button, select **Add plugins...**, and upload the plugin ZIP
+    2. **Start with this prompt:**
+        ```
+        I want to deconstruct my [workflow name] workflow into AI building
+        blocks. Walk me through the full process.
+        ```
+    3. **Review the outputs** — deliverables are saved to the `outputs/` directory
+
+    You can also run individual steps using the skills directly: `discovering-workflows`, `analyzing-workflows`, `generating-workflow-outputs`.
+
+    For Cowork setup details, see [Using Plugins in Cowork](../../plugins/using-plugins.md#using-plugins-in-claude-cowork).
+
+=== "Claude.ai"
+
+    Use this if you prefer working in the Claude.ai web interface. You'll upload individual skills as ZIP files and run the three steps in separate conversations.
+
+    **Prerequisites:** You need Claude Code installed first to access the skill files. Install the plugin in Claude Code (`/plugin install business-first-ai@handsonai`), then follow these steps:
+
+    1. **Find the skills folder** — `~/.claude/plugins/marketplaces/handsonai/plugins/business-first-ai/skills/`
+    2. **Zip each skill** you want to use (`discovering-workflows`, `analyzing-workflows`, `generating-workflow-outputs`)
+    3. **Upload each skill** in Claude.ai under **Settings > Capabilities > Upload skill**
+    4. **Run each step in a separate conversation**, saving the output file between steps
+
+    For detailed upload instructions, see [Using Skills in Claude.ai](../../plugins/using-plugins.md#using-skills-in-claudeai-web).
+
+    !!! warning "The orchestrator agent doesn't work in Claude.ai"
+        The `workflow-deconstructor` agent (which orchestrates all three steps in one session) only works in Claude Code or Cowork. In Claude.ai, you run the three skills individually and pass the output files between conversations — same process, just manual handoffs.
+
+All four options follow the same process and produce the same deliverables. Choose whichever fits your setup.
 
 !!! tip "Start with a workflow you actually do"
     Real workflows produce the best results. The model will surface hidden steps and assumptions you've internalized — that's much harder with hypothetical processes. If you don't have an existing workflow but have a clear problem to solve, that works too — the model will help you design one.
 
 !!! tip "Keep your files together"
     By the end you'll have four Markdown files: `[name]-blueprint.md`, `[name]-analysis.md`, `[name]-prompt.md`, and `[name]-skill-recs.md`. Keep them in a single folder — they form a complete record of your workflow deconstruction. You can share any of these files with your instructor for feedback, put them in version control, or hand them to a colleague.
-
-### Option B: Claude skills
-
-Use this if you're on the Claude platform (Claude Code, Claude.ai, or Cowork). The [Business First AI plugin](../../plugins/business-first-ai.md) includes the `workflow-deconstructor` agent (which orchestrates all three steps) and individual skills for each step (`discovering-workflows`, `analyzing-workflows`, `generating-workflow-outputs`).
-
-**Claude Code or Cowork** — install the plugin and everything is available immediately:
-
-1. **Install the plugin** — `/plugin install business-first-ai@handsonai`
-2. **Start with this prompt:**
-    ```
-    I want to deconstruct my [workflow name] workflow into AI building
-    blocks. Walk me through the full process.
-    ```
-    The `workflow-deconstructor` agent activates and walks you through all three steps automatically.
-3. **Review the outputs** — deliverables are saved to the `outputs/` directory
-
-**Claude.ai** — upload individual skills as ZIP files:
-
-1. **Zip the skill folder** you want to use (e.g., `discovering-workflows`) from `~/.claude/plugins/marketplaces/handsonai/plugins/business-first-ai/skills/`
-2. **Upload it** in Claude.ai under **Settings > Capabilities > Upload skill**
-3. **Start a new chat** with the same prompt above — Claude uses the skill automatically
-4. **Repeat** for each step's skill, or upload all three at once
-
-For detailed upload instructions, see [Using Skills in Claude.ai](../../plugins/using-plugins.md#using-skills-in-claudeai-web).
-
-Both options follow the same process and produce the same deliverables. Choose whichever fits your workflow.
 
 ### Example: What the first exchange looks like
 

--- a/docs/business-first-ai-framework/deconstruct/outputs.md
+++ b/docs/business-first-ai-framework/deconstruct/outputs.md
@@ -24,7 +24,7 @@ There are two ways to run Step 3, depending on which tools you use:
 
 ### Option B: Claude skill
 
-Use the `generating-workflow-outputs` skill from the [Business First AI plugin](../../plugins/business-first-ai.md). It reads the Analysis Document from Step 2 and generates both deliverables automatically.
+Use the `generating-workflow-outputs` skill from the [Business-First AI plugin](../../plugins/business-first-ai.md). It reads the Analysis Document from Step 2 and generates both deliverables automatically.
 
 - **Claude Code or Cowork** — install the plugin (`/plugin install business-first-ai@handsonai`) and start with:
     ```

--- a/docs/business-first-ai-framework/discover.md
+++ b/docs/business-first-ai-framework/discover.md
@@ -34,40 +34,57 @@ This prompt template guides an AI through a structured analysis of your work and
 
 ## How to Use This
 
-There are two ways to run Phase 1, depending on which tools you use:
+There are four ways to run Phase 1, depending on which tools you use:
 
-### Option A: Prompt template (any AI tool)
+=== "Any AI Tool"
 
-Use this if you're working in Claude, ChatGPT, Gemini, or M365 Copilot.
+    Use this if you're working in ChatGPT, Gemini, M365 Copilot, or any AI chat tool.
 
-1. **Make sure memory is enabled** in your AI tool of choice — this lets the AI draw on everything it knows about you from past conversations
-2. **Copy the prompt** from the code block below
-3. **Paste it into any conversation** — the AI will automatically scan its memory for context about your role, tasks, and workflows
-4. **Review the output** and pick one or two opportunities to pilot first
+    1. **Make sure memory is enabled** in your AI tool of choice — this lets the AI draw on everything it knows about you from past conversations
+    2. **Copy the prompt** from the [Prompt Template](#the-prompt-template) section below
+    3. **Paste it into any conversation** — the AI will automatically scan its memory for context about your role, tasks, and workflows
+    4. **Review the output** and pick one or two opportunities to pilot first
 
-### Option B: Claude skill
+=== "Claude Code"
 
-Use this if you're on the Claude platform (Claude Code, Claude.ai, or Cowork). The `finding-ai-opportunities` skill from the [Business First AI plugin](../plugins/business-first-ai.md) runs the same process interactively.
+    Use this if you have Claude Code installed. The `finding-ai-opportunities` skill from the [Business-First AI plugin](../plugins/business-first-ai.md) runs the same process interactively.
 
-**Claude Code or Cowork** — install the plugin and the skill is available immediately:
+    1. **Install the plugin** — `/plugin install business-first-ai@handsonai`
+    2. **Start with this prompt:**
+        ```
+        I'd like to find AI opportunities in my workflows. Help me audit
+        what I do and identify where AI could help.
+        ```
+    3. **Review the output** — the report is saved to `outputs/ai-opportunity-report.md`
 
-1. **Install the plugin** — `/plugin install business-first-ai@handsonai`
-2. **Start with this prompt:**
-    ```
-    I'd like to find AI opportunities in my workflows. Help me audit
-    what I do and identify where AI could help.
-    ```
-3. **Review the output** — the report is saved to `outputs/ai-opportunity-report.md`
+=== "Cowork"
 
-**Claude.ai** — upload the skill as a ZIP file:
+    Use this if you have Claude Desktop on macOS. The `finding-ai-opportunities` skill works in Cowork the same way it does in Claude Code — through a visual interface with no terminal required.
 
-1. **Zip the skill folder** from `~/.claude/plugins/marketplaces/handsonai/plugins/business-first-ai/skills/finding-ai-opportunities/`
-2. **Upload it** in Claude.ai under **Settings > Capabilities > Upload skill**
-3. **Start a new chat** with the same prompt above — Claude uses the skill automatically
+    1. **Add the plugin to Cowork** — click the **+** button, select **Add plugins...**, and upload the plugin ZIP
+    2. **Start with this prompt:**
+        ```
+        I'd like to find AI opportunities in my workflows. Help me audit
+        what I do and identify where AI could help.
+        ```
+    3. **Review the output** — the report is saved to `outputs/ai-opportunity-report.md`
 
-For detailed upload instructions, see [Using Skills in Claude.ai](../plugins/using-plugins.md#using-skills-in-claudeai-web).
+    For Cowork setup details, see [Using Plugins in Cowork](../plugins/using-plugins.md#using-plugins-in-claude-cowork).
 
-Both options follow the same three-step process and produce the same structured report. Choose whichever fits your workflow.
+=== "Claude.ai"
+
+    Use this if you prefer working in the Claude.ai web interface. You'll upload the skill as a ZIP file.
+
+    **Prerequisites:** You need Claude Code installed first to access the skill files. Install the plugin in Claude Code (`/plugin install business-first-ai@handsonai`), then follow these steps:
+
+    1. **Find the skill folder** — `~/.claude/plugins/marketplaces/handsonai/plugins/business-first-ai/skills/finding-ai-opportunities/`
+    2. **Zip the folder**
+    3. **Upload it** in Claude.ai under **Settings > Capabilities > Upload skill**
+    4. **Start a new chat** with the same prompt above — Claude uses the skill automatically
+
+    For detailed upload instructions, see [Using Skills in Claude.ai](../plugins/using-plugins.md#using-skills-in-claudeai-web).
+
+All four options follow the same three-step process and produce the same structured report. Choose whichever fits your workflow.
 
 !!! tip "Best results come from rich context"
     The more the AI knows about your actual work, the better the recommendations. If possible, use a tool where you've had many prior conversations or uploaded relevant documents.

--- a/docs/business-first-ai-framework/index.md
+++ b/docs/business-first-ai-framework/index.md
@@ -28,7 +28,7 @@ The audit uses a three-step process: scan what AI already knows about your work,
 **Two ways to run Phase 1:**
 
 - **Any AI tool** — Copy the [Discover AI Workflow Opportunities](discover.md) prompt into Claude, ChatGPT, Gemini, or M365 Copilot
-- **Claude platform** — Use the `finding-ai-opportunities` skill from the [Business First AI plugin](../plugins/business-first-ai.md) in Claude Code, Claude.ai, or Cowork ([setup guide](../plugins/using-plugins.md))
+- **Claude platform** — Use the `finding-ai-opportunities` skill from the [Business-First AI plugin](../plugins/business-first-ai.md) in Claude Code, Claude.ai, or Cowork ([setup guide](../plugins/using-plugins.md))
 
 ---
 
@@ -55,7 +55,7 @@ Each step gets mapped to one or more of the **six AI building blocks**: Prompt, 
 **Two ways to run Phase 2:**
 
 - **Any AI tool** — Copy the [Deconstruct Workflows](deconstruct/index.md) prompts into Claude, ChatGPT, Gemini, or M365 Copilot
-- **Claude platform** — Use the `workflow-deconstructor` agent or individual deconstruction skills from the [Business First AI plugin](../plugins/business-first-ai.md) in Claude Code, Claude.ai, or Cowork ([setup guide](../plugins/using-plugins.md))
+- **Claude platform** — Use the `workflow-deconstructor` agent or individual deconstruction skills from the [Business-First AI plugin](../plugins/business-first-ai.md) in Claude Code, Claude.ai, or Cowork ([setup guide](../plugins/using-plugins.md))
 
 ---
 
@@ -125,7 +125,7 @@ Used to decompose each workflow step:
 
 ## Tools
 
-For Claude platform users (Claude Code, Claude.ai, or Cowork), the [Business First AI plugin](../plugins/business-first-ai.md) implements all three phases as executable skills you can run interactively:
+For Claude platform users (Claude Code, Claude.ai, or Cowork), the [Business-First AI plugin](../plugins/business-first-ai.md) implements all three phases as executable skills you can run interactively:
 
 ```bash
 /plugin install business-first-ai@handsonai

--- a/docs/plugins/business-first-ai.md
+++ b/docs/plugins/business-first-ai.md
@@ -1,17 +1,87 @@
 ---
-title: Business First AI
+title: Business-First AI
 description: The Business-First AI Framework as executable Claude Code skills — discover opportunities, deconstruct workflows, and build with worked examples
 ---
 
-# Business First AI
+# Business-First AI
 
-This plugin implements the [Business-First AI Framework](../business-first-ai-framework/index.md) as executable Claude Code skills. It covers all three phases: discover where AI fits in your workflows, deconstruct those workflows into AI building blocks, and build with worked examples across the autonomy spectrum. Install it to get a complete toolkit for going from "where should I use AI?" to working AI workflows.
+This plugin implements the [Business-First AI Framework](../business-first-ai-framework/index.md) as executable Claude Code agents and skills. It covers all three phases: discover where AI fits in your workflows, deconstruct those workflows into AI building blocks, and build with worked examples across the autonomy spectrum. Install it to get a complete toolkit for going from "where should I use AI?" to working AI workflows.
 
 ## Install
 
 ```bash
 /plugin install business-first-ai@handsonai
 ```
+
+## How to Use This Plugin
+
+How you use this plugin depends on your platform:
+
+=== "Claude Code"
+
+    Install the plugin and everything is available immediately. Agents activate automatically
+    when your prompt matches — just describe what you need and Claude handles the rest.
+
+    ```bash
+    /plugin install business-first-ai@handsonai
+    ```
+
+    **Recommended path:**
+
+    1. Say *"Help me find AI opportunities in my workflows"* → the `finding-ai-opportunities` skill runs Phase 1
+    2. Say *"I want to deconstruct my [workflow] into AI building blocks"* → the `workflow-deconstructor` agent orchestrates all of Phase 2
+    3. Review your outputs in the `outputs/` folder
+
+=== "Cowork"
+
+    Use this if you have Claude Desktop on macOS. Cowork supports the same plugins as Claude Code
+    through a visual interface — no terminal needed.
+
+    1. **Open Cowork** — launch Claude Desktop and click **Cowork** in the sidebar
+    2. **Add the plugin** — click the **+** button, select **Add plugins...**, then upload the plugin ZIP
+    3. **Use the same prompts as Claude Code** — say *"Help me find AI opportunities in my workflows"* for Phase 1, or *"I want to deconstruct my [workflow] into AI building blocks"* for Phase 2. Claude uses the plugin automatically.
+
+    For detailed Cowork setup, see [Using Plugins in Cowork](using-plugins.md#using-plugins-in-claude-cowork).
+
+    !!! note "How to get the plugin ZIP"
+        The Business-First AI plugin isn't in Cowork's built-in directory yet. Download the plugin folder from [GitHub](https://github.com/jamesgray-ai/handsonai/tree/main/plugins/business-first-ai), zip it, and upload to Cowork. Or install via Claude Code first (`/plugin install business-first-ai@handsonai`) and the plugin files are already on your machine.
+
+=== "Claude.ai"
+
+    Individual **skills** (not agents) can be uploaded to Claude.ai as ZIP files. You need
+    Claude Code installed first to access the skill files.
+
+    1. **Install the plugin in Claude Code** — `/plugin install business-first-ai@handsonai`
+    2. **Find the skill folder** — navigate to `~/.claude/plugins/marketplaces/handsonai/plugins/business-first-ai/skills/`
+    3. **Zip the skill** you want (e.g., the `finding-ai-opportunities` folder)
+    4. **Upload it** in Claude.ai under **Settings > Capabilities > Upload skill**
+    5. **Start a new chat** — Claude uses the skill automatically
+
+    For detailed upload instructions, see [Using Skills in Claude.ai](using-plugins.md#using-skills-in-claudeai-web).
+
+    !!! warning "Agents don't work in Claude.ai"
+        The `workflow-deconstructor` agent (which orchestrates all three Phase 2 steps) only works in Claude Code or Cowork. In Claude.ai, upload and run the three Phase 2 skills individually: `discovering-workflows` → `analyzing-workflows` → `generating-workflow-outputs`.
+
+### Platform Compatibility
+
+| Component | Type | Claude Code | Cowork | Claude.ai |
+|-----------|------|:-----------:|:------:|:---------:|
+| `finding-ai-opportunities` | Skill | Yes | Yes | Yes |
+| `workflow-deconstructor` | Agent | Yes | Yes | No |
+| `discovering-workflows` | Skill | Yes | Yes | Yes |
+| `analyzing-workflows` | Skill | Yes | Yes | Yes |
+| `generating-workflow-outputs` | Skill | Yes | Yes | Yes |
+| `tech-executive-writer` | Agent | Yes | Yes | No |
+| `hbr-editor` | Agent | Yes | Yes | No |
+| `hbr-publisher` | Agent | Yes | Yes | No |
+| `ai-productivity-researcher` | Agent | Yes | Yes | No |
+| `meeting-prep-researcher` | Agent | Yes | Yes | No |
+| `ai-news-researcher` | Agent | Yes | Yes | No |
+| `claude-research-daily` | Agent | Yes | Yes | No |
+| `editing-hbr-articles` | Skill | Yes | Yes | No |
+| `preparing-meeting-briefs` | Skill | Yes | Yes | Yes |
+
+Agents activate automatically in Claude Code when your prompt matches. In Cowork, describe your task using the prompts above and Claude activates the right agent. Skills marked "Yes" for Claude.ai can be uploaded as ZIP files.
 
 ## Components
 
@@ -457,4 +527,4 @@ The file-based handoffs mean you can continue in a new conversation. Just invoke
 The categories used during analysis: Prompt (single instruction), Context (reference material), Skill (multi-step workflow), Agent (autonomous personality), MCP (external tool connection), and Project (workspace configuration). Each step gets mapped to one or more of these.
 
 **Do I need Claude Code for all of this?**
-No. The Phase 1 skill and Phase 2 skills work in Claude.ai too. The prompts work in any AI tool. The agents require Claude Code for automatic activation, but you can use the skill workflows manually anywhere.
+No. Skills and agents work differently across platforms — see the [Platform Compatibility](#platform-compatibility) table above. All skills and agents work in both Claude Code and Cowork (Claude Desktop on macOS). Skills marked "Yes" for Claude.ai can also be uploaded as ZIP files. Agents don't work in Claude.ai — use the individual skills instead. The prompt templates on the framework pages work in any AI tool — no plugin required.

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -39,7 +39,7 @@ For the full details on how marketplaces and plugin installation work, see the o
 
 ---
 
-## :material-rocket-launch: Business First AI
+## :material-rocket-launch: Business-First AI
 
 The [Business-First AI Framework](../business-first-ai-framework/index.md) as executable Claude Code skills. Discover AI workflow opportunities (Phase 1), deconstruct workflows into AI building blocks (Phase 2), and build with worked examples across the autonomy spectrum (Phase 3).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,7 +136,7 @@ nav:
     - Marketplace: plugins/index.md
     - Getting Started: plugins/getting-started.md
     - Using Plugins: plugins/using-plugins.md
-    - Business First AI: plugins/business-first-ai.md
+    - Business-First AI: plugins/business-first-ai.md
     - AI Registry: plugins/ai-registry.md
   - Fundamentals:
     - Overview: fundamentals/index.md


### PR DESCRIPTION
## Summary

- Adds a dedicated **Cowork** content tab (between Claude Code and Claude.ai) on three pages: plugin detail page, Phase 1 Discover, and Phase 2 Deconstruct
- Updates the compatibility table on `business-first-ai.md` with a Cowork column (all components supported)
- Fixes intro lines from "three ways" → "four ways" on discover and deconstruct pages
- Rewrites FAQ answer to cover Claude Code, Cowork, and Claude.ai distinctly
- Normalizes "Business First AI" → "Business-First AI" across titles, nav, and body references

## Test plan

- [x] `mkdocs build` passes with no new warnings
- [ ] Verify all four content tabs render correctly on each page
- [ ] Confirm Cowork tab links to existing `using-plugins.md#using-plugins-in-claude-cowork` section
- [ ] Check compatibility table renders three platform columns: Claude Code, Cowork, Claude.ai
- [ ] Verify tab order is consistent: Any AI Tool → Claude Code → Cowork → Claude.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)