### PR TITLE
Rename Phase 2 step pages and deliverables to output-focused names

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "business-first-ai",
       "source": "./plugins/business-first-ai",
       "description": "The Business-First AI Framework — discover AI opportunities, deconstruct workflows, and build with worked examples",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "name": "ai-registry",

--- a/.claude/agents/workflow-deconstructor.md
+++ b/.claude/agents/workflow-deconstructor.md
@@ -11,32 +11,45 @@ You are an expert Workflow Deconstruction Orchestrator. Your job is to guide the
 
 You run three skills sequentially, using files as handoffs between stages:
 
-### Step 1 — Discovery & Deep Dive
+### Step 1 — Workflow Definition
 **Skill:** `discovering-workflows`
 
 Interactively discover the user's workflow and decompose every step. This is the longest phase — you'll ask about the business scenario, help refine steps, then systematically probe each step using the 5-question framework.
 
-**Produces:** `outputs/[name]-blueprint.md`
+During context probing, distinguish between reference materials (documents the model reads) and executable instructions (prompts/instructions the model follows). Flag executable instructions — they must be included in the Baseline Prompt.
 
-After the Blueprint is complete, tell the user you're moving to Step 2 and proceed automatically.
+After naming is confirmed, register the workflow to the Notion Workflows database if the Notion MCP server is available. Use the confirmed metadata (name, description, outcome, trigger, type) with Status = "Under Development."
 
-### Step 2 — Analysis & Mapping
+**Produces:** `outputs/[name]-definition.md`
+
+After the Workflow Definition is complete, tell the user you're moving to Step 2 and proceed automatically.
+
+### Step 2 — AI Building Blocks
 **Skill:** `analyzing-workflows`
 
-Read the Blueprint file, classify each step on the autonomy spectrum, map to AI building blocks, and produce the Workflow Analysis Document.
+Read the Workflow Definition file, classify each step on the autonomy spectrum, map to AI building blocks, and produce the AI Building Block Map.
 
-**Reads:** `outputs/[name]-blueprint.md`
-**Produces:** `outputs/[name]-analysis.md`
+**Reads:** `outputs/[name]-definition.md`
+**Produces:** `outputs/[name]-building-blocks.md`
 
-Present the mapping table to the user for review. After confirmation, generate the Analysis Document and proceed to Step 3.
+Present the mapping table to the user for review. After confirmation, generate the AI Building Block Map and proceed to Step 3.
 
-### Step 3 — Output Generation
+### Step 3 — Prompt & Skill Specs
 **Skill:** `generating-workflow-outputs`
 
-Read the Analysis Document and generate the Baseline Workflow Prompt and Skill Build Recommendations.
+Read the AI Building Block Map and generate the Baseline Workflow Prompt and the Skill Specs.
 
-**Reads:** `outputs/[name]-analysis.md`
-**Produces:** `outputs/[name]-prompt.md` + `outputs/[name]-skill-recs.md`
+The Baseline Prompt must be self-contained — all executable logic in the prompt, not referenced from external systems. Include an Execution Context section advising where to run the prompt (normal chat vs. project).
+
+**Reads:** `outputs/[name]-building-blocks.md`
+**Produces:** `outputs/[name]-prompt.md` + `outputs/[name]-skill-specs.md`
+
+### Post-Step 3 — Registry & SOP (if Notion available)
+
+If the workflow was registered to the Notion Workflows database during Step 1 naming, offer to generate the workflow SOP and save it to the page body. Use the Baseline Prompt's steps as the procedure source. This completes the workflow's Notion page: metadata in properties, SOP in the page content.
+
+**Reads:** `outputs/[name]-prompt.md` (for procedure steps)
+**Updates:** The workflow's Notion page body
 
 ## File Conventions
 
@@ -61,9 +74,10 @@ After all three steps, present a summary:
 
 > **Workflow deconstruction complete.** Here are your deliverables:
 >
-> 1. **Workflow Blueprint** — `outputs/[name]-blueprint.md`
-> 2. **Workflow Analysis Document** — `outputs/[name]-analysis.md`
+> 1. **Workflow Definition** — `outputs/[name]-definition.md`
+> 2. **AI Building Block Map** — `outputs/[name]-building-blocks.md`
 > 3. **Baseline Workflow Prompt** — `outputs/[name]-prompt.md`
-> 4. **Skill Build Recommendations** — `outputs/[name]-skill-recs.md`
+> 4. **Skill Specs** — `outputs/[name]-skill-specs.md`
+> 5. **Workflow SOP** — saved to the workflow's Notion page (if registered)
 >
 > Start by running the baseline prompt on a real scenario. Then build skills in priority order from the recommendations.

--- a/.claude/skills/analyzing-workflows/SKILL.md
+++ b/.claude/skills/analyzing-workflows/SKILL.md
@@ -2,17 +2,17 @@
 name: analyzing-workflows
 description: >
   Classify workflow steps on the autonomy spectrum, map them to AI building blocks, and produce
-  a Workflow Analysis Document. Use when the user has a Workflow Blueprint and wants to analyze
+  an AI Building Block Map. Use when the user has a Workflow Definition and wants to analyze
   it for AI operationalization. This is Step 2 of 3 in the workflow deconstruction series.
 ---
 
 # Workflow Analysis
 
-Take a Workflow Blueprint, classify each step on the autonomy spectrum, map to AI building blocks, and produce a complete Workflow Analysis Document.
+Take a Workflow Definition, classify each step on the autonomy spectrum, map to AI building blocks, and produce a complete AI Building Block Map.
 
 ## Workflow
 
-1. **Load Blueprint** — Read the Blueprint file from `outputs/[workflow-name]-blueprint.md`. If the user specifies a file path, use that. Otherwise, look for the most recent Blueprint in `outputs/`.
+1. **Load Workflow Definition** — Read the Workflow Definition file from `outputs/[workflow-name]-definition.md`. If the user specifies a file path, use that. Otherwise, look for the most recent Workflow Definition in `outputs/`.
 2. **Confirm understanding** — Summarize the workflow name, step count, and outcome. Ask the user to confirm before proceeding.
 3. **Classify each step** — For every refined step, determine:
    - **Autonomy level**: Human / AI-Deterministic / AI-Semi-Autonomous / AI-Autonomous
@@ -20,13 +20,13 @@ Take a Workflow Blueprint, classify each step on the autonomy spectrum, map to A
    - **Tools and connectors**: External tools, APIs, integrations needed
    - **Human-in-the-loop gates**: Where human review is recommended
 4. **Present mapping** — Show the classification as a clear table. Walk through reasoning for non-obvious classifications. Ask the user if they want to adjust anything.
-5. **Generate Analysis Document** — After confirmation, produce the complete Workflow Analysis Document and write it to the output file.
+5. **Generate AI Building Block Map** — After confirmation, produce the complete AI Building Block Map and write it to the output file.
 
 ## Output
 
-Write the Workflow Analysis Document to `outputs/[workflow-name]-analysis.md` using the same workflow name from the Blueprint.
+Write the AI Building Block Map to `outputs/[workflow-name]-building-blocks.md` using the same workflow name from the Workflow Definition.
 
-The Analysis Document must include:
+The AI Building Block Map must include:
 
 ### Scenario Summary
 - Workflow name, description, outcome, trigger, type, business objective, current owner(s)
@@ -48,8 +48,8 @@ The Analysis Document must include:
 
 ### Context Inventory
 
-| Artifact | Description | Used By Steps | Status | Format | Key Contents |
-|----------|-------------|---------------|--------|--------|--------------|
+| Artifact | Type | Description | Used By Steps | Status | Format | Key Contents |
+|----------|------|-------------|---------------|--------|--------|--------------|
 
 ### Tools and Connectors Required
 
@@ -58,9 +58,12 @@ The Analysis Document must include:
 2. **High-value semi-autonomous steps** — AI does most work, human review gate
 3. **Complex agent steps** — Fully autonomous, requiring Agents/MCP/multi-tool orchestration
 
+### Execution Context
+Recommend where the Baseline Workflow Prompt should be run (normal chat vs. project workspace). Normal chat for infrequent workflows with few context files. Project workspace for frequent workflows with multiple context files or where conversation memory is valuable. State the recommendation, reasoning, and specific context files to attach or pre-load. The Baseline Workflow Prompt is always self-contained — the project provides file staging, not workflow logic.
+
 ## Guidelines
 
-- If the Blueprint is missing information needed for classification, ask the user to clarify
+- If the Workflow Definition is missing information needed for classification, ask the user to clarify
 - If the user mentions they're using Claude, note where Skills are the appropriate building block
 - Explain reasoning for non-obvious classifications
-- After writing the Analysis Document, tell the user: "Analysis saved to `outputs/[name]-analysis.md`. Ready for Step 3 — Output Generation."
+- After writing the AI Building Block Map, tell the user: "AI Building Block Map saved to `outputs/[name]-building-blocks.md`. Ready for Step 3 — Prompt & Skill Specs."

--- a/.claude/skills/discovering-workflows/SKILL.md
+++ b/.claude/skills/discovering-workflows/SKILL.md
@@ -1,34 +1,36 @@
 ---
 name: discovering-workflows
 description: >
-  Interactively discover and decompose a business workflow into a structured Workflow Blueprint.
+  Interactively discover and decompose a business workflow into a structured Workflow Definition.
   Use when the user wants to deconstruct a workflow, break down a business process, or start
   the workflow deconstruction process. This is Step 1 of 3 in the workflow deconstruction series.
 ---
 
-# Workflow Discovery
+# Workflow Definition
 
-Interactively discover a business workflow and decompose every step into a structured Workflow Blueprint using the 5-question framework.
+Interactively discover a business workflow and decompose every step into a structured Workflow Definition using the 5-question framework.
 
 ## Workflow
 
 1. **Scenario discovery** — Ask about the business scenario, objective, high-level steps, and ownership. One question at a time. If the user describes a problem instead of a workflow, propose a candidate workflow for them to react to.
 2. **Scope check** — Assess whether this is one workflow or multiple bundled together. If multiple, recommend splitting and ask which to start with.
 3. **Name the workflow** — Present 2-3 name options following naming conventions (2-4 word noun phrase, Title Case). Confirm name, description, outcome, trigger, and type.
-4. **Deep dive** — Work through each step using the 5-question framework:
+4. **Register to Workflows database (if Notion is available)** — After naming is confirmed, check if the Notion MCP server is accessible. If so, create a row in the Workflows database with: Name, Description, Process Outcome, Type, Trigger, Status = "Under Development". Ask the user which Business Process domain this belongs to (or leave blank). If Notion is not available, skip this step silently and continue to the deep dive.
+5. **Deep dive** — Work through each step using the 5-question framework:
    - Discrete steps (is this actually multiple steps?)
    - Decision points (if/then branches, quality gates)
    - Data flows (inputs, outputs, sources, destinations)
    - Context needs (specific documents, files, reference materials)
    - Failure modes (what happens when this step fails)
-5. **Propose and react** — For steps 4+, propose a hypothesis across all 5 dimensions and ask "What's right, what's wrong, what am I missing?" instead of asking each question individually.
-6. **Map sequence** — After all steps, identify sequential vs. parallel steps and the critical path.
-7. **Consolidate context** — Present a rolled-up "context shopping list" of every artifact the workflow needs.
-8. **Generate Blueprint** — Produce the structured Workflow Blueprint and write it to the output file.
+   When probing context needs, distinguish between **reference materials** (documents, files, data the model reads) and **executable instructions** (prompts, project instructions, system prompts the model follows). For any step where AI is already being used, ask specifically for existing prompt instructions or configurations — these contain workflow logic that must be included in the Baseline Prompt.
+6. **Propose and react** — For steps 4+, propose a hypothesis across all 5 dimensions and ask "What's right, what's wrong, what am I missing?" instead of asking each question individually.
+7. **Map sequence** — After all steps, identify sequential vs. parallel steps and the critical path.
+8. **Consolidate context** — Present a rolled-up "context shopping list" of every artifact the workflow needs. For each artifact, include its type (Reference Material or Executable Instructions). Artifacts typed as "Executable Instructions" contain workflow logic that must be included in the Baseline Workflow Prompt.
+9. **Generate Workflow Definition** — Produce the structured Workflow Definition and write it to the output file.
 
 ## Output
 
-Write the Workflow Blueprint to `outputs/[workflow-name]-blueprint.md` where `[workflow-name]` is the kebab-case workflow name (e.g., `lead-qualification`).
+Write the Workflow Definition to `outputs/[workflow-name]-definition.md` where `[workflow-name]` is the kebab-case workflow name (e.g., `lead-qualification`).
 
 The Blueprint must include:
 
@@ -42,7 +44,7 @@ For each step: number, name, action, sub-steps, decision points, data in/out, co
 - Sequential steps, parallel steps, critical path, dependency map
 
 ### Context Shopping List
-For each artifact: name, description, used by steps, status (Exists/Needs Creation), key contents
+For each artifact: name, type (Reference Material / Executable Instructions), description, used by steps, status (Exists/Needs Creation), key contents
 
 ## Guidelines
 
@@ -51,4 +53,4 @@ For each artifact: name, description, used by steps, status (Exists/Needs Creati
 - Surface hidden assumptions ("How do you decide when X is good enough?")
 - Use plain language; avoid jargon unless the user introduced it
 - Push beyond vague context answers like "domain knowledge" — identify the specific artifact
-- After writing the Blueprint file, tell the user: "Blueprint saved to `outputs/[name]-blueprint.md`. Ready for Step 2 — Analysis & Mapping."
+- After writing the Workflow Definition file, tell the user: "Workflow Definition saved to `outputs/[name]-definition.md`. Ready for Step 2 — AI Building Blocks."

--- a/.claude/skills/generating-workflow-outputs/SKILL.md
+++ b/.claude/skills/generating-workflow-outputs/SKILL.md
@@ -1,22 +1,24 @@
 ---
 name: generating-workflow-outputs
 description: >
-  Generate a Baseline Workflow Prompt and Skill Build Recommendations from a Workflow Analysis
-  Document. Use when the user has a completed Analysis Document and wants the final deliverables.
+  Generate a Baseline Workflow Prompt and Skill Specs from an AI Building Block
+  Map. Use when the user has a completed AI Building Block Map and wants the final deliverables.
   This is Step 3 of 3 in the workflow deconstruction series.
 ---
 
 # Workflow Output Generation
 
-Take a Workflow Analysis Document and produce two deliverables: a Baseline Workflow Prompt and Skill Build Recommendations.
+Take an AI Building Block Map and produce two deliverables: a Baseline Workflow Prompt and Skill Specs.
 
 ## Workflow
 
-1. **Load Analysis Document** — Read the Analysis Document from `outputs/[workflow-name]-analysis.md`. If the user specifies a file path, use that. Otherwise, look for the most recent Analysis Document in `outputs/`.
+1. **Load AI Building Block Map** — Read the AI Building Block Map from `outputs/[workflow-name]-building-blocks.md`. If the user specifies a file path, use that. Otherwise, look for the most recent AI Building Block Map in `outputs/`.
 2. **Confirm understanding** — Summarize the workflow name, step count, how many are AI-eligible, and the recommended implementation order. Ask the user to confirm before proceeding.
-3. **Clarify if needed** — If anything in the Analysis Document is ambiguous, ask before generating. Maximum 1-2 clarifying questions.
-4. **Generate Baseline Workflow Prompt** — Produce a ready-to-use prompt and write it to the output file.
-5. **Generate Skill Build Recommendations** — Produce skill specs and write them to the output file.
+3. **Clarify if needed** — If anything in the AI Building Block Map is ambiguous, ask before generating. Maximum 1-2 clarifying questions.
+4. **Check for executable instructions** — Before generating, check the Context Inventory for any artifacts typed as "Executable Instructions." These contain workflow logic that must be included in the Baseline Prompt — not referenced, but actually included. If executable instructions exist but their content is not in the AI Building Block Map, ask the user to paste or upload them. The Baseline Prompt cannot reference external systems for its core logic.
+5. **Generate Baseline Workflow Prompt** — Produce a ready-to-use, self-contained prompt and write it to the output file. Include an Execution Context section advising where to run the prompt (normal chat vs. project) based on the AI Building Block Map's recommendation.
+6. **Generate Skill Specs** — Produce skill specs and write them to the output file.
+7. **Write SOP to Notion (if available)** — After both deliverables are generated, check if the Notion MCP server is accessible AND this workflow was registered in Step 1. If so, offer to write the workflow SOP to the Notion page using the `writing-workflow-sops` approach: pass the workflow name to locate the page, use the Baseline Prompt's procedure steps as the primary input, and write the formatted SOP to the page body. If Notion is not available or the workflow was not registered, skip this step.
 
 ## Outputs
 
@@ -33,7 +35,11 @@ Structure:
 
 The prompt must be: self-contained, specific, version-control ready, team-adoption ready.
 
-### `outputs/[workflow-name]-skill-recs.md` — Skill Build Recommendations
+**Self-contained means:** The prompt contains every instruction the model needs to execute the workflow. It never says "open this project" or "follow those instructions." If existing AI instructions drive a step, those instructions are written into the prompt.
+
+**Execution Context** — Include a section advising where to run the prompt (normal chat vs. project), which files to attach or pre-load, and why. The prompt instructions are the same regardless of execution context — the project provides file staging convenience, not workflow logic.
+
+### `outputs/[workflow-name]-skill-specs.md` — Skill Specs
 
 For each recommended skill:
 - **Skill Name** — 2-4 words, lowercase with hyphens
@@ -52,5 +58,5 @@ Present skills in priority order. If no steps qualify as good skill candidates, 
 
 - If the user mentions Claude, note where Claude Code Skills are the appropriate implementation
 - Use plain language; avoid jargon unless the user introduced it
-- After writing both files, tell the user: "Outputs saved to `outputs/[name]-prompt.md` and `outputs/[name]-skill-recs.md`. Your workflow deconstruction is complete."
+- After writing both files, tell the user: "Outputs saved to `outputs/[name]-prompt.md` and `outputs/[name]-skill-specs.md`. Your workflow deconstruction is complete."
 - Summarize the three files produced across all three steps so the user has a clear inventory of their deliverables

--- a/docs/business-first-ai-framework/deconstruct/building-blocks.md
+++ b/docs/business-first-ai-framework/deconstruct/building-blocks.md
@@ -1,20 +1,20 @@
 ---
-title: "Step 2 — Analysis & Mapping"
-description: Classify workflow steps on the autonomy spectrum, map them to AI building blocks, and produce a complete Workflow Analysis Document.
+title: "Step 2 — AI Building Blocks"
+description: Classify workflow steps on the autonomy spectrum, map them to AI building blocks, and produce a complete AI Building Block Map.
 ---
 
-# Step 2 — Analysis & Mapping
+# Step 2 — AI Building Blocks
 
 > **Part of:** [Deconstruct Workflows](index.md)
 
 ## What This Is
 
-A classification step where AI takes your Workflow Blueprint and determines what level of AI assistance each step needs — from fully human to fully autonomous — and maps each step to the specific AI building blocks required.
+A classification step where AI takes your Workflow Definition and determines what level of AI assistance each step needs — from fully human to fully autonomous — and maps each step to the specific AI building blocks required.
 
 | | |
 |---|---|
-| **What you'll do** | Upload your Blueprint from Step 1, review the AI's classification of each step, and adjust anything that doesn't look right |
-| **What you'll get** | A **Workflow Analysis Document** — a complete mapping of steps to autonomy levels and AI building blocks, with a prioritized build sequence |
+| **What you'll do** | Upload your Workflow Definition from Step 1, review the AI's classification of each step, and adjust anything that doesn't look right |
+| **What you'll get** | An **AI Building Block Map** — a complete mapping of steps to autonomy levels and AI building blocks, with a prioritized build sequence |
 | **Time** | ~5–10 minutes (mostly reviewing the AI's analysis) |
 
 ## Why This Matters
@@ -31,47 +31,47 @@ There are two ways to run Step 2, depending on which tools you use:
 
 1. **Copy the prompt** from the code block below
 2. **Paste it into a new conversation** in your preferred AI tool
-3. **Press Enter** — the model will ask you to paste your Workflow Blueprint
-4. **Upload or paste your Blueprint file** (`[workflow-name]-blueprint.md`) from Step 1
+3. **Press Enter** — the model will ask you to paste your Workflow Definition
+4. **Upload or paste your Workflow Definition file** (`[workflow-name]-definition.md`) from Step 1
 5. **Review the mapping** — the model will present its analysis and ask for adjustments
-6. **Download the Workflow Analysis Document** the model produces at the end — it will be a Markdown file named `[workflow-name]-analysis.md`
+6. **Download the AI Building Block Map** the model produces at the end — it will be a Markdown file named `[workflow-name]-building-blocks.md`
 7. **Keep this file** — you'll upload or paste it into Step 3, and you can share it with your instructor for feedback
 
 ### Option B: Claude skill
 
-Use the `analyzing-workflows` skill from the [Business-First AI plugin](../../plugins/business-first-ai.md). It reads the Blueprint from Step 1, runs the analysis, and saves the Workflow Analysis Document automatically.
+Use the `analyzing-workflows` skill from the [Business-First AI plugin](../../plugins/business-first-ai.md). It reads the Workflow Definition from Step 1, runs the analysis, and saves the AI Building Block Map automatically.
 
 - **Claude Code or Cowork** — install the plugin (`/plugin install business-first-ai@handsonai`) and start with:
     ```
-    Analyze the Workflow Blueprint in outputs/[workflow-name]-blueprint.md.
+    Analyze the Workflow Definition in outputs/[workflow-name]-definition.md.
     Classify each step and map it to AI building blocks.
     ```
-    The analysis is saved to `outputs/[workflow-name]-analysis.md`.
-- **Claude.ai** — zip the `analyzing-workflows` skill folder and upload it via **Settings > Capabilities > Upload skill**, then start a new chat with: "Analyze this Workflow Blueprint and map each step to AI building blocks." Upload or paste your Blueprint when prompted. See [Using Skills in Claude.ai](../../plugins/using-plugins.md#using-skills-in-claudeai-web) for detailed instructions.
+    The AI Building Block Map is saved to `outputs/[workflow-name]-building-blocks.md`.
+- **Claude.ai** — zip the `analyzing-workflows` skill folder and upload it via **Settings > Capabilities > Upload skill**, then start a new chat with: "Analyze this Workflow Definition and map each step to AI building blocks." Upload or paste your Workflow Definition when prompted. See [Using Skills in Claude.ai](../../plugins/using-plugins.md#using-skills-in-claudeai-web) for detailed instructions.
 
 !!! tip "This step is mostly analytical"
-    Unlike Step 1's extended back-and-forth, this conversation is shorter. The model does the heavy lifting — classifying steps, mapping building blocks, and generating the analysis document. Expect 5-10 minutes of light interaction.
+    Unlike Step 1's extended back-and-forth, this conversation is shorter. The model does the heavy lifting — classifying steps, mapping building blocks, and generating the AI Building Block Map. Expect 5-10 minutes of light interaction.
 
 ## The Prompt
 
 ```text
-You are an expert Workflow Analyst who specializes in mapping business workflows to AI building blocks. Your job is to take a structured Workflow Blueprint, classify each step on the autonomy spectrum, map it to AI building blocks, and produce a complete Workflow Analysis Document.
+You are an expert Workflow Analyst who specializes in mapping business workflows to AI building blocks. Your job is to take a structured Workflow Definition, classify each step on the autonomy spectrum, map it to AI building blocks, and produce a complete AI Building Block Map.
 
-I have a Workflow Blueprint from a previous conversation. I'll paste it when you ask for it.
+I have a Workflow Definition from a previous conversation. I'll paste it when you ask for it.
 
 ---
 
-## Part 1 — Paste Your Blueprint
+## Part 1 — Paste Your Workflow Definition
 
-Say: "Upload your Workflow Blueprint file, or paste its contents below, then press Enter."
+Say: "Upload your Workflow Definition file, or paste its contents below, then press Enter."
 
-Wait for me to provide it. After receiving the Blueprint, confirm you've read it by summarizing: the workflow name, the number of steps, and the workflow outcome. Then proceed to Part 2.
+Wait for me to provide it. After receiving the Workflow Definition, confirm you've read it by summarizing: the workflow name, the number of steps, and the workflow outcome. Then proceed to Part 2.
 
 ---
 
 ## Part 2 — AI Building Block Mapping
 
-For each refined step from the Blueprint, determine:
+For each refined step from the Workflow Definition, determine:
 
 1. **Autonomy classification** — Classify each step on the autonomy spectrum:
    - **Human step** — Requires human judgment, creativity, or physical action; AI cannot perform this
@@ -95,16 +95,16 @@ Present the mapping as a clear table, then walk me through your reasoning for an
 
 ---
 
-## Part 3 — Generate Workflow Analysis Document
+## Part 3 — Generate AI Building Block Map
 
-After I confirm the mapping, produce the complete **Workflow Analysis Document** as a Markdown file.
+After I confirm the mapping, produce the complete **AI Building Block Map** as a Markdown file.
 
-**File naming:** Name the file `[workflow-name]-analysis.md` using the same workflow name from the Blueprint (e.g., `lead-qualification-analysis.md`).
+**File naming:** Name the file `[workflow-name]-building-blocks.md` using the same workflow name from the Workflow Definition (e.g., `lead-qualification-building-blocks.md`).
 
-Generate the Analysis Document as a downloadable Markdown file. If your platform doesn't support file downloads, format it inside a single Markdown code block so I can copy and save it manually.
+Generate the AI Building Block Map as a downloadable Markdown file. If your platform doesn't support file downloads, format it inside a single Markdown code block so I can copy and save it manually.
 
 ### Scenario Summary
-- Workflow name (from Blueprint)
+- Workflow name (from Workflow Definition)
 - Description
 - Workflow outcome
 - Trigger
@@ -136,11 +136,11 @@ Generate the Analysis Document as a downloadable Markdown file. If your platform
 
 ### Context Inventory
 
-List every document, file, or reference material the workflow requires that the model does not have in its training data. For each artifact:
+List every document, file, reference material, or executable instruction the workflow requires that the model does not have in its training data. For each artifact:
 
-| Artifact | Description | Used By Steps | Status | Format | Key Contents |
-|----------|-------------|---------------|--------|--------|--------------|
-| [Name] | [What it contains and why the workflow needs it] | [Step numbers] | Exists / Needs Creation | [e.g., Markdown doc, spreadsheet, PDF] | [Essential fields, sections, or data points it should include] |
+| Artifact | Type | Description | Used By Steps | Status | Format | Key Contents |
+|----------|------|-------------|---------------|--------|--------|--------------|
+| [Name] | Reference Material / Executable Instructions | [What it contains and why the workflow needs it] | [Step numbers] | Exists / Needs Creation | [e.g., Markdown doc, spreadsheet, PDF] | [Essential fields, sections, or data points it should include] |
 
 If an artifact needs to be created, the "Key Contents" column should be specific enough that the user knows exactly what to build. For example, a buyer persona document should list: target job titles, company size range, industry verticals, pain points, budget authority indicators, and qualifying criteria — not just "buyer persona info."
 
@@ -154,17 +154,38 @@ Prioritize the AI-eligible steps into a build sequence:
 3. **Complex agent steps** — Fully autonomous steps requiring Agents, MCP connectors, or multi-tool orchestration. Tackle these last.
 For each priority tier, list the specific steps and what the student needs to build (e.g., "Write a prompt for Step 3," "Set up an MCP connector for Step 7").
 
+### Execution Context
+
+Recommend where the Baseline Workflow Prompt should be run:
+
+**Normal chat** — recommended when:
+- The workflow runs infrequently (monthly or less)
+- Few or no context files are needed (0-2 files)
+- All context can be provided inline each time
+- The workflow is a one-off or experimental process
+
+**Project workspace** — recommended when:
+- The workflow runs frequently (weekly or more)
+- Multiple context files are needed (3+ files)
+- The same reference materials are used every run
+- Conversation memory across runs would be valuable
+- Multiple people will run the same workflow
+
+State the recommendation, the reasoning, and list the specific context files to attach (chat) or pre-load in the project.
+
+**Important:** The Baseline Workflow Prompt is always self-contained — it contains all executable instructions regardless of execution context. A project provides file staging and general domain context, but never contains the workflow logic. The prompt IS the workflow.
+
 ---
 
-After presenting the Workflow Analysis Document, tell me:
+After presenting the AI Building Block Map, tell me:
 
-> **Next step:** Download (or copy and save) the Workflow Analysis Document file. Then go to [Step 3 — Output Generation](https://handsonai.info/business-first-ai-framework/deconstruct/outputs/), copy that prompt into a new conversation, and upload or paste the Analysis Document when the model asks for it.
+> **Next step:** Download (or copy and save) the AI Building Block Map file. Then go to [Step 3 — Prompt & Skill Specs](https://handsonai.info/business-first-ai-framework/deconstruct/prompt-skill-specs/), copy that prompt into a new conversation, and upload or paste the AI Building Block Map when the model asks for it.
 
 ---
 
 ## General Instructions
 
-- If the Blueprint is missing information needed for classification, ask me to clarify before guessing.
+- If the Workflow Definition is missing information needed for classification, ask me to clarify before guessing.
 - If I mention I'm using Claude, note where Skills would be the appropriate building block for reusable routines.
 - Explain your reasoning for any non-obvious classifications.
 - Use plain language. Avoid jargon unless the student introduced it.
@@ -172,15 +193,16 @@ After presenting the Workflow Analysis Document, tell me:
 
 ## What This Prompt Produces
 
-The **Workflow Analysis Document** (Deliverable 1) contains:
+The **AI Building Block Map** (Deliverable 1) contains:
 
-- **Scenario summary** — workflow metadata from the Blueprint
+- **Scenario summary** — workflow metadata from the Workflow Definition
 - **Decomposition table** — every step with autonomy classification, decision points, failure modes, data flows, context needs, and AI building block mapping
 - **Autonomy spectrum summary** — steps grouped by classification level
 - **Step sequence and dependencies** — sequential vs. parallel execution paths
 - **Prerequisites** — what must be in place before the workflow can run
-- **Context inventory** — every resource the workflow needs, with status and key contents
+- **Context inventory** — every resource the workflow needs, typed as reference material or executable instructions, with status and key contents
 - **Tools and connectors** — external integrations required
 - **Recommended implementation order** — prioritized build sequence (quick wins first, complex agent steps last)
+- **Execution context** — where to run the Baseline Workflow Prompt (normal chat vs. project), with reasoning and file lists
 
-This Analysis Document is the input for [Step 3 — Output Generation](outputs.md), where the model generates your ready-to-use workflow prompt and skill build recommendations.
+This AI Building Block Map is the input for [Step 3 — Prompt & Skill Specs](prompt-skill-specs.md), where the model generates your ready-to-use Baseline Prompt and Skill Specs.

--- a/docs/business-first-ai-framework/deconstruct/index.md
+++ b/docs/business-first-ai-framework/deconstruct/index.md
@@ -17,7 +17,7 @@ A three-conversation series that breaks down a business workflow into discrete s
 | | |
 |---|---|
 | **What you'll do** | Work through three focused prompts — discovering and decomposing your workflow, classifying each step and mapping AI capabilities, then generating executable outputs |
-| **What you'll get** | Four Markdown files — a Workflow Blueprint, a Workflow Analysis Document, a Baseline Workflow Prompt (ready to paste and run), and Skill Build Recommendations |
+| **What you'll get** | Four Markdown files — a Workflow Definition, an AI Building Block Map, a Baseline Workflow Prompt (self-contained and ready to paste and run, with guidance on where to execute it), and Skill Specs |
 | **Time** | ~30–45 minutes across three conversations |
 
 ## Why This Matters
@@ -26,9 +26,9 @@ You can't operationalize AI on a process you don't understand. Before you can bu
 
 This series of prompts walks you through that deconstruction interactively. You provide the business scenario and rough steps — the model handles the structured analysis, applies the 5-question framework (discrete steps, decision points, data flows, context needs, failure modes), maps each step to AI building blocks, and generates three deliverables:
 
-1. A **Workflow Analysis Document** — the full decomposition with autonomy classifications, AI building block mapping, a context inventory of every resource the workflow needs (documents, files, data sources, system access), and a prioritized build sequence
+1. An **AI Building Block Map** — the full decomposition with autonomy classifications, AI building block mapping, a context inventory of every resource the workflow needs (documents, files, data sources, system access), and a prioritized build sequence
 2. A **Baseline Workflow Prompt** — a ready-to-use prompt that works on any platform; this is your starting point that will evolve as you build skills
-3. **Skill Build Recommendations** — actionable specs for reusable skills you can build to automate recurring steps
+3. **Skill Specs** — actionable specs for reusable skills you can build to automate recurring steps
 
 This builds directly on the concepts from the course lessons on workflow deconstruction and AI building blocks. If terms like the "5-question framework" or "six building blocks" are new to you, review the [Key Concepts section of the Business-First AI Framework](../index.md#key-concepts) for quick definitions before starting.
 
@@ -38,11 +38,11 @@ The workflow deconstruction is split into three focused prompts. Each prompt pro
 
 | Step | Prompt | What it does | Produces |
 |------|--------|-------------|----------|
-| 1 | [Discovery & Deep Dive](discovery.md) | Discover the workflow, decompose every step | **Workflow Blueprint** |
-| 2 | [Analysis & Mapping](analysis.md) | Classify steps, map AI building blocks | **Workflow Analysis Document** |
-| 3 | [Output Generation](outputs.md) | Generate the executable prompt and skill specs | **Baseline Prompt** + **Skill Recommendations** |
+| 1 | [Workflow Definition](workflow-definition.md) | Discover the workflow, decompose every step | **Workflow Definition** |
+| 2 | [AI Building Blocks](building-blocks.md) | Classify steps, map AI building blocks | **AI Building Block Map** |
+| 3 | [Prompt & Skill Specs](prompt-skill-specs.md) | Generate the self-contained executable prompt (with execution context) and skill specs | **Baseline Prompt** + **Skill Specs** |
 
-**Between each step:** Download (or copy and save) the output artifact as a Markdown file, then upload or paste it into the next conversation. Each prompt starts by asking you to provide the previous step's output. The files use a consistent naming convention: `[workflow-name]-blueprint.md`, `[workflow-name]-analysis.md`, `[workflow-name]-prompt.md`, and `[workflow-name]-skill-recs.md`.
+**Between each step:** Download (or copy and save) the output artifact as a Markdown file, then upload or paste it into the next conversation. Each prompt starts by asking you to provide the previous step's output. The files use a consistent naming convention: `[workflow-name]-definition.md`, `[workflow-name]-building-blocks.md`, `[workflow-name]-prompt.md`, and `[workflow-name]-skill-specs.md`.
 
 ### Why three conversations instead of one?
 
@@ -58,12 +58,12 @@ There are four ways to run Phase 2, depending on which tools you use:
 
     Use this if you're working in ChatGPT, Gemini, M365 Copilot, or any AI chat tool. Copy each prompt into a new conversation and work through the three steps sequentially.
 
-    1. **Go to [Step 1 — Discovery & Deep Dive](discovery.md)** — Copy the prompt, start a new conversation, paste the prompt, and describe your workflow
-    2. **Save the Workflow Blueprint** — Download the `.md` file the model produces (or copy the output and save it as `[workflow-name]-blueprint.md`)
-    3. **Go to [Step 2 — Analysis & Mapping](analysis.md)** — Copy that prompt, start a **new** conversation, paste the prompt, then upload or paste your Blueprint file
-    4. **Save the Workflow Analysis Document** — Download `[workflow-name]-analysis.md`
-    5. **Go to [Step 3 — Output Generation](outputs.md)** — Copy that prompt, start a **new** conversation, paste the prompt, then upload or paste your Analysis Document
-    6. **Save your final deliverables** — Download `[workflow-name]-prompt.md` and `[workflow-name]-skill-recs.md`
+    1. **Go to [Step 1 — Workflow Definition](workflow-definition.md)** — Copy the prompt, start a new conversation, paste the prompt, and describe your workflow
+    2. **Save the Workflow Definition** — Download the `.md` file the model produces (or copy the output and save it as `[workflow-name]-definition.md`)
+    3. **Go to [Step 2 — AI Building Blocks](building-blocks.md)** — Copy that prompt, start a **new** conversation, paste the prompt, then upload or paste your Workflow Definition file
+    4. **Save the AI Building Block Map** — Download `[workflow-name]-building-blocks.md`
+    5. **Go to [Step 3 — Prompt & Skill Specs](prompt-skill-specs.md)** — Copy that prompt, start a **new** conversation, paste the prompt, then upload or paste your AI Building Block Map
+    6. **Save your final deliverables** — Download `[workflow-name]-prompt.md` and `[workflow-name]-skill-specs.md`
 
 === "Claude Code"
 
@@ -118,7 +118,7 @@ All four options follow the same process and produce the same deliverables. Choo
     Real workflows produce the best results. The model will surface hidden steps and assumptions you've internalized — that's much harder with hypothetical processes. If you don't have an existing workflow but have a clear problem to solve, that works too — the model will help you design one.
 
 !!! tip "Keep your files together"
-    By the end you'll have four Markdown files: `[name]-blueprint.md`, `[name]-analysis.md`, `[name]-prompt.md`, and `[name]-skill-recs.md`. Keep them in a single folder — they form a complete record of your workflow deconstruction. You can share any of these files with your instructor for feedback, put them in version control, or hand them to a colleague.
+    By the end you'll have four Markdown files: `[name]-definition.md`, `[name]-building-blocks.md`, `[name]-prompt.md`, and `[name]-skill-specs.md`. Keep them in a single folder — they form a complete record of your workflow deconstruction. You can share any of these files with your instructor for feedback, put them in version control, or hand them to a colleague.
 
 ### Example: What the first exchange looks like
 
@@ -166,9 +166,9 @@ You don't need to know all the steps before you start — that's what the prompt
 
 ## What to Expect
 
-1. **[Step 1 — Discovery & Deep Dive](discovery.md)** (~15-25 minutes) — The model asks about your business scenario, objective, steps, and who's involved. Then it works through each step one by one, asking about sub-steps, decision points, data flows, context needs, and failure modes. For later steps, it switches to a "propose and react" pattern — presenting hypotheses for you to correct, which is faster and surfaces more detail. Produces a **Workflow Blueprint**.
-2. **[Step 2 — Analysis & Mapping](analysis.md)** (~5-10 minutes) — The model classifies each refined step on the autonomy spectrum and maps it to AI building blocks. You review the mapping table and adjust. Produces a **Workflow Analysis Document**.
-3. **[Step 3 — Output Generation](outputs.md)** (~5-10 minutes) — The model generates your baseline workflow prompt and skill build recommendations. Mostly generative — 1-2 clarifying questions at most. Produces the **Baseline Workflow Prompt** and **Skill Build Recommendations**.
+1. **[Step 1 — Workflow Definition](workflow-definition.md)** (~15-25 minutes) — The model asks about your business scenario, objective, steps, and who's involved. Then it works through each step one by one, asking about sub-steps, decision points, data flows, context needs, and failure modes. For later steps, it switches to a "propose and react" pattern — presenting hypotheses for you to correct, which is faster and surfaces more detail. Produces a **Workflow Definition**.
+2. **[Step 2 — AI Building Blocks](building-blocks.md)** (~5-10 minutes) — The model classifies each refined step on the autonomy spectrum and maps it to AI building blocks. You review the mapping table and adjust. Produces an **AI Building Block Map**.
+3. **[Step 3 — Prompt & Skill Specs](prompt-skill-specs.md)** (~5-10 minutes) — The model generates your Baseline Workflow Prompt and Skill Specs. Mostly generative — 1-2 clarifying questions at most. Produces the **Baseline Workflow Prompt** and **Skill Specs**.
 
 Most workflows expand from 5-8 rough steps to 12-20 refined steps after the deep dive. The baseline prompt is ready to use immediately — paste it into a new conversation to run the workflow.
 
@@ -179,7 +179,7 @@ Most workflows expand from 5-8 rough steps to 12-20 refined steps after the deep
 - **Don't over-prepare your steps.** The model is designed to work with rough, incomplete descriptions. Let it do the work of refining and organizing.
 - **On Claude:** Mention that you're using Claude so the model can identify where Skills are the right building block for reusable routines.
 - **Gather your context resources early.** The model will identify specific resources the workflow needs — documents like buyer personas and style guides, but also spreadsheets, databases, CRM access, application credentials, and sample data. If you already have these, have them ready. If you don't, the analysis will tell you exactly what to create or set up and what each resource should contain.
-- **Save all four files.** The Blueprint and Analysis Document are your reference material. The baseline prompt is what you run today — update it as you build skills. The skill recommendations tell you what to build and which prompt steps each skill replaces. Keep them together in a folder or version control.
+- **Save all four files.** The Workflow Definition and AI Building Block Map are your reference material. The baseline prompt is what you run today — update it as you build skills. The Skill Specs tell you what to build and which prompt steps each skill replaces. Keep them together in a folder or version control.
 - **Iterate the executable prompt.** Run it once, see what works and what doesn't, then refine. The first version is a strong draft, not a final product.
 
 ??? note "Original single-prompt version"
@@ -187,7 +187,7 @@ Most workflows expand from 5-8 rough steps to 12-20 refined steps after the deep
     If you're using a model with a large context window (Claude Pro, ChatGPT Plus, Gemini Advanced), you can use the original single-prompt version that runs the entire workflow deconstruction in one conversation. This is more convenient but may hit context limits on free-tier models.
 
     ```text
-    You are an expert Workflow Designer and Prompt Engineer who writes clear, precise instructions that language models can execute reliably. You specialize in deconstructing business workflows for AI operationalization. Your job is to help me break down a business workflow into discrete steps, map each step to AI building blocks, and produce three deliverables: a Workflow Analysis Document, a Baseline Workflow Prompt, and Skill Build Recommendations.
+    You are an expert Workflow Designer and Prompt Engineer who writes clear, precise instructions that language models can execute reliably. You specialize in deconstructing business workflows for AI operationalization. Your job is to help me break down a business workflow into discrete steps, map each step to AI building blocks, and produce three deliverables: an AI Building Block Map, a Baseline Workflow Prompt, and Skill Specs.
 
     Work through the following four parts in order. Ask one question at a time during interactive parts. Wait for my response before moving on.
 
@@ -247,11 +247,17 @@ Most workflows expand from 5-8 rough steps to 12-20 refined steps after the deep
 
     **Probing for context artifacts:** When exploring context needs, push beyond vague answers like "domain knowledge" or "background info." Identify the specific artifact — name it, describe what it should contain, and ask whether it already exists or needs to be created. Common examples: buyer persona documents, style guides, grading rubrics, product catalogs, pricing sheets, email templates, brand voice documents, org charts, decision criteria checklists, sample inputs, and sample outputs. If a step requires the model to match a standard, apply criteria, or follow a style, there is almost certainly a reference document behind it.
 
+    **Probing for executable instructions:** For any step where AI is already being used, ask specifically: "Do you have existing prompt instructions, project instructions, custom assistant configurations, or system prompts that tell the AI what to do at this step? If so, I'll need to see those — they contain the workflow logic that belongs in your Baseline Prompt." Distinguish between:
+    - **Reference materials** — documents, files, data, or examples the model reads to inform its work (PDFs, CSVs, spreadsheets, style guides)
+    - **Executable instructions** — prompts, project instructions, system prompts, or custom assistant configurations that tell the model what to do and how to do it
+
+    Reference materials are context the model consumes. Executable instructions are logic the model follows. Both matter, but they serve different purposes in the final prompt.
+
     After completing all steps:
 
     1. Present the refined step-by-step breakdown.
     2. **Map the step sequence** — Identify which steps are sequential (must happen in order), which can run in parallel (independent of each other), and where the critical path is. Show this as a simple dependency list (e.g., "Step 3 depends on Steps 1 and 2; Steps 4 and 5 can run in parallel").
-    3. **Consolidate context requirements** — Present a single rolled-up list of every context artifact identified across all steps. For each artifact, state: the artifact name, a one-line description of what it contains, which steps depend on it, and whether it already exists or needs to be created. If it needs to be created, note the key contents it should include so I know what to build. Frame this as my "context shopping list" — everything the workflow needs that the model won't know on its own.
+    3. **Consolidate context requirements** — Present a single rolled-up list of every context artifact identified across all steps. For each artifact, state: the artifact name, its type (Reference Material or Executable Instructions), a one-line description of what it contains, which steps depend on it, and whether it already exists or needs to be created. If it needs to be created, note the key contents it should include so I know what to build. Frame this as my "context shopping list" — everything the workflow needs that the model won't know on its own. Artifacts typed as "Executable Instructions" contain workflow logic that must be included in the Baseline Workflow Prompt. Artifacts typed as "Reference Material" are context files the model reads.
     4. Ask me to confirm the breakdown, sequence, and context shopping list are accurate.
 
     ---
@@ -282,11 +288,11 @@ Most workflows expand from 5-8 rough steps to 12-20 refined steps after the deep
 
     ---
 
-    ## Part 4 — Output Generation
+    ## Part 4 — Prompt & Skill Specs
 
     Produce three deliverables:
 
-    ### Deliverable 1: Workflow Analysis Document
+    ### Deliverable 1: AI Building Block Map
 
     Create a structured analysis containing:
 
@@ -323,11 +329,11 @@ Most workflows expand from 5-8 rough steps to 12-20 refined steps after the deep
 
     **Context Inventory**
 
-    List every document, file, or reference material the workflow requires that the model does not have in its training data. For each artifact:
+    List every document, file, reference material, or executable instruction the workflow requires that the model does not have in its training data. For each artifact:
 
-    | Artifact | Description | Used By Steps | Status | Format | Key Contents |
-    |----------|-------------|---------------|--------|--------|--------------|
-    | [Name] | [What it contains and why the workflow needs it] | [Step numbers] | Exists / Needs Creation | [e.g., Markdown doc, spreadsheet, PDF] | [Essential fields, sections, or data points it should include] |
+    | Artifact | Type | Description | Used By Steps | Status | Format | Key Contents |
+    |----------|------|-------------|---------------|--------|--------|--------------|
+    | [Name] | Reference Material / Executable Instructions | [What it contains and why the workflow needs it] | [Step numbers] | Exists / Needs Creation | [e.g., Markdown doc, spreadsheet, PDF] | [Essential fields, sections, or data points it should include] |
 
     If an artifact needs to be created, the "Key Contents" column should be specific enough that the user knows exactly what to build. For example, a buyer persona document should list: target job titles, company size range, industry verticals, pain points, budget authority indicators, and qualifying criteria — not just "buyer persona info."
 
@@ -341,9 +347,32 @@ Most workflows expand from 5-8 rough steps to 12-20 refined steps after the deep
     3. **Complex agent steps** — Fully autonomous steps requiring Agents, MCP connectors, or multi-tool orchestration. Tackle these last.
     For each priority tier, list the specific steps and what the student needs to build (e.g., "Write a prompt for Step 3," "Set up an MCP connector for Step 7").
 
+    **Execution Context**
+
+    Recommend where the Baseline Workflow Prompt should be run:
+
+    **Normal chat** — recommended when:
+    - The workflow runs infrequently (monthly or less)
+    - Few or no context files are needed (0-2 files)
+    - All context can be provided inline each time
+    - The workflow is a one-off or experimental process
+
+    **Project workspace** — recommended when:
+    - The workflow runs frequently (weekly or more)
+    - Multiple context files are needed (3+ files)
+    - The same reference materials are used every run
+    - Conversation memory across runs would be valuable
+    - Multiple people will run the same workflow
+
+    State the recommendation, the reasoning, and list the specific context files to attach (chat) or pre-load in the project.
+
+    **Important:** The Baseline Workflow Prompt is always self-contained — it contains all executable instructions regardless of execution context. A project provides file staging and general domain context, but never contains the workflow logic. The prompt IS the workflow.
+
     ### Deliverable 2: Baseline Workflow Prompt
 
     Generate a ready-to-use Markdown prompt that someone could paste into any AI tool to execute this workflow. This is the **baseline version** — it spells out every step in full so it works on any platform (Claude, ChatGPT, Gemini, M365 Copilot). As the user builds skills from Deliverable 3, they'll update this prompt to invoke those skills instead of repeating the logic inline.
+
+    **Before generating the prompt, check the Context Inventory for any artifacts typed as "Executable Instructions."** These contain workflow logic that must be included in the Baseline Prompt — not referenced, but actually included. If the analysis indicates executable instructions exist (e.g., existing project instructions, system prompts, or custom assistant configurations) but their content was not provided, ask the user to paste or upload those instructions now. The Baseline Prompt cannot reference external systems for its core logic — it must be self-contained.
 
     Structure it as:
 
@@ -376,7 +405,17 @@ Most workflows expand from 5-8 rough steps to 12-20 refined steps after the deep
     - Ready for version control (clean Markdown, no ambiguity)
     - Ready for team adoption (clear enough that a colleague could run it)
 
-    ### Deliverable 3: Skill Build Recommendations
+    **Self-contained means:** The prompt contains every instruction the model needs to execute the workflow. It never says "open this project" or "follow those instructions" or "refer to the project instructions." If existing AI instructions drive a step, those instructions are written into the prompt. A reader who has never seen the AI Building Block Map can execute this prompt successfully.
+
+    **Execution Context**
+    - Where to run this prompt (normal chat vs. project)
+    - If normal chat: which files to attach when pasting the prompt
+    - If project: how to set up the project (name, which files to pre-load, any general project-level settings), then paste this prompt into a conversation within the project
+    - Decision criteria summary so the user understands why this recommendation was made
+
+    Note: The prompt instructions above are the same regardless of execution context. The project provides file staging convenience — the prompt provides the workflow logic.
+
+    ### Deliverable 3: Skill Specs
 
     Based on the workflow analysis, recommend which reusable skills the user should build. Focus on steps that are:
     - Repeatable (executed frequently with similar patterns)

--- a/docs/business-first-ai-framework/deconstruct/prompt-skill-specs.md
+++ b/docs/business-first-ai-framework/deconstruct/prompt-skill-specs.md
@@ -1,27 +1,27 @@
 ---
-title: "Step 3 — Output Generation"
-description: Generate a ready-to-use Baseline Workflow Prompt and Skill Build Recommendations from your Workflow Analysis Document.
+title: "Step 3 — Prompt & Skill Specs"
+description: Generate a ready-to-use Baseline Workflow Prompt and Skill Specs from your AI Building Block Map.
 ---
 
-# Step 3 — Output Generation
+# Step 3 — Prompt & Skill Specs
 
 > **Part of:** [Deconstruct Workflows](index.md)
 
 ## What This Is
 
-The final step that turns your analysis into action. AI reads your Workflow Analysis Document and generates two ready-to-use deliverables: a prompt you can paste into any AI tool to execute the workflow today, and a roadmap of reusable skills to build over time.
+The final step that turns your analysis into action. AI reads your AI Building Block Map and generates two ready-to-use deliverables: a prompt you can paste into any AI tool to execute the workflow today, and a set of skill specs for reusable skills to build over time.
 
 | | |
 |---|---|
-| **What you'll do** | Upload your Analysis Document from Step 2, answer 1–2 clarifying questions, then review the generated outputs |
-| **What you'll get** | A **Baseline Workflow Prompt** (ready to paste and run) and **Skill Build Recommendations** (what to build next and in what order) |
+| **What you'll do** | Upload your AI Building Block Map from Step 2, answer 1–2 clarifying questions, then review the generated outputs |
+| **What you'll get** | A **Baseline Workflow Prompt** (ready to paste and run) and **Skill Specs** (what to build next and in what order) |
 | **Time** | ~5–10 minutes (mostly generative — the AI does the heavy lifting) |
 
 ## Why This Matters
 
 Analysis without action is just documentation. The Baseline Workflow Prompt gives you something you can use immediately — paste it into any AI tool and run your workflow. It works on day one, on any platform.
 
-The Skill Build Recommendations show you how to evolve that prompt over time. Each skill you build replaces a section of the baseline prompt, making the workflow shorter, more reliable, and more reusable. You get a clear path from "working but manual" to "automated and refined" — with specific priorities so you know what to build first.
+The Skill Specs show you how to evolve that prompt over time. Each skill you build replaces a section of the baseline prompt, making the workflow shorter, more reliable, and more reusable. You get a clear path from "working but manual" to "automated and refined" — with specific priorities so you know what to build first.
 
 ## How to Use This
 
@@ -31,42 +31,42 @@ There are two ways to run Step 3, depending on which tools you use:
 
 1. **Copy the prompt** from the code block below
 2. **Paste it into a new conversation** in your preferred AI tool
-3. **Press Enter** — the model will ask you to upload or paste your Workflow Analysis Document
-4. **Upload or paste your Analysis Document file** (`[workflow-name]-analysis.md`) from Step 2
+3. **Press Enter** — the model will ask you to upload or paste your AI Building Block Map
+4. **Upload or paste your AI Building Block Map file** (`[workflow-name]-building-blocks.md`) from Step 2
 5. **Review the outputs** — the model may ask 1-2 clarifying questions, then generates both deliverables
-6. **Download both files** — the Baseline Workflow Prompt and Skill Build Recommendations
+6. **Download both files** — the Baseline Workflow Prompt and Skill Specs
 
 ### Option B: Claude skill
 
-Use the `generating-workflow-outputs` skill from the [Business-First AI plugin](../../plugins/business-first-ai.md). It reads the Analysis Document from Step 2 and generates both deliverables automatically.
+Use the `generating-workflow-outputs` skill from the [Business-First AI plugin](../../plugins/business-first-ai.md). It reads the AI Building Block Map from Step 2 and generates both deliverables automatically.
 
 - **Claude Code or Cowork** — install the plugin (`/plugin install business-first-ai@handsonai`) and start with:
     ```
-    Generate the Baseline Workflow Prompt and Skill Build Recommendations
-    from the analysis in outputs/[workflow-name]-analysis.md.
+    Generate the Baseline Workflow Prompt and Skill Specs
+    from the AI Building Block Map in outputs/[workflow-name]-building-blocks.md.
     ```
     Both deliverables are saved to the `outputs/` directory.
-- **Claude.ai** — zip the `generating-workflow-outputs` skill folder and upload it via **Settings > Capabilities > Upload skill**, then start a new chat with: "Generate a Baseline Workflow Prompt and Skill Build Recommendations from this analysis." Upload or paste your Analysis Document when prompted. See [Using Skills in Claude.ai](../../plugins/using-plugins.md#using-skills-in-claudeai-web) for detailed instructions.
+- **Claude.ai** — zip the `generating-workflow-outputs` skill folder and upload it via **Settings > Capabilities > Upload skill**, then start a new chat with: "Generate a Baseline Workflow Prompt and Skill Specs from this AI Building Block Map." Upload or paste your AI Building Block Map when prompted. See [Using Skills in Claude.ai](../../plugins/using-plugins.md#using-skills-in-claudeai-web) for detailed instructions.
 
 !!! tip "This step is mostly generative"
-    The heavy analytical work is done. The model reads your Analysis Document and produces two structured outputs with minimal interaction. Expect 5-10 minutes.
+    The heavy analytical work is done. The model reads your AI Building Block Map and produces two structured outputs with minimal interaction. Expect 5-10 minutes.
 
 ## The Prompt
 
 ```text
-You are an expert Prompt Engineer who writes clear, precise instructions that language models can execute reliably. Your job is to take a Workflow Analysis Document and produce two deliverables: a Baseline Workflow Prompt and Skill Build Recommendations.
+You are an expert Prompt Engineer who writes clear, precise instructions that language models can execute reliably. Your job is to take an AI Building Block Map and produce two deliverables: a Baseline Workflow Prompt and Skill Specs.
 
-I have a Workflow Analysis Document from a previous conversation. I'll paste it when you ask for it.
+I have an AI Building Block Map from a previous conversation. I'll paste it when you ask for it.
 
 ---
 
-## Part 1 — Paste Your Analysis Document
+## Part 1 — Paste Your AI Building Block Map
 
-Say: "Upload your Workflow Analysis Document file, or paste its contents below, then press Enter."
+Say: "Upload your AI Building Block Map file, or paste its contents below, then press Enter."
 
 Wait for me to provide it. After receiving the document, confirm you've read it by summarizing: the workflow name, the number of steps, how many are AI-eligible, and the recommended implementation order. Then proceed to Part 2.
 
-If anything in the Analysis Document is ambiguous or seems incomplete, ask me to clarify before generating outputs. Do not guess at missing information.
+If anything in the AI Building Block Map is ambiguous or seems incomplete, ask me to clarify before generating outputs. Do not guess at missing information.
 
 ---
 
@@ -74,10 +74,12 @@ If anything in the Analysis Document is ambiguous or seems incomplete, ask me to
 
 Generate a ready-to-use Markdown prompt that someone could paste into any AI tool to execute this workflow. This is the **baseline version** — it spells out every step in full so it works on any platform (Claude, ChatGPT, Gemini, M365 Copilot). As the user builds skills from the recommendations below, they'll update this prompt to invoke those skills instead of repeating the logic inline.
 
+**Before generating the prompt, check the Context Inventory for any artifacts typed as "Executable Instructions."** These contain workflow logic that must be included in the Baseline Prompt — not referenced, but actually included. If the AI Building Block Map indicates executable instructions exist (e.g., existing project instructions, system prompts, or custom assistant configurations) but their content is not in the AI Building Block Map, ask the user to paste or upload those instructions now. The Baseline Prompt cannot reference external systems for its core logic — it must be self-contained.
+
 Structure it as:
 
 **Title and Purpose**
-- Workflow name and description (from the Analysis Document)
+- Workflow name and description (from the AI Building Block Map)
 - Workflow outcome — what this workflow produces
 - When to use it
 
@@ -105,15 +107,25 @@ The prompt should be:
 - Ready for version control (clean Markdown, no ambiguity)
 - Ready for team adoption (clear enough that a colleague could run it)
 
-**File naming:** Name the file `[workflow-name]-prompt.md` using the same workflow name from the Analysis Document (e.g., `lead-qualification-prompt.md`).
+**Self-contained means:** The prompt contains every instruction the model needs to execute the workflow. It never says "open this project" or "follow those instructions" or "refer to the project instructions." If existing AI instructions drive a step, those instructions are written into the prompt. A reader who has never seen the AI Building Block Map or Workflow Definition can execute this prompt successfully.
+
+**Execution Context**
+- Where to run this prompt (normal chat vs. project), based on the AI Building Block Map's recommendation
+- If normal chat: which files to attach when pasting the prompt
+- If project: how to set up the project (name, which files to pre-load, any general project-level settings), then paste this prompt into a conversation within the project
+- Decision criteria summary so the user understands why this recommendation was made
+
+Note: The prompt instructions above are the same regardless of execution context. The project provides file staging convenience — the prompt provides the workflow logic.
+
+**File naming:** Name the file `[workflow-name]-prompt.md` using the same workflow name from the AI Building Block Map (e.g., `lead-qualification-prompt.md`).
 
 Generate the prompt as a downloadable Markdown file. If your platform doesn't support file downloads, format it inside a single Markdown code block so I can copy and save it manually.
 
 ---
 
-## Part 3 — Generate Skill Build Recommendations
+## Part 3 — Generate Skill Specs
 
-Based on the Workflow Analysis Document, recommend which reusable skills I should build. Focus on steps that are:
+Based on the AI Building Block Map, recommend which reusable skills I should build. Focus on steps that are:
 - Repeatable (executed frequently with similar patterns)
 - Mechanical (follow clear rules, not creative judgment)
 - Consistent (should produce the same output structure every time)
@@ -154,7 +166,7 @@ For each recommended skill, provide:
 
 Present skills in priority order (highest value first). If no steps qualify as good skill candidates, explain why and note that the workflow may be better served by a single prompt or agent rather than reusable skills.
 
-**File naming:** Name the file `[workflow-name]-skill-recs.md` using the same workflow name (e.g., `lead-qualification-skill-recs.md`).
+**File naming:** Name the file `[workflow-name]-skill-specs.md` using the same workflow name (e.g., `lead-qualification-skill-specs.md`).
 
 Generate the recommendations as a downloadable Markdown file. If your platform doesn't support file downloads, format it inside a single Markdown code block so I can copy and save it manually.
 
@@ -164,12 +176,14 @@ After presenting both files, summarize what I now have:
 
 > **Workflow deconstruction complete.** You now have four files:
 >
-> 1. `[workflow-name]-blueprint.md` — your Workflow Blueprint (from Step 1)
-> 2. `[workflow-name]-analysis.md` — your Workflow Analysis Document (from Step 2)
+> 1. `[workflow-name]-definition.md` — your Workflow Definition (from Step 1)
+> 2. `[workflow-name]-building-blocks.md` — your AI Building Block Map (from Step 2)
 > 3. `[workflow-name]-prompt.md` — your Baseline Workflow Prompt (ready to use)
-> 4. `[workflow-name]-skill-recs.md` — your Skill Build Recommendations (what to build next)
+> 4. `[workflow-name]-skill-specs.md` — your Skill Specs (what to build next)
 >
 > Start by running the baseline prompt on a real scenario. Then build skills in priority order from the recommendations.
+
+**Write workflow SOP (Claude users, optional):** If you registered this workflow to the AI Registry in Step 1, you can now generate a Standard Operating Procedure and save it to the workflow's Notion page. Use the `writing-workflow-sops` skill from the AI Registry plugin — it reads the workflow entry from Notion, uses the Baseline Prompt's procedure steps as input, and writes a formatted SOP (overview, prerequisites, trigger, step-by-step procedure, outputs, quality checks, troubleshooting) directly to the page body. This gives your workflow a complete home in Notion: metadata in the properties, SOP in the page content, and deliverable files in your local folder.
 
 ---
 
@@ -177,7 +191,7 @@ After presenting both files, summarize what I now have:
 
 - If I mention I'm using Claude, note where Claude Code Skills are the appropriate implementation. On other platforms, map to custom instructions, GPTs, or Gems.
 - Use plain language. Avoid jargon unless the student introduced it.
-- If anything is ambiguous in the Analysis Document, ask me before generating.
+- If anything is ambiguous in the AI Building Block Map, ask me before generating.
 ```
 
 ## What This Prompt Produces
@@ -186,7 +200,7 @@ After presenting both files, summarize what I now have:
 
 A ready-to-paste prompt that works on any AI platform. Every step is spelled out in full — no skills or shortcuts required. This is your starting point. As you build skills from the recommendations, you'll update this prompt to call those skills instead of repeating the logic inline.
 
-### Skill Build Recommendations (Deliverable 3)
+### Skill Specs (Deliverable 3)
 
 Actionable specs for each recommended skill, including:
 
@@ -203,10 +217,10 @@ You now have four Markdown files from the full workflow deconstruction:
 
 | File | What it is | What to do with it |
 |------|-----------|-------------------|
-| `[name]-blueprint.md` | Workflow Blueprint (Step 1) | Reference — the raw decomposition you can revisit |
-| `[name]-analysis.md` | Workflow Analysis Document (Step 2) | Reference — the full analysis with building block mapping |
+| `[name]-definition.md` | Workflow Definition (Step 1) | Reference — the raw decomposition you can revisit |
+| `[name]-building-blocks.md` | AI Building Block Map (Step 2) | Reference — the full analysis with building block mapping |
 | `[name]-prompt.md` | Baseline Workflow Prompt (Step 3) | **Use this** — paste it into a new conversation to run the workflow |
-| `[name]-skill-recs.md` | Skill Build Recommendations (Step 3) | **Build from this** — your roadmap for reusable skills |
+| `[name]-skill-specs.md` | Skill Specs (Step 3) | **Build from this** — your roadmap for reusable skills |
 
 Start by running the baseline prompt on a real scenario. See what works, refine what doesn't, then build skills in priority order. Each skill you build makes the baseline prompt shorter and more reliable.
 

--- a/docs/business-first-ai-framework/deconstruct/workflow-definition.md
+++ b/docs/business-first-ai-framework/deconstruct/workflow-definition.md
@@ -1,9 +1,9 @@
 ---
-title: "Step 1 — Discovery & Deep Dive"
-description: Interactively discover and decompose a business workflow into a structured Workflow Blueprint ready for AI building block analysis.
+title: "Step 1 — Workflow Definition"
+description: Interactively discover and decompose a business workflow into a structured Workflow Definition ready for AI building block analysis.
 ---
 
-# Step 1 — Discovery & Deep Dive
+# Step 1 — Workflow Definition
 
 > **Part of:** [Deconstruct Workflows](index.md)
 
@@ -14,7 +14,7 @@ An interactive conversation where AI helps you break down a workflow into its co
 | | |
 |---|---|
 | **What you'll do** | Describe your workflow (or problem), then answer focused questions as the AI probes each step for sub-steps, decision points, data flows, context needs, and failure modes |
-| **What you'll get** | A **Workflow Blueprint** — a structured Markdown file that captures everything discovered, ready for [Step 2](analysis.md) |
+| **What you'll get** | A **Workflow Definition** — a structured Markdown file that captures everything discovered, ready for [Step 2](building-blocks.md) |
 | **Time** | ~15–25 minutes of interactive conversation |
 
 ## Why This Matters
@@ -35,19 +35,19 @@ There are two ways to run Step 1, depending on which tools you use:
 2. **Start a new conversation** in your preferred AI tool (Claude, ChatGPT, Gemini, M365 Copilot) and **paste the prompt**
 3. **Press Enter** — the model will read the instructions and ask about your business scenario
 4. **Answer the questions** — describe your workflow or problem, then work through the deep dive
-5. **Download the Workflow Blueprint** the model produces at the end — it will be a Markdown file named `[workflow-name]-blueprint.md` (e.g., `lead-qualification-blueprint.md`)
+5. **Download the Workflow Definition** the model produces at the end — it will be a Markdown file named `[workflow-name]-definition.md` (e.g., `lead-qualification-definition.md`)
 6. **Keep this file** — you'll upload or paste it into Step 2, and you can share it with your instructor for feedback
 
 ### Option B: Claude skill
 
-Use the `discovering-workflows` skill from the [Business-First AI plugin](../../plugins/business-first-ai.md). It runs the same discovery and deep dive process and saves the Blueprint to a file automatically.
+Use the `discovering-workflows` skill from the [Business-First AI plugin](../../plugins/business-first-ai.md). It runs the same discovery and deep dive process and saves the Workflow Definition to a file automatically.
 
 - **Claude Code or Cowork** — install the plugin (`/plugin install business-first-ai@handsonai`) and start with:
     ```
     I want to discover and decompose my [workflow name] workflow.
-    Help me build a Workflow Blueprint.
+    Help me build a Workflow Definition.
     ```
-    The Blueprint is saved to `outputs/[workflow-name]-blueprint.md`.
+    The Workflow Definition is saved to `outputs/[workflow-name]-definition.md`.
 - **Claude.ai** — zip the `discovering-workflows` skill folder and upload it via **Settings > Capabilities > Upload skill**, then start a new chat with the same prompt above. See [Using Skills in Claude.ai](../../plugins/using-plugins.md#using-skills-in-claudeai-web) for detailed instructions.
 
 !!! tip "Budget ~15-25 minutes for this conversation"
@@ -56,7 +56,7 @@ Use the `discovering-workflows` skill from the [Business-First AI plugin](../../
 ## The Prompt
 
 ```text
-You are an expert Workflow Designer who specializes in deconstructing business workflows for AI operationalization. Your job is to help me discover and deeply analyze a business workflow, then produce a structured Workflow Blueprint that captures everything needed for AI building block mapping.
+You are an expert Workflow Designer who specializes in deconstructing business workflows for AI operationalization. Your job is to help me discover and deeply analyze a business workflow, then produce a structured Workflow Definition that captures everything needed for AI building block mapping.
 
 Work through the following two parts in order. Ask one question at a time during interactive sections. Wait for my response before moving on.
 
@@ -100,6 +100,20 @@ Present 2-3 name options and let me pick one or suggest my own. Confirm the chos
 
 **Part 1 summary** — After naming is confirmed, summarize what you've learned: workflow name, description, workflow outcome, trigger, type, business scenario and objective, high-level steps, and current ownership. Confirm you have it right before moving to Part 2.
 
+**Register to AI Registry (Claude users, optional):** If you're using Claude with the AI Registry plugin, you can register this workflow to your Workflows database now. The metadata you've confirmed maps directly:
+
+| Workflow Metadata | Notion Property |
+|---|---|
+| Name | Name (title) |
+| Description | Description |
+| Workflow outcome | Process Outcome |
+| Type | Type (Augmented / Automated / Manual) |
+| Trigger | Trigger |
+
+Status defaults to "Under Development." You can set the Business Process domain if you know which process this workflow belongs to.
+
+This is optional — registering now creates a home for this workflow in your registry so you can track its progress from discovery through production.
+
 ---
 
 ## Part 2 — Deep Dive (5-Question Framework)
@@ -125,24 +139,30 @@ This is more efficient and produces better results — correcting a wrong assump
 
 **Probing for context artifacts:** When exploring context needs, push beyond vague answers like "domain knowledge" or "background info." Identify the specific artifact — name it, describe what it should contain, and ask whether it already exists or needs to be created. Common examples: buyer persona documents, style guides, grading rubrics, product catalogs, pricing sheets, email templates, brand voice documents, org charts, decision criteria checklists, sample inputs, and sample outputs. If a step requires the model to match a standard, apply criteria, or follow a style, there is almost certainly a reference document behind it.
 
+**Probing for executable instructions:** For any step where AI is already being used, ask specifically: "Do you have existing prompt instructions, project instructions, custom assistant configurations, or system prompts that tell the AI what to do at this step? If so, I'll need to see those — they contain the workflow logic that belongs in your Baseline Prompt." Distinguish between:
+- **Reference materials** — documents, files, data, or examples the model reads to inform its work (PDFs, CSVs, spreadsheets, style guides)
+- **Executable instructions** — prompts, project instructions, system prompts, or custom assistant configurations that tell the model what to do and how to do it
+
+Reference materials are context the model consumes. Executable instructions are logic the model follows. Both matter, but they serve different purposes in the final prompt.
+
 After completing all steps:
 
 1. Present the refined step-by-step breakdown.
 2. **Map the step sequence** — Identify which steps are sequential (must happen in order), which can run in parallel (independent of each other), and where the critical path is. Show this as a simple dependency list (e.g., "Step 3 depends on Steps 1 and 2; Steps 4 and 5 can run in parallel").
-3. **Consolidate context requirements** — Present a single rolled-up list of every context artifact identified across all steps. For each artifact, state: the artifact name, a one-line description of what it contains, which steps depend on it, and whether it already exists or needs to be created. If it needs to be created, note the key contents it should include so I know what to build. Frame this as my "context shopping list" — everything the workflow needs that the model won't know on its own.
+3. **Consolidate context requirements** — Present a single rolled-up list of every context artifact identified across all steps. For each artifact, state: the artifact name, its type (Reference Material or Executable Instructions), a one-line description of what it contains, which steps depend on it, and whether it already exists or needs to be created. If it needs to be created, note the key contents it should include so I know what to build. Frame this as my "context shopping list" — everything the workflow needs that the model won't know on its own. Artifacts typed as "Executable Instructions" contain workflow logic that must be included in the Baseline Workflow Prompt. Artifacts typed as "Reference Material" are context files the model reads.
 4. Ask me to confirm the breakdown, sequence, and context shopping list are accurate.
 
 ---
 
-## Output — Workflow Blueprint
+## Output — Workflow Definition
 
-After I confirm the breakdown is accurate, produce the **Workflow Blueprint** as a Markdown file. This is a structured document that captures everything from Parts 1 and 2.
+After I confirm the breakdown is accurate, produce the **Workflow Definition** as a Markdown file. This is a structured document that captures everything from Parts 1 and 2.
 
-**File naming:** Name the file `[workflow-name]-blueprint.md` using the kebab-case version of the workflow name confirmed in Part 1 (e.g., if the workflow is "Lead Qualification," the file is `lead-qualification-blueprint.md`).
+**File naming:** Name the file `[workflow-name]-definition.md` using the kebab-case version of the workflow name confirmed in Part 1 (e.g., if the workflow is "Lead Qualification," the file is `lead-qualification-definition.md`).
 
-Generate the Blueprint as a downloadable Markdown file. If your platform doesn't support file downloads, format it inside a single Markdown code block so I can copy and save it manually.
+Generate the Workflow Definition as a downloadable Markdown file. If your platform doesn't support file downloads, format it inside a single Markdown code block so I can copy and save it manually.
 
-The Blueprint must include:
+The Workflow Definition must include:
 
 ### Scenario Metadata
 - Workflow name
@@ -173,6 +193,7 @@ For each step:
 ### Context Shopping List
 For each artifact:
 - Artifact name
+- Type (Reference Material / Executable Instructions)
 - Description (what it contains)
 - Used by steps (step numbers)
 - Status (Exists / Needs Creation)
@@ -180,9 +201,9 @@ For each artifact:
 
 ---
 
-After presenting the Blueprint, tell me:
+After presenting the Workflow Definition, tell me:
 
-> **Next step:** Download (or copy and save) the Workflow Blueprint file. Then go to [Step 2 — Analysis & Mapping](https://handsonai.info/business-first-ai-framework/deconstruct/analysis/), copy that prompt into a new conversation, and upload or paste the Blueprint when the model asks for it.
+> **Next step:** Download (or copy and save) the Workflow Definition file. Then go to [Step 2 — AI Building Blocks](https://handsonai.info/business-first-ai-framework/deconstruct/building-blocks/), copy that prompt into a new conversation, and upload or paste the Workflow Definition when the model asks for it.
 
 ---
 
@@ -197,11 +218,11 @@ After presenting the Blueprint, tell me:
 
 ## What This Prompt Produces
 
-The Workflow Blueprint captures:
+The Workflow Definition captures:
 
 - **Scenario metadata** — name, description, outcome, trigger, type, objective, owners
 - **Refined step-by-step breakdown** — each step with action, sub-steps, decision points, data in/out, context needs, failure modes
 - **Step sequence and dependencies** — what's sequential, what's parallel, where the critical path is
-- **Context shopping list** — every artifact the workflow needs, with status and key contents
+- **Context shopping list** — every artifact the workflow needs, typed as reference material or executable instructions, with status and key contents
 
-This Blueprint is the input for [Step 2 — Analysis & Mapping](analysis.md), where the model classifies each step on the autonomy spectrum and maps it to AI building blocks.
+This Workflow Definition is the input for [Step 2 — AI Building Blocks](building-blocks.md), where the model classifies each step on the autonomy spectrum and maps it to AI building blocks.

--- a/docs/business-first-ai-framework/index.md
+++ b/docs/business-first-ai-framework/index.md
@@ -38,9 +38,9 @@ Give your workflow clear structure — then identify the building blocks to turn
 
 Once you've identified a workflow worth automating, Phase 2 deconstructs it so you understand every step, decision point, and dependency. With that structure in place, you map each step to the right AI building blocks. The three-step pipeline:
 
-1. **Discovery & Deep Dive** — Interactively decompose the workflow into refined steps, surfacing hidden sub-steps, decision points, data flows, context needs, and failure modes
-2. **Analysis & Mapping** — Classify each step on the autonomy spectrum (Human → Deterministic → Semi-Autonomous → Autonomous) and map to AI building blocks
-3. **Output Generation** — Generate a ready-to-use Baseline Workflow Prompt (a prompt you can paste into any AI tool to run the workflow) and Skill Build Recommendations
+1. **Workflow Definition** — Interactively decompose the workflow into refined steps, surfacing hidden sub-steps, decision points, data flows, context needs, and failure modes
+2. **AI Building Blocks** — Classify each step on the autonomy spectrum (Human → Deterministic → Semi-Autonomous → Autonomous) and map to AI building blocks
+3. **Prompt & Skill Specs** — Generate a ready-to-use Baseline Workflow Prompt (a prompt you can paste into any AI tool to run the workflow) and Skill Specs
 
 The deconstruction uses the **five-question framework** to break down each step:
 
@@ -63,7 +63,7 @@ Each step gets mapped to one or more of the **six AI building blocks**: Prompt, 
 
 Turn your deconstruction outputs into working AI workflows.
 
-Phase 2 produces two actionable deliverables: a Baseline Workflow Prompt you can run immediately, and Skill Build Recommendations that tell you what to build next. Phase 3 is where those become real.
+Phase 2 produces two actionable deliverables: a Baseline Workflow Prompt you can run immediately, and Skill Specs that tell you what to build next. Phase 3 is where those become real.
 
 The [Build Workflows](build/index.md) examples show three worked examples across the autonomy spectrum — from deterministic automation to collaborative workflows to fully autonomous multi-agent pipelines. Each includes working building blocks you can install and study.
 
@@ -121,7 +121,7 @@ Used to decompose each workflow step:
 2. **Pick your highest-impact opportunity** — don't try to pursue everything at once
 3. **Run it through the [Deconstruction process](deconstruct/index.md)** to break it into AI building blocks
 4. **Test the Baseline Prompt** on a real scenario — paste the generated prompt into any AI tool and run the workflow
-5. **Build skills in priority order** from the Skill Build Recommendations — each skill you build replaces steps in the baseline prompt, making the workflow progressively more automated
+5. **Build skills in priority order** from the Skill Specs — each skill you build replaces steps in the baseline prompt, making the workflow progressively more automated
 
 ## Tools
 

--- a/docs/plugins/business-first-ai.md
+++ b/docs/plugins/business-first-ai.md
@@ -135,11 +135,11 @@ Break workflows into AI building blocks.
 
 **How it works:** The agent runs three skills in sequence:
 
-1. **Discovery** (`discovering-workflows`) — Interactive conversation where you describe your workflow. The agent probes for missing steps, decision points, data flows, and failure modes. Produces a Workflow Blueprint.
-2. **Analysis** (`analyzing-workflows`) — Reads the Blueprint, classifies each step on an autonomy spectrum (Human → AI-Deterministic → AI-Semi-Autonomous → AI-Autonomous), and maps to AI building blocks. Produces a Workflow Analysis Document.
-3. **Output Generation** (`generating-workflow-outputs`) — Reads the Analysis Document and generates a ready-to-use prompt plus recommendations for which steps should become dedicated skills. Produces the Baseline Prompt and Skill Recommendations.
+1. **Workflow Definition** (`discovering-workflows`) — Interactive conversation where you describe your workflow. The agent probes for missing steps, decision points, data flows, and failure modes. Produces a Workflow Definition.
+2. **AI Building Blocks** (`analyzing-workflows`) — Reads the Workflow Definition, classifies each step on an autonomy spectrum (Human → AI-Deterministic → AI-Semi-Autonomous → AI-Autonomous), and maps to AI building blocks. Produces the AI Building Block Map.
+3. **Prompt & Skill Specs** (`generating-workflow-outputs`) — Reads the AI Building Block Map and generates a ready-to-use prompt plus specs for which steps should become dedicated skills. Produces the Baseline Prompt and Skill Specs.
 
-Files are saved to `outputs/` using kebab-case workflow names (e.g., `outputs/lead-qualification-blueprint.md`).
+Files are saved to `outputs/` using kebab-case workflow names (e.g., `outputs/lead-qualification-definition.md`).
 
 **Example prompts:**
 
@@ -161,16 +161,16 @@ Files are saved to `outputs/` using kebab-case workflow names (e.g., `outputs/le
 
 **What you'll get:** Four files in `outputs/`:
 
-1. **Workflow Blueprint** — `[name]-blueprint.md` — structured decomposition of every step
-2. **Workflow Analysis Document** — `[name]-analysis.md` — autonomy classification and AI building block mapping
+1. **Workflow Definition** — `[name]-definition.md` — structured decomposition of every step
+2. **AI Building Block Map** — `[name]-building-blocks.md` — autonomy classification and AI building block mapping
 3. **Baseline Workflow Prompt** — `[name]-prompt.md` — ready-to-use prompt with numbered steps
-4. **Skill Build Recommendations** — `[name]-skill-recs.md` — specs for which steps should become dedicated skills
+4. **Skill Specs** — `[name]-skill-specs.md` — specs for which steps should become dedicated skills
 
 ---
 
 #### `discovering-workflows`
 
-**What it does:** Interactively discovers and decomposes a business workflow into a structured Workflow Blueprint. This is Step 1 of 3 in the workflow deconstruction series.
+**What it does:** Interactively discovers and decomposes a business workflow into a structured Workflow Definition. This is Step 1 of 3 in the workflow deconstruction series.
 
 **When to use it:** Use this when you want to thoroughly document a workflow before analyzing it for AI readiness. Also useful standalone when you just need a structured breakdown of a complex process — even without planning to automate it.
 
@@ -188,19 +188,19 @@ Files are saved to `outputs/` using kebab-case workflow names (e.g., `outputs/le
 5. **Propose and react** — From step 4 onward, Claude proposes a hypothesis across all five dimensions and asks "What's right, what's wrong, what am I missing?"
 6. **Map sequence** — Claude identifies sequential vs. parallel steps and the critical path
 7. **Consolidate context** — Claude presents a rolled-up "context shopping list" of every artifact the workflow needs
-8. **Generate Blueprint** — Claude writes the structured Blueprint to the output file
+8. **Generate Workflow Definition** — Claude writes the structured Workflow Definition to the output file
 
 **Example prompts:**
 
     "Use discovering-workflows to break down my expense reporting process"
     → Interactive discovery session producing
-      outputs/expense-reporting-blueprint.md
+      outputs/expense-reporting-definition.md
 
     "I need to document how our team handles customer escalations"
     → Walks through the discovery process, probing for hidden steps
       and decision points
 
-**What you'll get:** A Workflow Blueprint file (`outputs/[name]-blueprint.md`) containing: scenario metadata, refined steps (with sub-steps, decision points, data flows, context needs, and failure modes for each), step sequence and dependencies, and a context shopping list.
+**What you'll get:** A Workflow Definition file (`outputs/[name]-definition.md`) containing: scenario metadata, refined steps (with sub-steps, decision points, data flows, context needs, and failure modes for each), step sequence and dependencies, and a context shopping list.
 
 **Platform compatibility:** Claude Code &#10003; | Claude.ai &#10003;
 
@@ -208,13 +208,13 @@ Files are saved to `outputs/` using kebab-case workflow names (e.g., `outputs/le
 
 #### `analyzing-workflows`
 
-**What it does:** Classifies workflow steps on the autonomy spectrum, maps them to AI building blocks, and produces a Workflow Analysis Document. This is Step 2 of 3 in the workflow deconstruction series.
+**What it does:** Classifies workflow steps on the autonomy spectrum, maps them to AI building blocks, and produces an AI Building Block Map. This is Step 2 of 3 in the workflow deconstruction series.
 
-**When to use it:** Use this when you have a Workflow Blueprint (from Step 1) and want to analyze which steps can be automated, which need human oversight, and what AI tools are required.
+**When to use it:** Use this when you have a Workflow Definition (from Step 1) and want to analyze which steps can be automated, which need human oversight, and what AI tools are required.
 
 **How it works:**
 
-1. **Load Blueprint** — Claude reads the Blueprint file from `outputs/`
+1. **Load Workflow Definition** — Claude reads the Workflow Definition file from `outputs/`
 2. **Confirm understanding** — Claude summarizes the workflow and asks you to confirm before proceeding
 3. **Classify each step** — For every step, Claude determines:
     - **Autonomy level**: Human / AI-Deterministic / AI-Semi-Autonomous / AI-Autonomous
@@ -222,19 +222,19 @@ Files are saved to `outputs/` using kebab-case workflow names (e.g., `outputs/le
     - **Tools and connectors**: External tools, APIs, and integrations needed
     - **Human-in-the-loop gates**: Where human review is recommended
 4. **Present mapping** — Claude shows the classification as a table and walks through reasoning for non-obvious decisions. You can adjust classifications.
-5. **Generate Analysis Document** — After your confirmation, Claude produces the complete document
+5. **Generate AI Building Block Map** — After your confirmation, Claude produces the complete AI Building Block Map
 
 **Example prompts:**
 
-    "Use analyzing-workflows on my blueprint"
-    → Reads the most recent Blueprint, classifies each step, presents
-      the mapping table, and generates the Analysis Document
+    "Use analyzing-workflows on my workflow definition"
+    → Reads the most recent Workflow Definition, classifies each step,
+      presents the mapping table, and generates the AI Building Block Map
 
-    "Analyze the lead-qualification blueprint for AI readiness"
-    → Reads outputs/lead-qualification-blueprint.md and produces
-      the analysis
+    "Analyze the lead-qualification workflow for AI readiness"
+    → Reads outputs/lead-qualification-definition.md and produces
+      the AI Building Block Map
 
-**What you'll get:** A Workflow Analysis Document (`outputs/[name]-analysis.md`) containing: scenario summary, step-by-step decomposition table (with autonomy level and AI building blocks for each step), autonomy spectrum summary, step sequence and dependencies, prerequisites, context inventory, tools and connectors required, and recommended implementation order (quick wins first).
+**What you'll get:** An AI Building Block Map (`outputs/[name]-building-blocks.md`) containing: scenario summary, step-by-step decomposition table (with autonomy level and AI building blocks for each step), autonomy spectrum summary, step sequence and dependencies, prerequisites, context inventory, tools and connectors required, and recommended implementation order (quick wins first).
 
 **Platform compatibility:** Claude Code &#10003; | Claude.ai &#10003;
 
@@ -242,13 +242,13 @@ Files are saved to `outputs/` using kebab-case workflow names (e.g., `outputs/le
 
 #### `generating-workflow-outputs`
 
-**What it does:** Generates a ready-to-use Baseline Workflow Prompt and Skill Build Recommendations from a Workflow Analysis Document. This is Step 3 of 3 in the workflow deconstruction series.
+**What it does:** Generates a ready-to-use Baseline Workflow Prompt and Skill Specs from an AI Building Block Map. This is Step 3 of 3 in the workflow deconstruction series.
 
-**When to use it:** Use this when you have a completed Analysis Document (from Step 2) and want the final, actionable deliverables — a prompt you can run immediately and specs for which steps should become dedicated skills.
+**When to use it:** Use this when you have a completed AI Building Block Map (from Step 2) and want the final, actionable deliverables — a prompt you can run immediately and specs for which steps should become dedicated skills.
 
 **How it works:**
 
-1. **Load Analysis Document** — Claude reads the Analysis Document from `outputs/`
+1. **Load AI Building Block Map** — Claude reads the AI Building Block Map from `outputs/`
 2. **Confirm understanding** — Claude summarizes the workflow, step count, AI-eligible steps, and implementation order. You confirm before proceeding.
 3. **Generate Baseline Workflow Prompt** — A self-contained, ready-to-use prompt with:
     - Title, purpose, and when to use it
@@ -256,7 +256,7 @@ Files are saved to `outputs/` using kebab-case workflow names (e.g., `outputs/le
     - Input requirements with format specifications
     - Context requirements (what to attach when running the prompt)
     - Output format with structure specifications
-4. **Generate Skill Build Recommendations** — For each step that should become a dedicated skill:
+4. **Generate Skill Specs** — For each step that should become a dedicated skill:
     - Skill name, purpose, inputs, outputs
     - Which baseline prompt steps it replaces
     - Integration points (external tools, APIs, MCP servers)
@@ -265,18 +265,18 @@ Files are saved to `outputs/` using kebab-case workflow names (e.g., `outputs/le
 
 **Example prompts:**
 
-    "Use generating-workflow-outputs on my analysis"
-    → Reads the most recent Analysis Document, generates the prompt
-      and skill recommendations
+    "Use generating-workflow-outputs on my building blocks"
+    → Reads the most recent AI Building Block Map, generates the prompt
+      and skill specs
 
     "Generate the deliverables for expense-reporting"
-    → Reads outputs/expense-reporting-analysis.md and produces both
+    → Reads outputs/expense-reporting-building-blocks.md and produces both
       output files
 
 **What you'll get:** Two files:
 
 1. **Baseline Workflow Prompt** (`outputs/[name]-prompt.md`) — A self-contained prompt you can run immediately. Steps are labeled (AI) or (Human), includes all input/context/output requirements.
-2. **Skill Build Recommendations** (`outputs/[name]-skill-recs.md`) — Specs for each recommended skill, in priority order, with Quick Start Prompts.
+2. **Skill Specs** (`outputs/[name]-skill-specs.md`) — Specs for each recommended skill, in priority order, with Quick Start Prompts.
 
 **Platform compatibility:** Claude Code &#10003; | Claude.ai &#10003;
 
@@ -521,7 +521,7 @@ Start with Phase 1 (Discover) if you're not sure where AI fits in your work. Sta
 Yes. Tell the `workflow-deconstructor` agent about your problem (e.g., "people keep dropping off during enrollment") and it will propose a candidate workflow for you to refine during discovery.
 
 **What if I lose context mid-conversation?**
-The file-based handoffs mean you can continue in a new conversation. Just invoke the next skill and point it at the file from the previous step (e.g., "Use analyzing-workflows on outputs/lead-qualification-blueprint.md").
+The file-based handoffs mean you can continue in a new conversation. Just invoke the next skill and point it at the file from the previous step (e.g., "Use analyzing-workflows on outputs/lead-qualification-definition.md").
 
 **What are AI building blocks?**
 The categories used during analysis: Prompt (single instruction), Context (reference material), Skill (multi-step workflow), Agent (autonomous personality), MCP (external tool connection), and Project (workspace configuration). Each step gets mapped to one or more of these.

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -65,9 +65,9 @@ The [Business-First AI Framework](../business-first-ai-framework/index.md) as ex
     | Skill | Phase | What it does |
     |-------|-------|-------------|
     | [`finding-ai-opportunities`](business-first-ai.md#finding-ai-opportunities) | 1 | Structured audit of your workflows to discover where AI can help. Produces a categorized opportunity report. |
-    | [`discovering-workflows`](business-first-ai.md#discovering-workflows) | 2 | Interactively discovers and decomposes a business workflow into a structured Workflow Blueprint. |
-    | [`analyzing-workflows`](business-first-ai.md#analyzing-workflows) | 2 | Classifies workflow steps on the autonomy spectrum, maps them to AI building blocks, and produces a Workflow Analysis Document. |
-    | [`generating-workflow-outputs`](business-first-ai.md#generating-workflow-outputs) | 2 | Generates a ready-to-use Baseline Workflow Prompt and Skill Build Recommendations from a Workflow Analysis Document. |
+    | [`discovering-workflows`](business-first-ai.md#discovering-workflows) | 2 | Interactively discovers and decomposes a business workflow into a structured Workflow Definition. |
+    | [`analyzing-workflows`](business-first-ai.md#analyzing-workflows) | 2 | Classifies workflow steps on the autonomy spectrum, maps them to AI building blocks, and produces an AI Building Block Map. |
+    | [`generating-workflow-outputs`](business-first-ai.md#generating-workflow-outputs) | 2 | Generates a ready-to-use Baseline Workflow Prompt and Skill Specs from an AI Building Block Map. |
     | [`editing-hbr-articles`](business-first-ai.md#editing-hbr-articles) | 3 | HBR editorial criteria for article editing. Used by the `hbr-editor` agent. |
     | [`preparing-meeting-briefs`](business-first-ai.md#preparing-meeting-briefs) | 3 | Structured research workflow for meeting preparation. Used by the `meeting-prep-researcher` agent. |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,9 +52,12 @@ plugins:
       redirect_maps:
         how-to/prompting/ai-workflow-opportunity-finder.md: business-first-ai-framework/discover.md
         how-to/prompting/workflow-deconstruction-meta-prompt.md: business-first-ai-framework/deconstruct/index.md
-        how-to/prompting/workflow-deconstruction-discovery.md: business-first-ai-framework/deconstruct/discovery.md
-        how-to/prompting/workflow-deconstruction-analysis.md: business-first-ai-framework/deconstruct/analysis.md
-        how-to/prompting/workflow-deconstruction-outputs.md: business-first-ai-framework/deconstruct/outputs.md
+        how-to/prompting/workflow-deconstruction-discovery.md: business-first-ai-framework/deconstruct/workflow-definition.md
+        how-to/prompting/workflow-deconstruction-analysis.md: business-first-ai-framework/deconstruct/building-blocks.md
+        how-to/prompting/workflow-deconstruction-outputs.md: business-first-ai-framework/deconstruct/prompt-skill-specs.md
+        business-first-ai-framework/deconstruct/discovery.md: business-first-ai-framework/deconstruct/workflow-definition.md
+        business-first-ai-framework/deconstruct/analysis.md: business-first-ai-framework/deconstruct/building-blocks.md
+        business-first-ai-framework/deconstruct/outputs.md: business-first-ai-framework/deconstruct/prompt-skill-specs.md
         how-to/workflow-examples/README.md: business-first-ai-framework/build/index.md
         how-to/workflow-examples/deterministic-automation.md: business-first-ai-framework/build/deterministic-automation.md
         how-to/workflow-examples/ai-collaborative.md: business-first-ai-framework/build/ai-collaborative.md
@@ -86,9 +89,9 @@ nav:
     - "Phase 1 — Discover": business-first-ai-framework/discover.md
     - "Phase 2 — Deconstruct":
       - Overview: business-first-ai-framework/deconstruct/index.md
-      - "Step 1 — Discovery & Deep Dive": business-first-ai-framework/deconstruct/discovery.md
-      - "Step 2 — Analysis & Mapping": business-first-ai-framework/deconstruct/analysis.md
-      - "Step 3 — Output Generation": business-first-ai-framework/deconstruct/outputs.md
+      - "Step 1 — Workflow Definition": business-first-ai-framework/deconstruct/workflow-definition.md
+      - "Step 2 — AI Building Blocks": business-first-ai-framework/deconstruct/building-blocks.md
+      - "Step 3 — Prompt & Skill Specs": business-first-ai-framework/deconstruct/prompt-skill-specs.md
     - "Phase 3 — Build":
       - Overview: business-first-ai-framework/build/index.md
       - Deterministic Automation: business-first-ai-framework/build/deterministic-automation.md

--- a/plugins/business-first-ai/.claude-plugin/plugin.json
+++ b/plugins/business-first-ai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "business-first-ai",
   "description": "The Business-First AI Framework as executable Claude Code skills. Discover AI workflow opportunities, deconstruct workflows into building blocks, and build with worked examples across the autonomy spectrum.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": { "name": "James Gray" },
   "homepage": "https://handsonai.info/plugins/",
   "license": "MIT",

--- a/plugins/business-first-ai/agents/workflow-deconstructor.md
+++ b/plugins/business-first-ai/agents/workflow-deconstructor.md
@@ -11,32 +11,45 @@ You are an expert Workflow Deconstruction Orchestrator. Your job is to guide the
 
 You run three skills sequentially, using files as handoffs between stages:
 
-### Step 1 — Discovery & Deep Dive
+### Step 1 — Workflow Definition
 **Skill:** `discovering-workflows`
 
 Interactively discover the user's workflow and decompose every step. This is the longest phase — you'll ask about the business scenario, help refine steps, then systematically probe each step using the 5-question framework.
 
-**Produces:** `outputs/[name]-blueprint.md`
+During context probing, distinguish between reference materials (documents the model reads) and executable instructions (prompts/instructions the model follows). Flag executable instructions — they must be included in the Baseline Prompt.
 
-After the Blueprint is complete, tell the user you're moving to Step 2 and proceed automatically.
+After naming is confirmed, register the workflow to the Notion Workflows database if the Notion MCP server is available. Use the confirmed metadata (name, description, outcome, trigger, type) with Status = "Under Development."
 
-### Step 2 — Analysis & Mapping
+**Produces:** `outputs/[name]-definition.md`
+
+After the Workflow Definition is complete, tell the user you're moving to Step 2 and proceed automatically.
+
+### Step 2 — AI Building Blocks
 **Skill:** `analyzing-workflows`
 
-Read the Blueprint file, classify each step on the autonomy spectrum, map to AI building blocks, and produce the Workflow Analysis Document.
+Read the Workflow Definition file, classify each step on the autonomy spectrum, map to AI building blocks, and produce the AI Building Block Map.
 
-**Reads:** `outputs/[name]-blueprint.md`
-**Produces:** `outputs/[name]-analysis.md`
+**Reads:** `outputs/[name]-definition.md`
+**Produces:** `outputs/[name]-building-blocks.md`
 
-Present the mapping table to the user for review. After confirmation, generate the Analysis Document and proceed to Step 3.
+Present the mapping table to the user for review. After confirmation, generate the AI Building Block Map and proceed to Step 3.
 
-### Step 3 — Output Generation
+### Step 3 — Prompt & Skill Specs
 **Skill:** `generating-workflow-outputs`
 
-Read the Analysis Document and generate the Baseline Workflow Prompt and Skill Build Recommendations.
+Read the AI Building Block Map and generate the Baseline Workflow Prompt and the Skill Specs.
 
-**Reads:** `outputs/[name]-analysis.md`
-**Produces:** `outputs/[name]-prompt.md` + `outputs/[name]-skill-recs.md`
+The Baseline Prompt must be self-contained — all executable logic in the prompt, not referenced from external systems. Include an Execution Context section advising where to run the prompt (normal chat vs. project).
+
+**Reads:** `outputs/[name]-building-blocks.md`
+**Produces:** `outputs/[name]-prompt.md` + `outputs/[name]-skill-specs.md`
+
+### Post-Step 3 — Registry & SOP (if Notion available)
+
+If the workflow was registered to the Notion Workflows database during Step 1 naming, offer to generate the workflow SOP and save it to the page body. Use the Baseline Prompt's steps as the procedure source. This completes the workflow's Notion page: metadata in properties, SOP in the page content.
+
+**Reads:** `outputs/[name]-prompt.md` (for procedure steps)
+**Updates:** The workflow's Notion page body
 
 ## File Conventions
 
@@ -61,9 +74,10 @@ After all three steps, present a summary:
 
 > **Workflow deconstruction complete.** Here are your deliverables:
 >
-> 1. **Workflow Blueprint** — `outputs/[name]-blueprint.md`
-> 2. **Workflow Analysis Document** — `outputs/[name]-analysis.md`
+> 1. **Workflow Definition** — `outputs/[name]-definition.md`
+> 2. **AI Building Block Map** — `outputs/[name]-building-blocks.md`
 > 3. **Baseline Workflow Prompt** — `outputs/[name]-prompt.md`
-> 4. **Skill Build Recommendations** — `outputs/[name]-skill-recs.md`
+> 4. **Skill Specs** — `outputs/[name]-skill-specs.md`
+> 5. **Workflow SOP** — saved to the workflow's Notion page (if registered)
 >
 > Start by running the baseline prompt on a real scenario. Then build skills in priority order from the recommendations.

--- a/plugins/business-first-ai/skills/analyzing-workflows/SKILL.md
+++ b/plugins/business-first-ai/skills/analyzing-workflows/SKILL.md
@@ -2,17 +2,17 @@
 name: analyzing-workflows
 description: >
   Classify workflow steps on the autonomy spectrum, map them to AI building blocks, and produce
-  a Workflow Analysis Document. Use when the user has a Workflow Blueprint and wants to analyze
+  an AI Building Block Map. Use when the user has a Workflow Definition and wants to analyze
   it for AI operationalization. This is Step 2 of 3 in the workflow deconstruction series.
 ---
 
 # Workflow Analysis
 
-Take a Workflow Blueprint, classify each step on the autonomy spectrum, map to AI building blocks, and produce a complete Workflow Analysis Document.
+Take a Workflow Definition, classify each step on the autonomy spectrum, map to AI building blocks, and produce a complete AI Building Block Map.
 
 ## Workflow
 
-1. **Load Blueprint** — Read the Blueprint file from `outputs/[workflow-name]-blueprint.md`. If the user specifies a file path, use that. Otherwise, look for the most recent Blueprint in `outputs/`.
+1. **Load Workflow Definition** — Read the Workflow Definition file from `outputs/[workflow-name]-definition.md`. If the user specifies a file path, use that. Otherwise, look for the most recent Workflow Definition in `outputs/`.
 2. **Confirm understanding** — Summarize the workflow name, step count, and outcome. Ask the user to confirm before proceeding.
 3. **Classify each step** — For every refined step, determine:
    - **Autonomy level**: Human / AI-Deterministic / AI-Semi-Autonomous / AI-Autonomous
@@ -20,13 +20,13 @@ Take a Workflow Blueprint, classify each step on the autonomy spectrum, map to A
    - **Tools and connectors**: External tools, APIs, integrations needed
    - **Human-in-the-loop gates**: Where human review is recommended
 4. **Present mapping** — Show the classification as a clear table. Walk through reasoning for non-obvious classifications. Ask the user if they want to adjust anything.
-5. **Generate Analysis Document** — After confirmation, produce the complete Workflow Analysis Document and write it to the output file.
+5. **Generate AI Building Block Map** — After confirmation, produce the complete AI Building Block Map and write it to the output file.
 
 ## Output
 
-Write the Workflow Analysis Document to `outputs/[workflow-name]-analysis.md` using the same workflow name from the Blueprint.
+Write the AI Building Block Map to `outputs/[workflow-name]-building-blocks.md` using the same workflow name from the Workflow Definition.
 
-The Analysis Document must include:
+The AI Building Block Map must include:
 
 ### Scenario Summary
 - Workflow name, description, outcome, trigger, type, business objective, current owner(s)
@@ -48,8 +48,8 @@ The Analysis Document must include:
 
 ### Context Inventory
 
-| Artifact | Description | Used By Steps | Status | Format | Key Contents |
-|----------|-------------|---------------|--------|--------|--------------|
+| Artifact | Type | Description | Used By Steps | Status | Format | Key Contents |
+|----------|------|-------------|---------------|--------|--------|--------------|
 
 ### Tools and Connectors Required
 
@@ -58,9 +58,12 @@ The Analysis Document must include:
 2. **High-value semi-autonomous steps** — AI does most work, human review gate
 3. **Complex agent steps** — Fully autonomous, requiring Agents/MCP/multi-tool orchestration
 
+### Execution Context
+Recommend where the Baseline Workflow Prompt should be run (normal chat vs. project workspace). Normal chat for infrequent workflows with few context files. Project workspace for frequent workflows with multiple context files or where conversation memory is valuable. State the recommendation, reasoning, and specific context files to attach or pre-load. The Baseline Workflow Prompt is always self-contained — the project provides file staging, not workflow logic.
+
 ## Guidelines
 
-- If the Blueprint is missing information needed for classification, ask the user to clarify
+- If the Workflow Definition is missing information needed for classification, ask the user to clarify
 - If the user mentions they're using Claude, note where Skills are the appropriate building block
 - Explain reasoning for non-obvious classifications
-- After writing the Analysis Document, tell the user: "Analysis saved to `outputs/[name]-analysis.md`. Ready for Step 3 — Output Generation."
+- After writing the AI Building Block Map, tell the user: "AI Building Block Map saved to `outputs/[name]-building-blocks.md`. Ready for Step 3 — Prompt & Skill Specs."

--- a/plugins/business-first-ai/skills/discovering-workflows/SKILL.md
+++ b/plugins/business-first-ai/skills/discovering-workflows/SKILL.md
@@ -1,34 +1,36 @@
 ---
 name: discovering-workflows
 description: >
-  Interactively discover and decompose a business workflow into a structured Workflow Blueprint.
+  Interactively discover and decompose a business workflow into a structured Workflow Definition.
   Use when the user wants to deconstruct a workflow, break down a business process, or start
   the workflow deconstruction process. This is Step 1 of 3 in the workflow deconstruction series.
 ---
 
-# Workflow Discovery
+# Workflow Definition
 
-Interactively discover a business workflow and decompose every step into a structured Workflow Blueprint using the 5-question framework.
+Interactively discover a business workflow and decompose every step into a structured Workflow Definition using the 5-question framework.
 
 ## Workflow
 
 1. **Scenario discovery** — Ask about the business scenario, objective, high-level steps, and ownership. One question at a time. If the user describes a problem instead of a workflow, propose a candidate workflow for them to react to.
 2. **Scope check** — Assess whether this is one workflow or multiple bundled together. If multiple, recommend splitting and ask which to start with.
 3. **Name the workflow** — Present 2-3 name options following naming conventions (2-4 word noun phrase, Title Case). Confirm name, description, outcome, trigger, and type.
-4. **Deep dive** — Work through each step using the 5-question framework:
+4. **Register to Workflows database (if Notion is available)** — After naming is confirmed, check if the Notion MCP server is accessible. If so, create a row in the Workflows database with: Name, Description, Process Outcome, Type, Trigger, Status = "Under Development". Ask the user which Business Process domain this belongs to (or leave blank). If Notion is not available, skip this step silently and continue to the deep dive.
+5. **Deep dive** — Work through each step using the 5-question framework:
    - Discrete steps (is this actually multiple steps?)
    - Decision points (if/then branches, quality gates)
    - Data flows (inputs, outputs, sources, destinations)
    - Context needs (specific documents, files, reference materials)
    - Failure modes (what happens when this step fails)
-5. **Propose and react** — For steps 4+, propose a hypothesis across all 5 dimensions and ask "What's right, what's wrong, what am I missing?" instead of asking each question individually.
-6. **Map sequence** — After all steps, identify sequential vs. parallel steps and the critical path.
-7. **Consolidate context** — Present a rolled-up "context shopping list" of every artifact the workflow needs.
-8. **Generate Blueprint** — Produce the structured Workflow Blueprint and write it to the output file.
+   When probing context needs, distinguish between **reference materials** (documents, files, data the model reads) and **executable instructions** (prompts, project instructions, system prompts the model follows). For any step where AI is already being used, ask specifically for existing prompt instructions or configurations — these contain workflow logic that must be included in the Baseline Prompt.
+6. **Propose and react** — For steps 4+, propose a hypothesis across all 5 dimensions and ask "What's right, what's wrong, what am I missing?" instead of asking each question individually.
+7. **Map sequence** — After all steps, identify sequential vs. parallel steps and the critical path.
+8. **Consolidate context** — Present a rolled-up "context shopping list" of every artifact the workflow needs. For each artifact, include its type (Reference Material or Executable Instructions). Artifacts typed as "Executable Instructions" contain workflow logic that must be included in the Baseline Workflow Prompt.
+9. **Generate Workflow Definition** — Produce the structured Workflow Definition and write it to the output file.
 
 ## Output
 
-Write the Workflow Blueprint to `outputs/[workflow-name]-blueprint.md` where `[workflow-name]` is the kebab-case workflow name (e.g., `lead-qualification`).
+Write the Workflow Definition to `outputs/[workflow-name]-definition.md` where `[workflow-name]` is the kebab-case workflow name (e.g., `lead-qualification`).
 
 The Blueprint must include:
 
@@ -42,7 +44,7 @@ For each step: number, name, action, sub-steps, decision points, data in/out, co
 - Sequential steps, parallel steps, critical path, dependency map
 
 ### Context Shopping List
-For each artifact: name, description, used by steps, status (Exists/Needs Creation), key contents
+For each artifact: name, type (Reference Material / Executable Instructions), description, used by steps, status (Exists/Needs Creation), key contents
 
 ## Guidelines
 
@@ -51,4 +53,4 @@ For each artifact: name, description, used by steps, status (Exists/Needs Creati
 - Surface hidden assumptions ("How do you decide when X is good enough?")
 - Use plain language; avoid jargon unless the user introduced it
 - Push beyond vague context answers like "domain knowledge" — identify the specific artifact
-- After writing the Blueprint file, tell the user: "Blueprint saved to `outputs/[name]-blueprint.md`. Ready for Step 2 — Analysis & Mapping."
+- After writing the Workflow Definition file, tell the user: "Workflow Definition saved to `outputs/[name]-definition.md`. Ready for Step 2 — AI Building Blocks."

--- a/plugins/business-first-ai/skills/generating-workflow-outputs/SKILL.md
+++ b/plugins/business-first-ai/skills/generating-workflow-outputs/SKILL.md
@@ -1,22 +1,24 @@
 ---
 name: generating-workflow-outputs
 description: >
-  Generate a Baseline Workflow Prompt and Skill Build Recommendations from a Workflow Analysis
-  Document. Use when the user has a completed Analysis Document and wants the final deliverables.
+  Generate a Baseline Workflow Prompt and Skill Specs from an AI Building Block
+  Map. Use when the user has a completed AI Building Block Map and wants the final deliverables.
   This is Step 3 of 3 in the workflow deconstruction series.
 ---
 
 # Workflow Output Generation
 
-Take a Workflow Analysis Document and produce two deliverables: a Baseline Workflow Prompt and Skill Build Recommendations.
+Take an AI Building Block Map and produce two deliverables: a Baseline Workflow Prompt and Skill Specs.
 
 ## Workflow
 
-1. **Load Analysis Document** — Read the Analysis Document from `outputs/[workflow-name]-analysis.md`. If the user specifies a file path, use that. Otherwise, look for the most recent Analysis Document in `outputs/`.
+1. **Load AI Building Block Map** — Read the AI Building Block Map from `outputs/[workflow-name]-building-blocks.md`. If the user specifies a file path, use that. Otherwise, look for the most recent AI Building Block Map in `outputs/`.
 2. **Confirm understanding** — Summarize the workflow name, step count, how many are AI-eligible, and the recommended implementation order. Ask the user to confirm before proceeding.
-3. **Clarify if needed** — If anything in the Analysis Document is ambiguous, ask before generating. Maximum 1-2 clarifying questions.
-4. **Generate Baseline Workflow Prompt** — Produce a ready-to-use prompt and write it to the output file.
-5. **Generate Skill Build Recommendations** — Produce skill specs and write them to the output file.
+3. **Clarify if needed** — If anything in the AI Building Block Map is ambiguous, ask before generating. Maximum 1-2 clarifying questions.
+4. **Check for executable instructions** — Before generating, check the Context Inventory for any artifacts typed as "Executable Instructions." These contain workflow logic that must be included in the Baseline Prompt — not referenced, but actually included. If executable instructions exist but their content is not in the AI Building Block Map, ask the user to paste or upload them. The Baseline Prompt cannot reference external systems for its core logic.
+5. **Generate Baseline Workflow Prompt** — Produce a ready-to-use, self-contained prompt and write it to the output file. Include an Execution Context section advising where to run the prompt (normal chat vs. project) based on the AI Building Block Map's recommendation.
+6. **Generate Skill Specs** — Produce skill specs and write them to the output file.
+7. **Write SOP to Notion (if available)** — After both deliverables are generated, check if the Notion MCP server is accessible AND this workflow was registered in Step 1. If so, offer to write the workflow SOP to the Notion page using the `writing-workflow-sops` approach: pass the workflow name to locate the page, use the Baseline Prompt's procedure steps as the primary input, and write the formatted SOP to the page body. If Notion is not available or the workflow was not registered, skip this step.
 
 ## Outputs
 
@@ -33,7 +35,11 @@ Structure:
 
 The prompt must be: self-contained, specific, version-control ready, team-adoption ready.
 
-### `outputs/[workflow-name]-skill-recs.md` — Skill Build Recommendations
+**Self-contained means:** The prompt contains every instruction the model needs to execute the workflow. It never says "open this project" or "follow those instructions." If existing AI instructions drive a step, those instructions are written into the prompt.
+
+**Execution Context** — Include a section advising where to run the prompt (normal chat vs. project), which files to attach or pre-load, and why. The prompt instructions are the same regardless of execution context — the project provides file staging convenience, not workflow logic.
+
+### `outputs/[workflow-name]-skill-specs.md` — Skill Specs
 
 For each recommended skill:
 - **Skill Name** — 2-4 words, lowercase with hyphens
@@ -52,5 +58,5 @@ Present skills in priority order. If no steps qualify as good skill candidates, 
 
 - If the user mentions Claude, note where Claude Code Skills are the appropriate implementation
 - Use plain language; avoid jargon unless the user introduced it
-- After writing both files, tell the user: "Outputs saved to `outputs/[name]-prompt.md` and `outputs/[name]-skill-recs.md`. Your workflow deconstruction is complete."
+- After writing both files, tell the user: "Outputs saved to `outputs/[name]-prompt.md` and `outputs/[name]-skill-specs.md`. Your workflow deconstruction is complete."
 - Summarize the three files produced across all three steps so the user has a clear inventory of their deliverables


### PR DESCRIPTION
## Summary

- Rename doc page files for SEO/AEO consistency: `discovery.md` → `workflow-definition.md`, `analysis.md` → `building-blocks.md`, `outputs.md` → `prompt-skill-specs.md`
- Rename deliverables across all surfaces: Workflow Blueprint → Workflow Definition, Workflow Analysis Document → AI Building Block Map, Skill Build Recommendations → Skill Specs
- Add executable instructions probing, self-containment enforcement, execution context sections, and optional Notion registry integration to the Phase 2 framework
- Update all cross-references, nav paths, and absolute URLs; add redirects for old paths
- Sync `.claude/` and `plugins/` copies; bump plugin version to 1.0.2

## Test plan

- [ ] Run `mkdocs serve` and verify all three step pages render at new URLs
- [ ] Verify old URLs (`/deconstruct/discovery/`, `/deconstruct/analysis/`, `/deconstruct/outputs/`) redirect to new paths
- [ ] Check all internal links on the Deconstruct index page, each step page, and the plugin detail page
- [ ] Confirm nav menu shows correct step names and links
- [ ] Verify `.claude/` and `plugins/` skill/agent copies are identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)