### PR TITLE
Add Workflow Candidate Summary step to Phase 1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "business-first-ai",
       "source": "./plugins/business-first-ai",
       "description": "The Business-First AI Framework — discover AI opportunities, deconstruct workflows, and build with worked examples",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "name": "ai-registry",

--- a/.claude/skills/finding-ai-opportunities/SKILL.md
+++ b/.claude/skills/finding-ai-opportunities/SKILL.md
@@ -13,7 +13,7 @@ Discover concrete opportunities where AI can improve your workflows. Produces a 
 
 ## Workflow
 
-Work through three steps in order:
+Work through four steps in order:
 
 ### Step 1 — Memory & History Scan
 
@@ -46,6 +46,31 @@ Ask these questions **one at a time** — not as a list. Use the user's answers 
 ### Step 3 — Opportunity Analysis & Report
 
 Once you can identify at least 3 concrete, specific opportunities with enough detail to fill the card format below, produce the structured report.
+
+### Step 4 — Workflow Candidate Summary
+
+After presenting the full report, ask the user to pick ONE opportunity from each category that they want to build during the course. Once they've chosen, produce a **Workflow Candidate Summary** in this exact format:
+
+---
+
+**Workflow:** [3-5 word name]
+**Type:** Collaborative AI
+**Pain point:** [1 sentence — what makes this time-consuming or frustrating today]
+**AI opportunity:** [1 sentence — how AI could help]
+
+**Workflow:** [3-5 word name]
+**Type:** Deterministic Automation
+**Pain point:** [1 sentence]
+**AI opportunity:** [1 sentence]
+
+**Workflow:** [3-5 word name]
+**Type:** Autonomous Agent
+**Pain point:** [1 sentence]
+**AI opportunity:** [1 sentence]
+
+---
+
+Append this summary to the output file under a `## Workflow Candidate Summary` heading.
 
 ## Output
 
@@ -99,4 +124,4 @@ Use these definitions when categorizing:
 - Use a conversational flow — let answers guide follow-up questions naturally
 - Push for concrete examples over vague descriptions
 - Be specific in recommendations: "AI could draft the weekly status email from your Jira board data" beats "AI could help with reporting"
-- After writing the report, tell the user: "Opportunity report saved to `outputs/ai-opportunity-report.md`. Pick 1-2 opportunities to pilot first — start with Collaborative AI if you're new to AI, or Deterministic Workflows if you've identified a process you repeat often."
+- After writing the report, ask the user to pick their three candidates (one per category) for Step 4. Once they've chosen, append the Workflow Candidate Summary to the output file and tell the user: "Opportunity report and Workflow Candidate Summary saved to `outputs/ai-opportunity-report.md`. Your candidate summary is ready to copy into your course assignment."

--- a/docs/business-first-ai-framework/discover.md
+++ b/docs/business-first-ai-framework/discover.md
@@ -94,7 +94,7 @@ All four options follow the same three-step process and produce the same structu
 ```text
 You are an AI Workflow Strategist with deep expertise in business process optimization and AI capabilities. Your job is to help me discover concrete opportunities where AI can improve my workflows.
 
-Work through the following three steps in order.
+Work through the following four steps in order.
 
 ---
 
@@ -177,6 +177,33 @@ Use these definitions when categorizing:
 - **Multi-Agent System**: A complex workflow where multiple AI agents (or AI + automation tools) coordinate across steps. Requires orchestration. Examples: research → analysis → report generation pipelines, intake → triage → routing systems, monitoring → alerting → response workflows.
 
 Group the detailed cards by category. Within each category, order opportunities from highest to lowest impact.
+
+---
+
+## Step 4 — Workflow Candidate Summary
+
+After presenting the full report, ask me to pick ONE opportunity from each category that I want to build during this course. Once I've chosen, produce a **Workflow Candidate Summary** in this exact format:
+
+---
+
+**Workflow:** [3-5 word name]
+**Type:** Collaborative AI
+**Pain point:** [1 sentence — what makes this time-consuming or frustrating today]
+**AI opportunity:** [1 sentence — how AI could help]
+
+**Workflow:** [3-5 word name]
+**Type:** Deterministic Automation
+**Pain point:** [1 sentence]
+**AI opportunity:** [1 sentence]
+
+**Workflow:** [3-5 word name]
+**Type:** Autonomous Agent
+**Pain point:** [1 sentence]
+**AI opportunity:** [1 sentence]
+
+---
+
+This summary is my assignment deliverable — format it so I can copy it directly into my course submission.
 ```
 
 ## What to Expect
@@ -186,8 +213,9 @@ After pasting the prompt, here's what typically happens:
 1. **Step 1** — The AI reviews what it knows about you and presents a summary. Correct anything that's wrong and fill in gaps.
 2. **Step 2** — The AI asks you a series of questions. Answer as specifically as you can — concrete examples produce better recommendations than general descriptions.
 3. **Step 3** — You receive a structured report with a summary table and detailed cards for each opportunity, grouped by category.
+4. **Step 4** — You pick one opportunity from each category to build during the course, and the AI formats a **Workflow Candidate Summary** you can copy directly into your assignment submission.
 
-Most people discover 5–15 opportunities across the three categories. Don't try to pursue all of them — pick 1–2 from the "Getting started" suggestions and pilot those first.
+Most people discover 5–15 opportunities across the three categories. You'll pick three to build during the course — one from each category.
 
 ### How to Prioritize
 

--- a/plugins/business-first-ai/.claude-plugin/plugin.json
+++ b/plugins/business-first-ai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "business-first-ai",
   "description": "The Business-First AI Framework as executable Claude Code skills. Discover AI workflow opportunities, deconstruct workflows into building blocks, and build with worked examples across the autonomy spectrum.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": { "name": "James Gray" },
   "homepage": "https://handsonai.info/plugins/",
   "license": "MIT",

--- a/plugins/business-first-ai/skills/finding-ai-opportunities/SKILL.md
+++ b/plugins/business-first-ai/skills/finding-ai-opportunities/SKILL.md
@@ -13,7 +13,7 @@ Discover concrete opportunities where AI can improve your workflows. Produces a 
 
 ## Workflow
 
-Work through three steps in order:
+Work through four steps in order:
 
 ### Step 1 — Memory & History Scan
 
@@ -46,6 +46,31 @@ Ask these questions **one at a time** — not as a list. Use the user's answers 
 ### Step 3 — Opportunity Analysis & Report
 
 Once you can identify at least 3 concrete, specific opportunities with enough detail to fill the card format below, produce the structured report.
+
+### Step 4 — Workflow Candidate Summary
+
+After presenting the full report, ask the user to pick ONE opportunity from each category that they want to build during the course. Once they've chosen, produce a **Workflow Candidate Summary** in this exact format:
+
+---
+
+**Workflow:** [3-5 word name]
+**Type:** Collaborative AI
+**Pain point:** [1 sentence — what makes this time-consuming or frustrating today]
+**AI opportunity:** [1 sentence — how AI could help]
+
+**Workflow:** [3-5 word name]
+**Type:** Deterministic Automation
+**Pain point:** [1 sentence]
+**AI opportunity:** [1 sentence]
+
+**Workflow:** [3-5 word name]
+**Type:** Autonomous Agent
+**Pain point:** [1 sentence]
+**AI opportunity:** [1 sentence]
+
+---
+
+Append this summary to the output file under a `## Workflow Candidate Summary` heading.
 
 ## Output
 
@@ -99,4 +124,4 @@ Use these definitions when categorizing:
 - Use a conversational flow — let answers guide follow-up questions naturally
 - Push for concrete examples over vague descriptions
 - Be specific in recommendations: "AI could draft the weekly status email from your Jira board data" beats "AI could help with reporting"
-- After writing the report, tell the user: "Opportunity report saved to `outputs/ai-opportunity-report.md`. Pick 1-2 opportunities to pilot first — start with Collaborative AI if you're new to AI, or Deterministic Workflows if you've identified a process you repeat often."
+- After writing the report, ask the user to pick their three candidates (one per category) for Step 4. Once they've chosen, append the Workflow Candidate Summary to the output file and tell the user: "Opportunity report and Workflow Candidate Summary saved to `outputs/ai-opportunity-report.md`. Your candidate summary is ready to copy into your course assignment."


### PR DESCRIPTION
## Summary
- Adds **Step 4 (Workflow Candidate Summary)** to the Phase 1 prompt template, finding-ai-opportunities skill, and Notion assignment
- After the full opportunity report, the AI now asks students to pick one candidate per category and formats a ready-to-submit summary
- Students can copy the output directly into their Maven portal submission — no reformatting needed
- Updates both `.claude/skills/` and `plugins/` copies of the skill, bumps plugin version to 1.0.1

## Test plan
- [ ] Verify `discover.md` prompt template includes Step 4 with the candidate summary format
- [ ] Verify `SKILL.md` (both copies) includes Step 4 and updated guidelines
- [ ] Verify plugin version bumped to 1.0.1 in both `plugin.json` and `marketplace.json`
- [ ] Verify Notion assignment page references the four-step process and tells students Step 4 produces their deliverable

🤖 Generated with [Claude Code](https://claude.com/claude-code)