### PR TITLE
Align Phase 1 and Phase 2 terminology across docs and assignments

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "business-first-ai",
       "source": "./plugins/business-first-ai",
       "description": "The Business-First AI Framework — discover AI opportunities, deconstruct workflows, and build with worked examples",
-      "version": "1.0.2"
+      "version": "1.0.3"
     },
     {
       "name": "ai-registry",

--- a/.claude/skills/finding-ai-opportunities/SKILL.md
+++ b/.claude/skills/finding-ai-opportunities/SKILL.md
@@ -3,7 +3,7 @@ name: finding-ai-opportunities
 description: >
   Discover where AI can improve your workflows through a structured audit.
   Produces a prioritized report of opportunities across three categories:
-  Collaborative AI, Deterministic Workflows, and Multi-Agent Systems.
+  Deterministic Workflows, Collaborative AI, and Autonomous Agents.
   This is Phase 1 of the Business-First AI Framework.
 ---
 
@@ -51,24 +51,22 @@ Once you can identify at least 3 concrete, specific opportunities with enough de
 
 After presenting the full report, ask the user to pick ONE opportunity from each category that they want to build during the course. Once they've chosen, produce a **Workflow Candidate Summary** in this exact format:
 
----
+```markdown
+- **Workflow:** [name]
+- **Type:** Deterministic
+- **Pain point:** [1 sentence]
+- **AI opportunity:** [1 sentence]
 
-**Workflow:** [3-5 word name]
-**Type:** Collaborative AI
-**Pain point:** [1 sentence — what makes this time-consuming or frustrating today]
-**AI opportunity:** [1 sentence — how AI could help]
+- **Workflow:** [name]
+- **Type:** Collaborative AI
+- **Pain point:** [1 sentence]
+- **AI opportunity:** [1 sentence]
 
-**Workflow:** [3-5 word name]
-**Type:** Deterministic Automation
-**Pain point:** [1 sentence]
-**AI opportunity:** [1 sentence]
-
-**Workflow:** [3-5 word name]
-**Type:** Autonomous Agent
-**Pain point:** [1 sentence]
-**AI opportunity:** [1 sentence]
-
----
+- **Workflow:** [name]
+- **Type:** Autonomous Agent
+- **Pain point:** [1 sentence]
+- **AI opportunity:** [1 sentence]
+```
 
 Append this summary to the output file under a `## Workflow Candidate Summary` heading.
 
@@ -82,7 +80,7 @@ The report must include:
 
 | # | Opportunity | Category | Impact |
 |---|------------|----------|--------|
-| 1 | [Name] | Collaborative AI / Deterministic Workflow / Multi-Agent System | High / Medium / Low |
+| 1 | [Name] | Deterministic Workflow / Collaborative AI / Autonomous Agent | High / Medium / Low |
 
 ### Detailed Opportunity Cards
 
@@ -94,7 +92,7 @@ For each opportunity:
 
 **[#] [Opportunity Name]**
 
-**Category:** Collaborative AI | Deterministic Workflow | Multi-Agent System
+**Category:** Deterministic Workflow | Collaborative AI | Autonomous Agent
 
 **Why it's a good candidate:**
 [What characteristics make this well-suited for AI — repetitive, pattern-based, language-heavy, clear inputs/outputs, etc.]
@@ -114,9 +112,9 @@ For each opportunity:
 
 Use these definitions when categorizing:
 
-- **Collaborative AI**: Human and AI work together in real time. The human drives the process; AI contributes suggestions, drafts, analysis, or feedback. Examples: co-writing, brainstorming, code review, data analysis.
 - **Deterministic Workflow**: A repeatable process with clear inputs, rules, and outputs that AI can execute reliably with minimal supervision. Examples: formatting reports, processing forms, generating routine communications, data transformation.
-- **Multi-Agent System**: A complex workflow where multiple AI agents (or AI + automation tools) coordinate across steps. Requires orchestration. Examples: research-then-write pipelines, intake-triage-routing systems, monitoring-alerting-response workflows.
+- **Collaborative AI**: Human and AI work together in real time. The human drives the process; AI contributes suggestions, drafts, analysis, or feedback. Examples: co-writing, brainstorming, code review, data analysis.
+- **Autonomous Agent**: A goal-driven workflow where AI plans and executes steps autonomously. The agent reasons about what to do, calls tools as needed, and adapts its approach. Ranges from a single agent handling a complex task to multi-agent systems where specialized agents coordinate across steps. Examples: competitor monitoring and alerting, research → analysis → report pipelines, intake → triage → routing systems.
 
 ## Guidelines
 

--- a/docs/business-first-ai-framework/deconstruct/building-blocks.md
+++ b/docs/business-first-ai-framework/deconstruct/building-blocks.md
@@ -193,7 +193,7 @@ After presenting the AI Building Block Map, tell me:
 
 ## What This Prompt Produces
 
-The **AI Building Block Map** (Deliverable 1) contains:
+The **AI Building Block Map** contains:
 
 - **Scenario summary** — workflow metadata from the Workflow Definition
 - **Decomposition table** — every step with autonomy classification, decision points, failure modes, data flows, context needs, and AI building block mapping

--- a/docs/business-first-ai-framework/deconstruct/index.md
+++ b/docs/business-first-ai-framework/deconstruct/index.md
@@ -24,11 +24,12 @@ A three-conversation series that breaks down a business workflow into discrete s
 
 You can't operationalize AI on a process you don't understand. Before you can build an AI-powered workflow, you need to break it down into discrete steps, identify the decision points and data flows, and map each step to the right level of AI assistance.
 
-This series of prompts walks you through that deconstruction interactively. You provide the business scenario and rough steps — the model handles the structured analysis, applies the 5-question framework (discrete steps, decision points, data flows, context needs, failure modes), maps each step to AI building blocks, and generates three deliverables:
+This series of prompts walks you through that deconstruction interactively. You provide the business scenario and rough steps — the model handles the structured analysis, applies the 5-question framework (discrete steps, decision points, data flows, context needs, failure modes), maps each step to AI building blocks, and produces four deliverables:
 
-1. An **AI Building Block Map** — the full decomposition with autonomy classifications, AI building block mapping, a context inventory of every resource the workflow needs (documents, files, data sources, system access), and a prioritized build sequence
-2. A **Baseline Workflow Prompt** — a ready-to-use prompt that works on any platform; this is your starting point that will evolve as you build skills
-3. **Skill Specs** — actionable specs for reusable skills you can build to automate recurring steps
+1. A **Workflow Definition** — the structured breakdown of your workflow into refined steps, with decision points, data flows, context needs, and failure modes captured for every step
+2. An **AI Building Block Map** — autonomy classifications, AI building block mapping, a context inventory of every resource the workflow needs (documents, files, data sources, system access), and a prioritized build sequence
+3. A **Baseline Workflow Prompt** — a ready-to-use prompt that works on any platform; this is your starting point that will evolve as you build skills
+4. **Skill Specs** — actionable specs for reusable skills you can build to automate recurring steps
 
 This builds directly on the concepts from the course lessons on workflow deconstruction and AI building blocks. If terms like the "5-question framework" or "six building blocks" are new to you, review the [Key Concepts section of the Business-First AI Framework](../index.md#key-concepts) for quick definitions before starting.
 
@@ -40,7 +41,7 @@ The workflow deconstruction is split into three focused prompts. Each prompt pro
 |------|--------|-------------|----------|
 | 1 | [Workflow Definition](workflow-definition.md) | Discover the workflow, decompose every step | **Workflow Definition** |
 | 2 | [AI Building Blocks](building-blocks.md) | Classify steps, map AI building blocks | **AI Building Block Map** |
-| 3 | [Prompt & Skill Specs](prompt-skill-specs.md) | Generate the self-contained executable prompt (with execution context) and skill specs | **Baseline Prompt** + **Skill Specs** |
+| 3 | [Prompt & Skill Specs](prompt-skill-specs.md) | Generate the self-contained executable prompt (with execution context) and skill specs | **Baseline Workflow Prompt** + **Skill Specs** |
 
 **Between each step:** Download (or copy and save) the output artifact as a Markdown file, then upload or paste it into the next conversation. Each prompt starts by asking you to provide the previous step's output. The files use a consistent naming convention: `[workflow-name]-definition.md`, `[workflow-name]-building-blocks.md`, `[workflow-name]-prompt.md`, and `[workflow-name]-skill-specs.md`.
 
@@ -113,6 +114,11 @@ All four options follow the same process and produce the same deliverables. Choo
 
 !!! tip "Keep your files together"
     By the end you'll have four Markdown files: `[name]-definition.md`, `[name]-building-blocks.md`, `[name]-prompt.md`, and `[name]-skill-specs.md`. Keep them in a single folder — they form a complete record of your workflow deconstruction. You can share any of these files with your instructor for feedback, put them in version control, or hand them to a colleague.
+
+!!! tip "Markdown renders as formatted text"
+    Markdown (`.md`) files are plain text with lightweight formatting — headings, bold, lists, tables. Many tools render them automatically: GitHub, Notion, VS Code, and most code editors show the formatted version when you open the file. You can also paste Markdown into Google Docs or Notion and it converts on the fly.
+
+    If you'd prefer a polished document, ask your AI tool: "Convert this to a Word document" or "Reformat this as a PDF." The content is the same — Markdown is just the most portable starting format because it works everywhere and is easy to version-control.
 
 ### Example: What the first exchange looks like
 

--- a/docs/business-first-ai-framework/deconstruct/prompt-skill-specs.md
+++ b/docs/business-first-ai-framework/deconstruct/prompt-skill-specs.md
@@ -196,11 +196,11 @@ After presenting both files, summarize what I now have:
 
 ## What This Prompt Produces
 
-### Baseline Workflow Prompt (Deliverable 2)
+### Baseline Workflow Prompt
 
 A ready-to-paste prompt that works on any AI platform. Every step is spelled out in full — no skills or shortcuts required. This is your starting point. As you build skills from the recommendations, you'll update this prompt to call those skills instead of repeating the logic inline.
 
-### Skill Specs (Deliverable 3)
+### Skill Specs
 
 Actionable specs for each recommended skill, including:
 

--- a/docs/business-first-ai-framework/discover.md
+++ b/docs/business-first-ai-framework/discover.md
@@ -5,7 +5,7 @@ description: Use this prompt template to discover where AI can help automate, au
 
 # Discover AI Workflow Opportunities
 
-> **Platforms:** `claude` `openai` `gemini`
+> **Platforms:** `claude` `openai` `gemini` `m365-copilot`
 
 !!! info "Business-First AI Framework — Phase 1: Discover"
     This guide is **Phase 1** of the [Business-First AI Framework](index.md) — discovering where AI fits in your workflows.
@@ -17,7 +17,7 @@ A structured audit that helps you find where AI fits in your work. The AI scans 
 | | |
 |---|---|
 | **What you'll do** | Walk through a guided conversation covering your role, tasks, and pain points |
-| **What you'll get** | A prioritized report of AI opportunities across three levels — Collaborative AI, Deterministic Workflows, and Multi-Agent Systems — with concrete next steps for each |
+| **What you'll get** | A prioritized report of AI opportunities across three levels — Deterministic Workflows, Collaborative AI, and Autonomous Agents — with concrete next steps for each |
 | **Time** | ~20–30 minutes for the full conversation |
 
 ## Why This Matters
@@ -28,9 +28,9 @@ A proactive audit of your workflows can reveal opportunities you'd never notice 
 
 This prompt template guides an AI through a structured analysis of your work and produces a categorized report of opportunities across three levels:
 
-- **Collaborative AI** — Tasks where you and AI work together in real time (drafting, brainstorming, reviewing)
 - **Deterministic Workflows** — Repeatable processes that AI can execute reliably with little or no supervision
-- **Multi-Agent Systems** — Complex workflows where multiple AI agents coordinate to handle different steps
+- **Collaborative AI** — Tasks where you and AI work together in real time (drafting, brainstorming, reviewing)
+- **Autonomous Agents** — Goal-driven workflows where AI plans and executes steps autonomously, from single agents to multi-agent systems
 
 ## How to Use This
 
@@ -40,10 +40,10 @@ There are four ways to run Phase 1, depending on which tools you use:
 
     Use this if you're working in ChatGPT, Gemini, M365 Copilot, or any AI chat tool.
 
-    1. **Make sure memory is enabled** in your AI tool of choice — this lets the AI draw on everything it knows about you from past conversations
+    1. **If your AI tool has a memory or personalization feature, make sure it's enabled** — this lets the AI draw on what it knows about you from past conversations. If it doesn't, that's fine — the interview in Step 2 will gather everything it needs
     2. **Copy the prompt** from the [Prompt Template](#the-prompt-template) section below
     3. **Paste it into any conversation** — the AI will automatically scan its memory for context about your role, tasks, and workflows
-    4. **Review the output** and pick one or two opportunities to pilot first
+    4. **Review the output**, pick one opportunity from each category, and save the Workflow Candidate Summary
 
 === "Claude Code"
 
@@ -140,7 +140,7 @@ Start with a table listing every opportunity:
 
 | # | Opportunity | Category | Impact |
 |---|------------|----------|--------|
-| 1 | [Name] | Collaborative AI / Deterministic Workflow / Multi-Agent System | High / Medium / Low |
+| 1 | [Name] | Deterministic Workflow / Collaborative AI / Autonomous Agent | High / Medium / Low |
 
 ### Detailed Opportunity Cards
 
@@ -150,7 +150,7 @@ Then for each opportunity, provide a detailed card in this format:
 
 **[#] [Opportunity Name]**
 
-**Category:** Collaborative AI | Deterministic Workflow | Multi-Agent System
+**Category:** Deterministic Workflow | Collaborative AI | Autonomous Agent
 
 **Why it's a good candidate:**
 [What characteristics of this task make it well-suited for AI — e.g., it's repetitive, pattern-based, language-heavy, has clear inputs/outputs, etc.]
@@ -170,11 +170,11 @@ Then for each opportunity, provide a detailed card in this format:
 
 Use these definitions when categorizing:
 
-- **Collaborative AI**: Human and AI work together in real time. The human drives the process; AI contributes suggestions, drafts, analysis, or feedback. Examples: co-writing, brainstorming, code review, data analysis.
-
 - **Deterministic Workflow**: A repeatable process with clear inputs, rules, and outputs that AI can execute reliably with minimal supervision. Examples: formatting reports, processing forms, generating routine communications, data transformation.
 
-- **Multi-Agent System**: A complex workflow where multiple AI agents (or AI + automation tools) coordinate across steps. Requires orchestration. Examples: research → analysis → report generation pipelines, intake → triage → routing systems, monitoring → alerting → response workflows.
+- **Collaborative AI**: Human and AI work together in real time. The human drives the process; AI contributes suggestions, drafts, analysis, or feedback. Examples: co-writing, brainstorming, code review, data analysis.
+
+- **Autonomous Agent**: A goal-driven workflow where AI plans and executes steps autonomously. The agent reasons about what to do, calls tools as needed, and adapts its approach. Ranges from a single agent handling a complex task to multi-agent systems where specialized agents coordinate across steps. Examples: competitor monitoring and alerting, research → analysis → report pipelines, intake → triage → routing systems.
 
 Group the detailed cards by category. Within each category, order opportunities from highest to lowest impact.
 
@@ -182,28 +182,29 @@ Group the detailed cards by category. Within each category, order opportunities 
 
 ## Step 4 — Workflow Candidate Summary
 
-After presenting the full report, ask me to pick ONE opportunity from each category that I want to build during this course. Once I've chosen, produce a **Workflow Candidate Summary** in this exact format:
+After presenting the full report, ask me to pick ONE opportunity from each category that I want to build during this course. Once I've chosen, produce a **Workflow Candidate Summary** in this exact format, wrapped in a markdown code block so I can copy it easily:
 
----
+```markdown
+- **Workflow:** [name]
+- **Type:** Deterministic
+- **Pain point:** [1 sentence]
+- **AI opportunity:** [1 sentence]
+- **Why it matters:** [1 sentence explaining why this workflow is worth building for my work]
 
-**Workflow:** [3-5 word name]
-**Type:** Collaborative AI
-**Pain point:** [1 sentence — what makes this time-consuming or frustrating today]
-**AI opportunity:** [1 sentence — how AI could help]
+- **Workflow:** [name]
+- **Type:** Collaborative AI
+- **Pain point:** [1 sentence]
+- **AI opportunity:** [1 sentence]
+- **Why it matters:** [1 sentence explaining why this workflow is worth building for my work]
 
-**Workflow:** [3-5 word name]
-**Type:** Deterministic Automation
-**Pain point:** [1 sentence]
-**AI opportunity:** [1 sentence]
+- **Workflow:** [name]
+- **Type:** Autonomous Agent
+- **Pain point:** [1 sentence]
+- **AI opportunity:** [1 sentence]
+- **Why it matters:** [1 sentence explaining why this workflow is worth building for my work]
+```
 
-**Workflow:** [3-5 word name]
-**Type:** Autonomous Agent
-**Pain point:** [1 sentence]
-**AI opportunity:** [1 sentence]
-
----
-
-This summary is my assignment deliverable — format it so I can copy it directly into my course submission.
+This summary is my assignment deliverable — present it inside a code block so I can copy it directly into my course submission. For each "Why it matters" line, use what you learned about my priorities and goals during the interview to explain why this workflow is worth building.
 ```
 
 ## What to Expect
@@ -221,7 +222,7 @@ Most people discover 5–15 opportunities across the three categories. You'll pi
 
 - **Start with Collaborative AI** opportunities if you're new to AI — they're the easiest to try and lowest risk
 - **Move to Deterministic Workflows** once you've identified a process you repeat often — the time savings compound quickly
-- **Explore Multi-Agent Systems** when you have experience with the other two categories and need to automate complex, multi-step processes
+- **Explore Autonomous Agents** when you have experience with the other two categories and need to automate complex, multi-step processes
 
 ## Tips for Better Results
 

--- a/docs/business-first-ai-framework/index.md
+++ b/docs/business-first-ai-framework/index.md
@@ -19,9 +19,9 @@ Find which workflows are candidates for AI.
 
 Before you can apply AI to anything, you need to know *where* it fits. Phase 1 is a structured audit of your workflows that produces a prioritized list of opportunities across three categories:
 
-- **Collaborative AI** — Tasks where you and AI work together in real time (drafting, brainstorming, reviewing)
 - **Deterministic Workflows** — Repeatable processes with clear inputs and outputs that AI can execute reliably with little supervision
-- **Multi-Agent Systems** — Complex workflows where multiple AI agents coordinate across steps
+- **Collaborative AI** — Tasks where you and AI work together in real time (drafting, brainstorming, reviewing)
+- **Autonomous Agents** — Goal-driven workflows where AI plans and executes steps autonomously
 
 The audit uses a three-step process: scan what AI already knows about your work, interview you to fill gaps, then produce a categorized report with specific opportunities and actionable first steps.
 
@@ -81,9 +81,9 @@ Quick reference for the framework's vocabulary:
 
 | Category | Description | Example |
 |----------|-------------|---------|
-| **Collaborative AI** | Human and AI work together in real time | Co-writing, brainstorming, code review |
 | **Deterministic Workflow** | Repeatable process AI executes with minimal supervision | Formatting reports, processing forms |
-| **Multi-Agent System** | Multiple AI agents coordinate across steps | Research → analysis → report pipelines |
+| **Collaborative AI** | Human and AI work together in real time | Co-writing, brainstorming, code review |
+| **Autonomous Agent** | AI plans and executes steps autonomously | Competitor monitoring, research → report pipelines |
 
 ### Five-Question Framework
 

--- a/docs/plugins/business-first-ai.md
+++ b/docs/plugins/business-first-ai.md
@@ -95,7 +95,7 @@ Find which workflows are candidates for AI.
 
 #### `finding-ai-opportunities`
 
-**What it does:** Runs a structured audit of your workflows to discover where AI can help. Produces a prioritized report of opportunities across three categories: Collaborative AI, Deterministic Workflows, and Multi-Agent Systems.
+**What it does:** Runs a structured audit of your workflows to discover where AI can help. Produces a prioritized report of opportunities across three categories: Deterministic Workflows, Collaborative AI, and Autonomous Agents.
 
 **When to use it:** Use this when you want to figure out where AI fits in your work. Especially useful when you're new to AI and need a starting point, or when you want a systematic review rather than ad-hoc experimentation.
 

--- a/docs/questions/strategy/how-do-i-find-workflows-worth-applying-ai-to.md
+++ b/docs/questions/strategy/how-do-i-find-workflows-worth-applying-ai-to.md
@@ -31,12 +31,12 @@ Once you've identified opportunities, use the [Deconstruct Workflows](../../busi
 4. **Pick 1-2 opportunities** to pilot first — don't try to pursue everything at once
 
 !!! tip "Start with Collaborative AI"
-    If you're new to AI, start with Collaborative AI opportunities — they're the easiest to try and lowest risk. Move to Deterministic Workflows once you've identified a process you repeat often. Explore Multi-Agent Systems when you have experience with the other two categories.
+    If you're new to AI, start with Collaborative AI opportunities — they're the easiest to try and lowest risk. Move to Deterministic Workflows once you've identified a process you repeat often. Explore Autonomous Agents when you have experience with the other two categories.
 
 ## Key Takeaways
 
 - Don't wait for problems — proactively audit your workflows to find AI opportunities
-- Think in three categories: collaborative AI, deterministic workflows, and multi-agent systems
+- Think in three categories: deterministic workflows, collaborative AI, and autonomous agents
 - Use the [Discover AI Workflow Opportunities](../../business-first-ai-framework/discover.md) meta prompt to run a structured audit
 - The richer context your AI has about your work, the better the recommendations
 - Start small — pick 1-2 opportunities and pilot them before scaling

--- a/plugins/business-first-ai/.claude-plugin/plugin.json
+++ b/plugins/business-first-ai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "business-first-ai",
   "description": "The Business-First AI Framework as executable Claude Code skills. Discover AI workflow opportunities, deconstruct workflows into building blocks, and build with worked examples across the autonomy spectrum.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": { "name": "James Gray" },
   "homepage": "https://handsonai.info/plugins/",
   "license": "MIT",

--- a/plugins/business-first-ai/skills/finding-ai-opportunities/SKILL.md
+++ b/plugins/business-first-ai/skills/finding-ai-opportunities/SKILL.md
@@ -3,7 +3,7 @@ name: finding-ai-opportunities
 description: >
   Discover where AI can improve your workflows through a structured audit.
   Produces a prioritized report of opportunities across three categories:
-  Collaborative AI, Deterministic Workflows, and Multi-Agent Systems.
+  Deterministic Workflows, Collaborative AI, and Autonomous Agents.
   This is Phase 1 of the Business-First AI Framework.
 ---
 
@@ -51,24 +51,22 @@ Once you can identify at least 3 concrete, specific opportunities with enough de
 
 After presenting the full report, ask the user to pick ONE opportunity from each category that they want to build during the course. Once they've chosen, produce a **Workflow Candidate Summary** in this exact format:
 
----
+```markdown
+- **Workflow:** [name]
+- **Type:** Deterministic
+- **Pain point:** [1 sentence]
+- **AI opportunity:** [1 sentence]
 
-**Workflow:** [3-5 word name]
-**Type:** Collaborative AI
-**Pain point:** [1 sentence — what makes this time-consuming or frustrating today]
-**AI opportunity:** [1 sentence — how AI could help]
+- **Workflow:** [name]
+- **Type:** Collaborative AI
+- **Pain point:** [1 sentence]
+- **AI opportunity:** [1 sentence]
 
-**Workflow:** [3-5 word name]
-**Type:** Deterministic Automation
-**Pain point:** [1 sentence]
-**AI opportunity:** [1 sentence]
-
-**Workflow:** [3-5 word name]
-**Type:** Autonomous Agent
-**Pain point:** [1 sentence]
-**AI opportunity:** [1 sentence]
-
----
+- **Workflow:** [name]
+- **Type:** Autonomous Agent
+- **Pain point:** [1 sentence]
+- **AI opportunity:** [1 sentence]
+```
 
 Append this summary to the output file under a `## Workflow Candidate Summary` heading.
 
@@ -82,7 +80,7 @@ The report must include:
 
 | # | Opportunity | Category | Impact |
 |---|------------|----------|--------|
-| 1 | [Name] | Collaborative AI / Deterministic Workflow / Multi-Agent System | High / Medium / Low |
+| 1 | [Name] | Deterministic Workflow / Collaborative AI / Autonomous Agent | High / Medium / Low |
 
 ### Detailed Opportunity Cards
 
@@ -94,7 +92,7 @@ For each opportunity:
 
 **[#] [Opportunity Name]**
 
-**Category:** Collaborative AI | Deterministic Workflow | Multi-Agent System
+**Category:** Deterministic Workflow | Collaborative AI | Autonomous Agent
 
 **Why it's a good candidate:**
 [What characteristics make this well-suited for AI — repetitive, pattern-based, language-heavy, clear inputs/outputs, etc.]
@@ -114,9 +112,9 @@ For each opportunity:
 
 Use these definitions when categorizing:
 
-- **Collaborative AI**: Human and AI work together in real time. The human drives the process; AI contributes suggestions, drafts, analysis, or feedback. Examples: co-writing, brainstorming, code review, data analysis.
 - **Deterministic Workflow**: A repeatable process with clear inputs, rules, and outputs that AI can execute reliably with minimal supervision. Examples: formatting reports, processing forms, generating routine communications, data transformation.
-- **Multi-Agent System**: A complex workflow where multiple AI agents (or AI + automation tools) coordinate across steps. Requires orchestration. Examples: research-then-write pipelines, intake-triage-routing systems, monitoring-alerting-response workflows.
+- **Collaborative AI**: Human and AI work together in real time. The human drives the process; AI contributes suggestions, drafts, analysis, or feedback. Examples: co-writing, brainstorming, code review, data analysis.
+- **Autonomous Agent**: A goal-driven workflow where AI plans and executes steps autonomously. The agent reasons about what to do, calls tools as needed, and adapts its approach. Ranges from a single agent handling a complex task to multi-agent systems where specialized agents coordinate across steps. Examples: competitor monitoring and alerting, research → analysis → report pipelines, intake → triage → routing systems.
 
 ## Guidelines
 


### PR DESCRIPTION
## Summary
- Standardize category names to canonical terms (Deterministic Workflow, Collaborative AI, Autonomous Agent) replacing outdated Multi-Agent Systems and Deterministic Automation references across all docs, skills, and plugin manifests
- Reorder categories to follow the autonomy spectrum consistently (Deterministic → Collaborative → Autonomous)
- Update Phase 1 prompt template to auto-generate "Why it matters" field so students get a ready-to-submit deliverable with 5 elements instead of 4
- Add Markdown format conversion tip for non-technical students, fix Phase 2 deliverable count (3 → 4), remove numbered deliverable labels, add m365-copilot platform badge, and soften memory prerequisite language

## Test plan
- [x] `mkdocs build` passes (only pre-existing warnings from unrelated files)
- [ ] Verify all outbound links on changed pages resolve correctly
- [ ] Spot-check Notion assignments render correctly with updated content
- [ ] Run Phase 1 prompt template in a test conversation to confirm "Why it matters" field generates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)