### PR TITLE
Add What This Is and Why This Matters sections to Phase 2 step pages

### DIFF
--- a/docs/business-first-ai-framework/deconstruct/analysis.md
+++ b/docs/business-first-ai-framework/deconstruct/analysis.md
@@ -7,7 +7,21 @@ description: Classify workflow steps on the autonomy spectrum, map them to AI bu
 
 > **Part of:** [Deconstruct Workflows](index.md)
 
-This is the second of three prompts. It takes the **Workflow Blueprint** file from [Step 1](discovery.md), classifies each step on the autonomy spectrum, maps it to AI building blocks, and produces a complete **Workflow Analysis Document** — the first major deliverable. You'll save that document and use it as input for [Step 3](outputs.md).
+## What This Is
+
+A classification step where AI takes your Workflow Blueprint and determines what level of AI assistance each step needs — from fully human to fully autonomous — and maps each step to the specific AI building blocks required.
+
+| | |
+|---|---|
+| **What you'll do** | Upload your Blueprint from Step 1, review the AI's classification of each step, and adjust anything that doesn't look right |
+| **What you'll get** | A **Workflow Analysis Document** — a complete mapping of steps to autonomy levels and AI building blocks, with a prioritized build sequence |
+| **Time** | ~5–10 minutes (mostly reviewing the AI's analysis) |
+
+## Why This Matters
+
+Not every step in a workflow should be automated. Some require human judgment. Some can run on autopilot. Some need AI to do the heavy lifting with a human checking the result. Getting this classification wrong means either over-automating (risking quality) or under-automating (leaving value on the table).
+
+This analysis also maps each step to specific **AI building blocks** — Prompt, Context, Skill, Agent, MCP, or Project — so you know exactly what to build for each step instead of guessing. The recommended implementation order (quick wins first, complex agent steps last) gives you a practical sequence for rolling out AI incrementally.
 
 ## How to Use This
 

--- a/docs/business-first-ai-framework/deconstruct/discovery.md
+++ b/docs/business-first-ai-framework/deconstruct/discovery.md
@@ -7,7 +7,23 @@ description: Interactively discover and decompose a business workflow into a str
 
 > **Part of:** [Deconstruct Workflows](index.md)
 
-This is the first of three prompts that break down a business workflow so you can power it with AI. This prompt handles **scenario discovery** (understanding your workflow) and the **deep dive** (decomposing each step using the 5-question framework). It produces a **Workflow Blueprint** — a Markdown file you'll save and use as input for [Step 2](analysis.md).
+## What This Is
+
+An interactive conversation where AI helps you break down a workflow into its component parts. You describe the process — rough and incomplete is fine — and the AI interviews you to surface every hidden step, decision, data handoff, and failure mode.
+
+| | |
+|---|---|
+| **What you'll do** | Describe your workflow (or problem), then answer focused questions as the AI probes each step for sub-steps, decision points, data flows, context needs, and failure modes |
+| **What you'll get** | A **Workflow Blueprint** — a structured Markdown file that captures everything discovered, ready for [Step 2](analysis.md) |
+| **Time** | ~15–25 minutes of interactive conversation |
+
+## Why This Matters
+
+Most people describe their workflows in 5–8 rough steps. But the real complexity — the decision points, data handoffs, exception paths, and hidden assumptions — lives in the gaps between those steps.
+
+This discovery process typically expands those 5–8 rough steps into 12–20 refined steps. That expansion is where the value is: each hidden detail you surface now is a potential failure point you won't have to debug later when AI is running the workflow.
+
+The prompt uses a **5-question framework** (discrete steps, decision points, data flows, context needs, failure modes) applied systematically to every step. After the first few steps, it switches to a "propose and react" pattern — presenting hypotheses for you to correct — which is faster and surfaces details you wouldn't think to mention unprompted.
 
 ## How to Use This
 

--- a/docs/business-first-ai-framework/deconstruct/outputs.md
+++ b/docs/business-first-ai-framework/deconstruct/outputs.md
@@ -7,7 +7,21 @@ description: Generate a ready-to-use Baseline Workflow Prompt and Skill Build Re
 
 > **Part of:** [Deconstruct Workflows](index.md)
 
-This is the final prompt in the three-part series. It takes the **Workflow Analysis Document** from [Step 2](analysis.md) and produces your two remaining deliverables: a **Baseline Workflow Prompt** you can paste into any AI tool to run the workflow, and **Skill Build Recommendations** showing which reusable skills to build and what they replace.
+## What This Is
+
+The final step that turns your analysis into action. AI reads your Workflow Analysis Document and generates two ready-to-use deliverables: a prompt you can paste into any AI tool to execute the workflow today, and a roadmap of reusable skills to build over time.
+
+| | |
+|---|---|
+| **What you'll do** | Upload your Analysis Document from Step 2, answer 1–2 clarifying questions, then review the generated outputs |
+| **What you'll get** | A **Baseline Workflow Prompt** (ready to paste and run) and **Skill Build Recommendations** (what to build next and in what order) |
+| **Time** | ~5–10 minutes (mostly generative — the AI does the heavy lifting) |
+
+## Why This Matters
+
+Analysis without action is just documentation. The Baseline Workflow Prompt gives you something you can use immediately — paste it into any AI tool and run your workflow. It works on day one, on any platform.
+
+The Skill Build Recommendations show you how to evolve that prompt over time. Each skill you build replaces a section of the baseline prompt, making the workflow shorter, more reliable, and more reusable. You get a clear path from "working but manual" to "automated and refined" — with specific priorities so you know what to build first.
 
 ## How to Use This
 


### PR DESCRIPTION
## Summary

- Adds `## What This Is` (one-sentence summary + summary table) and `## Why This Matters` (2-3 motivating paragraphs) sections to the three Phase 2 step pages: discovery.md, analysis.md, and outputs.md
- Replaces the single intro paragraph on each page with the structured sections used by the parent Phase pages (discover.md, deconstruct/index.md)
- All existing content (How to Use This, The Prompt, What This Prompt Produces) is preserved unchanged

## Test plan

- [x] `mkdocs build` passes with no new warnings
- [ ] Verify all three step pages render correctly on the dev server
- [ ] Confirm section order matches parent pages: What This Is → Why This Matters → How to Use This → The Prompt → What This Prompt Produces
- [ ] Check summary tables display correctly with What you'll do / What you'll get / Time rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)