### PR TITLE
Add Use Cases section with six AI primitives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ Hands-On AI (handsonai.info) — the consolidated site for James Gray's AI cours
 
 - `docs/agentic-building-blocks/` - The six AI building blocks (Prompts, Context, Projects, Skills, Agents, MCP)
 - `docs/business-first-ai-framework/` - Three-phase methodology (Discover, Deconstruct, Build)
+- `docs/use-cases/` - Six use case primitives (Content Creation, Research, Coding, Data Analysis, Ideation & Strategy, Automation)
 - `docs/platforms/` - Platform-specific content (Claude, OpenAI, Gemini, M365 Copilot)
 - `docs/builder-setup/` - Developer tool installation guides (terminal, Git, editor, Claude Code)
 - `docs/patterns/` - Reusable patterns and best practices

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -13,6 +13,7 @@ Thank you for contributing to Hands-On AI! This guide explains how to add new co
 |---------|----------|---------|
 | Agentic Building Blocks | `agentic-building-blocks/` | The six AI building blocks (Prompts, Context, Projects, Skills, Agents, MCP) |
 | Business-First AI Framework | `business-first-ai-framework/` | Three-phase methodology (Discover, Deconstruct, Build) |
+| Use Cases | `use-cases/` | Six use case primitives (Content Creation, Research, Coding, Data Analysis, Ideation & Strategy, Automation) |
 | Platforms | `platforms/` | Platform-specific content (Claude, OpenAI, Gemini, M365 Copilot) |
 | Builder Setup | `builder-setup/` | Tool setup and installation guides |
 | Patterns | `patterns/` | Document reusable approaches |

--- a/docs/agentic-building-blocks/agents/index.md
+++ b/docs/agentic-building-blocks/agents/index.md
@@ -29,4 +29,6 @@ Concepts for building AI agents and implementing tool use.
 ## Related
 
 - [Agentic Building Blocks](../index.md)
+- [AI Use Cases](../../use-cases/index.md) — what teams build with agents, organized by six primitives
+- [Automation Use Cases](../../use-cases/automation.md) — the highest-autonomy use cases powered by agents
 - [Patterns](../../patterns/index.md)

--- a/docs/agentic-building-blocks/context/index.md
+++ b/docs/agentic-building-blocks/context/index.md
@@ -72,5 +72,6 @@ Context makes prompts smarter. Projects organize context persistently so you don
 ## Related
 
 - [Agentic Building Blocks](../index.md) — Context in the context of all six building blocks
+- [AI Use Cases](../../use-cases/index.md) — what teams build with context, organized by six primitives
 - [Prompts](../prompts/index.md) — the instructions that context enhances
 - [Projects](../projects/index.md) — where context becomes persistent and organized

--- a/docs/agentic-building-blocks/index.md
+++ b/docs/agentic-building-blocks/index.md
@@ -271,6 +271,10 @@ A project is an active workspace — it provides standing instructions, persiste
 - [MCP](mcp/index.md) — connecting AI to external systems
 - [Patterns](../patterns/index.md) — reusable approaches across building blocks
 
+**Use cases:**
+
+- [AI Use Cases](../use-cases/index.md) — what teams build with these blocks, organized by six primitives
+
 **Platform-specific guides:**
 
 - [Claude Projects](../platforms/claude/projects/claude-projects-setup.md) — setting up the Project block on Claude

--- a/docs/agentic-building-blocks/mcp/index.md
+++ b/docs/agentic-building-blocks/mcp/index.md
@@ -61,6 +61,8 @@ MCP extends what agents and skills can do by connecting them to external systems
 ## Related
 
 - [Agentic Building Blocks](../index.md) — MCP in the context of all six building blocks
+- [AI Use Cases](../../use-cases/index.md) — what teams build with MCP, organized by six primitives
+- [Automation Use Cases](../../use-cases/automation.md) — MCP enables the data connections that power automated workflows
 - [Agents](../agents/index.md) — autonomous systems that use MCP to interact with external tools
 - [Skills](../skills/index.md) — reusable routines that MCP can enhance with external data
 - [Projects](../projects/index.md) — workspaces where MCP connectors are configured

--- a/docs/agentic-building-blocks/projects/index.md
+++ b/docs/agentic-building-blocks/projects/index.md
@@ -78,5 +78,6 @@ Good projects have:
 ## Related
 
 - [Agentic Building Blocks](../index.md) — Projects in the context of all six building blocks
+- [AI Use Cases](../../use-cases/index.md) — what teams build with projects, organized by six primitives
 - [Prompts](../prompts/index.md) — techniques for the prompts that go inside projects
 - [Business-First AI Framework](../../business-first-ai-framework/index.md) — uses projects as a building block in workflow analysis

--- a/docs/agentic-building-blocks/prompts/index.md
+++ b/docs/agentic-building-blocks/prompts/index.md
@@ -73,5 +73,6 @@ Not every prompt needs all four elements. A simple question needs only the task.
 ## Related
 
 - [Agentic Building Blocks](../index.md) — Prompts in the context of all six building blocks
+- [AI Use Cases](../../use-cases/index.md) — see how prompts are used across content creation, research, coding, data analysis, ideation, and automation
 - [Projects](../projects/index.md) — where prompts become persistent custom instructions
 - [Patterns](../../patterns/index.md) — reusable prompt structures

--- a/docs/agentic-building-blocks/skills/index.md
+++ b/docs/agentic-building-blocks/skills/index.md
@@ -75,6 +75,7 @@ The `SKILL.md` file contains the instructions. The `references/` folder holds an
 ## Related
 
 - [Agentic Building Blocks](../index.md) — Skills in the context of all six building blocks
+- [AI Use Cases](../../use-cases/index.md) — what teams build with skills, organized by six primitives
 - [Prompts](../prompts/index.md) — the foundation that skills build on
 - [Agents](../agents/index.md) — autonomous systems that invoke skills as part of multi-step workflows
 - [Plugin Marketplace](../../plugins/index.md) — pre-built skills you can install

--- a/docs/business-first-ai-framework/build/ai-collaborative.md
+++ b/docs/business-first-ai-framework/build/ai-collaborative.md
@@ -113,5 +113,7 @@ To adapt: identify tasks where you spend significant time gathering information 
 
 - [Deterministic Automation Workflow Example](./deterministic-automation.md) — when AI follows fixed rules with no judgment needed
 - [Autonomous Agent Workflow Example](./autonomous-agent.md) — when AI executes end-to-end with minimal supervision
+- [Research Use Cases](../../use-cases/research.md) — more examples of AI-powered research workflows like meeting prep
+- [Ideation & Strategy Use Cases](../../use-cases/ideation-and-strategy.md) — collaborative brainstorming and planning with AI
 - [Discover AI Workflow Opportunities](../discover.md) — discover which workflows are candidates for AI collaboration
 - [Deconstruct Workflows](../deconstruct/index.md) — break down workflows into AI-ready steps

--- a/docs/business-first-ai-framework/build/autonomous-agent.md
+++ b/docs/business-first-ai-framework/build/autonomous-agent.md
@@ -161,6 +161,9 @@ To adapt: identify the distinct phases of your workflow and the specialist exper
 
 - [Deterministic Automation Workflow Example](./deterministic-automation.md) — when AI follows fixed rules with no judgment needed
 - [AI Collaborative Workflow Example](./ai-collaborative.md) — when AI and human iterate together
+- [Content Creation Use Cases](../../use-cases/content-creation.md) — more examples of AI-powered content workflows
+- [Research Use Cases](../../use-cases/research.md) — more examples of AI-powered research workflows
+- [Automation Use Cases](../../use-cases/automation.md) — turning multi-agent pipelines into scheduled operations
 - [Discover AI Workflow Opportunities](../discover.md) — discover which workflows are candidates for autonomous agents
 - [Deconstruct Workflows](../deconstruct/index.md) — break down workflows into agent-ready steps
 - [Plugin Marketplace](../../plugins/index.md) — browse all agents and skills used in this pipeline

--- a/docs/business-first-ai-framework/build/deterministic-automation.md
+++ b/docs/business-first-ai-framework/build/deterministic-automation.md
@@ -136,5 +136,7 @@ To adapt: identify the **input criteria** (the persona equivalent), the **evalua
 
 - [AI Collaborative Workflow Example](./ai-collaborative.md) — when AI needs to research, reason, and iterate with a human
 - [Autonomous Agent Workflow Example](./autonomous-agent.md) — when AI executes end-to-end with minimal supervision
+- [Research Use Cases](../../use-cases/research.md) — more examples of AI-powered research workflows
+- [Automation Use Cases](../../use-cases/automation.md) — turning deterministic workflows into scheduled pipelines
 - [Discover AI Workflow Opportunities](../discover.md) — discover which of your workflows are candidates for automation
 - [Deconstruct Workflows](../deconstruct/index.md) — break down complex workflows into automatable steps

--- a/docs/business-first-ai-framework/build/index.md
+++ b/docs/business-first-ai-framework/build/index.md
@@ -85,6 +85,7 @@ These are the working building blocks included across all three examples. Each o
 
 ## Related
 
+- [AI Use Cases](../../use-cases/index.md) — browse use cases by type (content creation, research, coding, data analysis, ideation, automation)
 - [Discover AI Workflow Opportunities](../discover.md) — discover which of your workflows are candidates for AI
 - [Deconstruct Workflows](../deconstruct/index.md) — break down workflows into automatable steps
 - [Plugin Marketplace](../../plugins/index.md) — browse all available plugins

--- a/docs/business-first-ai-framework/deconstruct/index.md
+++ b/docs/business-first-ai-framework/deconstruct/index.md
@@ -152,7 +152,9 @@ From there, the model proposes a step-by-step workflow to address the problem, a
 
 ### Not sure which workflow to try?
 
-Pick something you do regularly and could describe to a colleague over coffee. Here are some examples students have used:
+Browse the [AI Use Cases](../../use-cases/index.md) section for inspiration — it organizes examples by type (content creation, research, coding, data analysis, ideation, and automation) with department-specific scenarios.
+
+Or pick something you do regularly and could describe to a colleague over coffee. Here are some examples students have used:
 
 - **Weekly team status reporting** — gathering updates from multiple sources, synthesizing, and distributing a summary
 - **New client onboarding** — intake, account setup, kickoff scheduling, and initial deliverables

--- a/docs/business-first-ai-framework/discover.md
+++ b/docs/business-first-ai-framework/discover.md
@@ -86,6 +86,9 @@ There are four ways to run Phase 1, depending on which tools you use:
 
 All four options follow the same three-step process and produce the same structured report. Choose whichever fits your workflow.
 
+!!! tip "Classify opportunities with the six primitives"
+    Once you've identified opportunities, use the [six use case primitives](../use-cases/index.md) — Content Creation, Research, Coding, Data Analysis, Ideation & Strategy, and Automation — to classify what type of AI work each one involves. This makes it easier to find examples and choose the right building blocks.
+
 !!! tip "Best results come from rich context"
     The more the AI knows about your actual work, the better the recommendations. If possible, use a tool where you've had many prior conversations or uploaded relevant documents.
 

--- a/docs/business-first-ai-framework/index.md
+++ b/docs/business-first-ai-framework/index.md
@@ -108,6 +108,10 @@ Used to decompose each workflow step:
 
 For detailed definitions and cross-platform examples, see [Agentic Building Blocks](../agentic-building-blocks/index.md).
 
+### Six Use Case Primitives
+
+When classifying opportunities from Phase 1, it helps to know what **type** of AI work each one involves. The [six use case primitives](../use-cases/index.md) — Content Creation, Research, Coding, Data Analysis, Ideation & Strategy, and Automation — provide a classification system for the opportunities you discover.
+
 ### Autonomy Spectrum
 
 | Level | Description |

--- a/docs/business-first-ai-framework/questions/how-do-i-find-workflows-worth-applying-ai-to.md
+++ b/docs/business-first-ai-framework/questions/how-do-i-find-workflows-worth-applying-ai-to.md
@@ -37,6 +37,7 @@ Once you've identified opportunities, use the [Deconstruct Workflows](../deconst
 
 - Don't wait for problems — proactively audit your workflows to find AI opportunities
 - Think in three categories: deterministic workflows, collaborative AI, and autonomous agents
+- Use the [six use case primitives](../../use-cases/index.md) — content creation, research, coding, data analysis, ideation, and automation — to classify what type of work each opportunity involves
 - Use the [Discover AI Workflow Opportunities](../discover.md) meta prompt to run a structured audit
 - The richer context your AI has about your work, the better the recommendations
 - Start small — pick 1-2 opportunities and pilot them before scaling

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,14 @@ Guides, patterns, ready-made tools, and direct answers — everything you need t
 
     [:octicons-arrow-right-24: Building blocks](agentic-building-blocks/)
 
+-   :material-target:{ .lg .middle } **Use Cases**
+
+    ---
+
+    Six primitives that cover what teams build with AI — content creation, research, coding, data analysis, ideation, and automation
+
+    [:octicons-arrow-right-24: Explore use cases](use-cases/)
+
 -   :material-wrench:{ .lg .middle } **Builder Setup**
 
     ---
@@ -64,6 +72,7 @@ Guides, patterns, ready-made tools, and direct answers — everything you need t
 | Schedule AI agents | [Scheduling Subagents](platforms/claude/subagents/scheduling-subagents.md) |
 | Set up Git and GitHub | [Git Installation](builder-setup/git-install.md) |
 | Learn the six AI building blocks | [Agentic Building Blocks](agentic-building-blocks/) |
+| Explore AI use cases by type | [Use Case Primitives](use-cases/) |
 | Install Claude Code plugins | [Plugin Marketplace](plugins/) |
 | Take a structured course | [Courses](courses/) |
 

--- a/docs/plugins/business-first-ai.md
+++ b/docs/plugins/business-first-ai.md
@@ -515,7 +515,7 @@ The plugin covers the full Business-First AI Framework. Here's the recommended p
 ## FAQ
 
 **Which phase should I start with?**
-Start with Phase 1 (Discover) if you're not sure where AI fits in your work. Start with Phase 2 (Deconstruct) if you already know which workflow you want to automate. Start with Phase 3 (Build) if you want to study working examples before deconstructing your own workflows.
+Start with Phase 1 (Discover) if you're not sure where AI fits in your work. Browse [AI Use Cases](../use-cases/index.md) to see what types of work AI handles — content creation, research, coding, data analysis, ideation, and automation. Start with Phase 2 (Deconstruct) if you already know which workflow you want to automate. Start with Phase 3 (Build) if you want to study working examples before deconstructing your own workflows.
 
 **Can I start from a problem instead of a workflow?**
 Yes. Tell the `workflow-deconstructor` agent about your problem (e.g., "people keep dropping off during enrollment") and it will propose a candidate workflow for you to refine during discovery.

--- a/docs/use-cases/automation.md
+++ b/docs/use-cases/automation.md
@@ -1,0 +1,101 @@
+---
+title: Automation
+description: AI use cases for repeatable routine tasks that run with minimal human involvement — scheduled pipelines, triggered workflows, and autonomous operations
+---
+
+# Automation
+
+## What Automation Is
+
+Automation use cases have AI execute repeatable routine tasks with minimal human involvement. Unlike the other primitives where you interact with AI in real time, automation runs on its own — on a schedule, in response to a trigger, or as part of a pipeline. You configure it once, and it produces consistent results without manual intervention.
+
+This is the highest-autonomy primitive. Automation typically builds on the other five primitives: a content creation workflow becomes automation when it runs weekly without prompting. A research workflow becomes automation when it monitors sources continuously. A data analysis workflow becomes automation when it generates reports on a schedule.
+
+Automation delivers the largest time savings because it eliminates recurring manual work entirely. But it also requires the most upfront investment in configuration, testing, and monitoring — you're trusting AI to act independently, so the instructions, guardrails, and error handling need to be robust.
+
+*Automation is one of six use case primitives identified in OpenAI's [Identifying and Scaling AI Use Cases](https://cdn.openai.com/business-guides-and-resources/identifying-and-scaling-ai-use-cases.pdf) guide. The examples here are adapted to be platform-agnostic and mapped to [Agentic Building Blocks](../agentic-building-blocks/index.md).*
+
+## Key Characteristics
+
+- **Runs without real-time human involvement** — the workflow executes on a schedule, trigger, or as part of a pipeline
+- **Builds on other primitives** — automation is rarely a primitive by itself; it's the operational wrapper around content creation, research, coding, data analysis, or ideation tasks
+- **Requires robust instructions** — since nobody is there to course-correct in real time, the instructions must handle edge cases, errors, and unexpected inputs
+- **Monitoring matters** — automated workflows need logging, alerting, and periodic review to ensure they're still producing quality output
+- **Compounds over time** — each automated workflow frees up recurring hours, and the savings accumulate week over week
+
+## When to Apply This Primitive
+
+**Use Automation when:**
+
+- A workflow runs on a predictable schedule (daily, weekly, monthly)
+- The same steps execute with different inputs each time
+- The workflow has clear success criteria that don't require subjective judgment
+- Speed and consistency matter more than creative nuance
+
+**NOT the right primitive when:**
+
+- The task requires real-time human judgment or creative direction (use the underlying primitive directly)
+- The workflow is unpredictable — different steps, different logic each time
+- You're still iterating on the workflow design (automate after you've proven the process works manually)
+
+## Department Examples
+
+| Department | Use Case | What AI Does | Typical Building Blocks |
+|-----------|----------|-------------|------------------------|
+| Marketing | Weekly competitive update | Monitors competitor sites, compiles changes, and distributes a summary report every Monday | Agent, MCP, Skill |
+| Sales | Lead enrichment pipeline | Automatically researches new leads, scores them, and populates CRM fields when leads enter the pipeline | Agent, MCP, Skill |
+| Finance | Recurring report generation | Pulls data from accounting systems, generates formatted reports, and distributes to stakeholders on schedule | Agent, MCP, Skill |
+| HR | Onboarding document preparation | Generates customized onboarding packets when a new hire is confirmed, pulling role-specific content and formatting | Agent, Skill, Context |
+| Product | Release communication | Generates release notes, changelog entries, and customer-facing announcements when new versions are deployed | Agent, MCP, Skill |
+| IT/Operations | System health summaries | Aggregates monitoring data, identifies trends, and produces daily operational summaries | Agent, MCP, Skill |
+
+## Building Block Patterns
+
+| Complexity | Building Blocks | Example |
+|-----------|----------------|---------|
+| **Simple** | Skill (scheduled) | A skill that runs daily to format and distribute yesterday's key metrics from a spreadsheet |
+| **Intermediate** | Agent + MCP | An agent that monitors a data source via MCP, detects changes, and takes predefined actions |
+| **Advanced** | Agent + MCP + multiple Skills | A pipeline agent that orchestrates multiple skills — gathering data, analyzing it, generating content, and distributing results — all running on a schedule |
+
+## Use Cases
+
+| | |
+|---|---|
+| **Department** | Marketing |
+| **Autonomy level** | Autonomous |
+| **Building blocks** | Agent, MCP, Skill |
+| **Problem** | The competitive intelligence report takes 4 hours every Monday — manually checking competitor websites, noting changes, comparing positioning, and formatting a summary for the team |
+| **Solution** | A scheduled agent runs every Sunday night: checks competitor sites via MCP, compares against the previous week's snapshot, generates a structured delta report using a content skill, and posts the summary to the team Slack channel |
+
+| | |
+|---|---|
+| **Department** | Sales |
+| **Autonomy level** | Autonomous |
+| **Building blocks** | Agent, MCP, Skill |
+| **Problem** | New leads sit in the CRM with minimal information — reps spend the first 15 minutes of every outreach sequence manually researching the company and contact before they can personalize their approach |
+| **Solution** | A triggered agent fires when a new lead enters the CRM: researches the company and contact via web search and LinkedIn, scores the lead against ideal customer criteria, and populates CRM fields with enriched data — so reps start every outreach with full context |
+
+| | |
+|---|---|
+| **Department** | Finance |
+| **Autonomy level** | Autonomous |
+| **Building blocks** | Agent, MCP, Skill |
+| **Problem** | Monthly board reporting requires pulling data from four systems, formatting it into the approved template, calculating variances, and writing commentary — the same process every month with different numbers |
+| **Solution** | A monthly agent pulls data from accounting, CRM, HR, and product analytics via MCP, populates the board report template, calculates period-over-period variances, drafts commentary on significant changes, and places the draft report in the CFO's review folder |
+
+## Common Mistakes
+
+**Automating before the process is proven.** Automate workflows that you've run manually at least several times and are confident work correctly. Automating an untested process just means you'll produce bad output faster and more consistently.
+
+**No monitoring or alerting.** Automated workflows fail silently. Build in logging, periodic output review, and alerting for failures or anomalous results. The worst automation failures are the ones nobody notices for weeks.
+
+**Over-automating judgment calls.** Automation works best for structured, predictable tasks. If a workflow step requires nuanced judgment (should we respond to this complaint? is this data anomaly real or a reporting error?), keep a human in the loop — even if that means the workflow pauses for review at that step.
+
+## Related
+
+- [AI Use Cases Overview](index.md) — all six primitives at a glance
+- [Agents](../agentic-building-blocks/agents/index.md) — the building block that powers most automation
+- [MCP](../agentic-building-blocks/mcp/index.md) — connecting automated workflows to external systems
+- [Skills](../agentic-building-blocks/skills/index.md) — reusable routines that agents invoke during automation
+- [Scheduling Subagents](../platforms/claude/subagents/scheduling-subagents.md) — how to schedule automated agents on Claude
+- [Phase 3 — Build](../business-first-ai-framework/build/index.md) — worked examples including autonomous agent workflows

--- a/docs/use-cases/coding.md
+++ b/docs/use-cases/coding.md
@@ -1,0 +1,100 @@
+---
+title: Coding
+description: AI use cases for generating, debugging, porting, and explaining code — from spreadsheet formulas to full applications
+---
+
+# Coding
+
+## What Coding Is
+
+Coding use cases have AI generate, debug, port, refactor, and explain code. This primitive extends far beyond traditional software engineering — it includes anyone who needs to create scripts, formulas, queries, macros, or technical artifacts as part of their work.
+
+A marketing manager writing an Excel formula, a data analyst creating a SQL query, an operations lead building a Google Apps Script, and a software engineer writing a microservice — all of these are coding use cases. The AI handles the translation from intent to working technical implementation.
+
+Coding is the primitive where AI agents are most mature. Modern AI coding agents can plan an approach, write code, run tests, debug failures, and iterate — handling multi-file changes across entire projects with minimal human guidance.
+
+*Coding is one of six use case primitives identified in OpenAI's [Identifying and Scaling AI Use Cases](https://cdn.openai.com/business-guides-and-resources/identifying-and-scaling-ai-use-cases.pdf) guide. The examples here are adapted to be platform-agnostic and mapped to [Agentic Building Blocks](../agentic-building-blocks/index.md).*
+
+## Key Characteristics
+
+- **Output is executable** — the deliverable is code, scripts, formulas, or queries that run and produce results
+- **Testable and verifiable** — unlike content or research, code either works or it doesn't, making quality assessment straightforward
+- **Amplifies non-technical users** — people who understand what they need but can't write code can now create technical solutions
+- **Benefits from iteration** — AI can write, run, see errors, and fix them in a loop, converging on working solutions
+- **Context accelerates quality** — existing codebase, documentation, and examples help AI produce code that fits your patterns and standards
+
+## When to Apply This Primitive
+
+**Use Coding when:**
+
+- The deliverable is something that executes — code, scripts, formulas, queries, or macros
+- You need to translate a business requirement into a technical implementation
+- You're debugging, refactoring, or porting existing code
+- Non-technical team members need technical artifacts (Excel formulas, SQL queries, simple scripts)
+
+**NOT the right primitive when:**
+
+- The main output is a written document (that's [Content Creation](content-creation.md))
+- You're analyzing data and the insight is the deliverable, not the analysis code (that's [Data Analysis](data-analysis.md))
+- You're creating a pipeline that runs autonomously (that's [Automation](automation.md) — though coding may be a step within it)
+
+## Department Examples
+
+| Department | Use Case | What AI Does | Typical Building Blocks |
+|-----------|----------|-------------|------------------------|
+| Engineering | Feature development | Plans, writes, tests, and debugs features across multiple files | Agent, Context, MCP |
+| Marketing | Dashboard formulas | Creates complex spreadsheet formulas and Google Sheets scripts from plain-language descriptions | Prompt, Context |
+| Finance | Financial models | Builds Excel models and Python scripts for scenario analysis | Prompt, Context, Skill |
+| Sales | CRM automation scripts | Writes scripts to automate CRM data entry, lead scoring, and pipeline management | Prompt, Context, Agent |
+| HR | Workflow automation | Creates Google Apps Scripts or Power Automate flows for approval processes | Prompt, Context |
+| IT/Operations | Infrastructure scripts | Generates deployment scripts, monitoring configurations, and automation tooling | Agent, Context, MCP |
+
+## Building Block Patterns
+
+| Complexity | Building Blocks | Example |
+|-----------|----------------|---------|
+| **Simple** | Prompt + Context | Ask AI to write a VLOOKUP formula, providing the spreadsheet structure as context |
+| **Intermediate** | Agent + Context | An AI agent that reads your codebase, writes a new feature, runs the tests, and iterates until they pass |
+| **Advanced** | Agent + MCP + Context | An agent connected to your repository (via MCP) that handles pull requests end-to-end — writing code, running CI, addressing review comments |
+
+## Use Cases
+
+| | |
+|---|---|
+| **Department** | Finance |
+| **Autonomy level** | Collaborative |
+| **Building blocks** | Prompt, Context |
+| **Problem** | Building financial models in Excel takes hours of formula debugging — nested IF statements, VLOOKUP chains, and array formulas are error-prone and hard to verify |
+| **Solution** | Describe the model logic in plain language with sample data as context. AI generates the formulas, explains each step, and troubleshoots errors when the results don't match expectations |
+
+| | |
+|---|---|
+| **Department** | Engineering |
+| **Autonomy level** | Autonomous |
+| **Building blocks** | Agent, Context, MCP |
+| **Problem** | Routine development tasks (bug fixes, test writing, dependency updates, small features) consume senior engineer time that should go to architecture and design |
+| **Solution** | An AI coding agent reads the issue, explores the codebase, writes the implementation, runs tests, and creates a pull request. Senior engineers review the output rather than writing it themselves |
+
+| | |
+|---|---|
+| **Department** | Marketing |
+| **Autonomy level** | Collaborative |
+| **Building blocks** | Prompt, Context, Skill |
+| **Problem** | The marketing team needs data pulled from multiple spreadsheets and combined into reports, but they depend on engineering for any formula or script work — creating a bottleneck |
+| **Solution** | A skill that takes a plain-language description of what data to combine and how, generates the appropriate Google Sheets formulas or Apps Script, and explains how to use it. Marketing becomes self-sufficient for routine data tasks |
+
+## Common Mistakes
+
+**Accepting code without testing it.** AI-generated code often works but may have subtle bugs, security issues, or edge cases. Always run the code, verify the output, and test edge cases before deploying — especially for code that handles sensitive data or runs in production.
+
+**Providing requirements without examples.** "Build a script that processes our invoices" is vague. "Build a script that reads CSV files with columns [date, vendor, amount, category], groups by category, and outputs a summary with totals — here's a sample file" produces working code on the first try.
+
+**Confusing coding with data analysis.** If the goal is the insight (what are our spending trends?), the primitive is [Data Analysis](data-analysis.md). If the goal is the tool (build me a script that analyzes spending), the primitive is Coding. The distinction matters because it changes how you evaluate the output.
+
+## Related
+
+- [AI Use Cases Overview](index.md) — all six primitives at a glance
+- [Agents](../agentic-building-blocks/agents/index.md) — autonomous coding agents that plan, write, test, and iterate
+- [Context](../agentic-building-blocks/context/index.md) — providing codebases, documentation, and examples
+- [Data Analysis](data-analysis.md) — when the insight is the goal, not the code
+- [Automation](automation.md) — when code runs as part of an unattended pipeline

--- a/docs/use-cases/content-creation.md
+++ b/docs/use-cases/content-creation.md
@@ -1,0 +1,100 @@
+---
+title: Content Creation
+description: AI use cases for drafting, editing, translating, and repurposing content across formats and audiences
+---
+
+# Content Creation
+
+## What Content Creation Is
+
+Content creation is the most common AI use case primitive. AI drafts, edits, translates, reformats, and repurposes written and visual content — handling the production work so you can focus on message, strategy, and quality control.
+
+This primitive covers any workflow where the primary output is a piece of content: emails, reports, blog posts, social media, presentations, documentation, training materials, and more. The AI handles first drafts, tone adjustments, format conversions, and audience adaptation. You provide direction, context, and final judgment.
+
+Content creation use cases scale from simple (rewriting an email for a different audience) to complex (generating a complete content calendar with drafts for each piece, adapted to platform-specific requirements).
+
+*Content Creation is one of six use case primitives identified in OpenAI's [Identifying and Scaling AI Use Cases](https://cdn.openai.com/business-guides-and-resources/identifying-and-scaling-ai-use-cases.pdf) guide. The examples here are adapted to be platform-agnostic and mapped to [Agentic Building Blocks](../agentic-building-blocks/index.md).*
+
+## Key Characteristics
+
+- **Output is written or visual content** — the deliverable is something people read, watch, or interact with
+- **Quality depends on context** — brand voice, style guides, examples, and audience knowledge dramatically improve output
+- **Human review is essential for quality** — AI produces strong first drafts but needs human judgment for nuance, accuracy, and brand alignment
+- **Highly reusable** — the same content creation workflow (write a blog post, draft an email, create a summary) runs repeatedly with different inputs
+- **Scales across formats** — one piece of source content can be adapted to multiple formats and audiences
+
+## When to Apply This Primitive
+
+**Use Content Creation when:**
+
+- The primary deliverable is a written document, message, or media asset
+- You're producing similar content repeatedly (weekly reports, social posts, email templates)
+- You need to adapt content for different audiences, formats, or languages
+- The task involves editing, proofreading, or reformatting existing content
+
+**NOT the right primitive when:**
+
+- The main goal is gathering and synthesizing information (that's [Research](research.md))
+- You're generating code, scripts, or technical artifacts (that's [Coding](coding.md))
+- The content is a plan, strategy, or set of recommendations (that's [Ideation & Strategy](ideation-and-strategy.md))
+
+## Department Examples
+
+| Department | Use Case | What AI Does | Typical Building Blocks |
+|-----------|----------|-------------|------------------------|
+| Marketing | Social media content calendar | Drafts platform-specific posts from a single brief, adapting tone for each channel | Prompt, Context, Skill, Project |
+| Sales | Proposal and pitch decks | Generates first-draft proposals using client context and past winning proposals | Prompt, Context, Project |
+| HR | Job descriptions and offer letters | Drafts job descriptions from role requirements, ensures consistent format and inclusive language | Prompt, Context, Skill |
+| Finance | Executive summaries | Transforms detailed financial reports into concise summaries for leadership | Prompt, Context, Skill |
+| Product | Release notes and changelogs | Converts technical commit logs into user-facing release notes | Prompt, Context, Skill |
+| Legal | Contract summaries | Produces plain-language summaries of contract terms for non-legal stakeholders | Prompt, Context |
+
+## Building Block Patterns
+
+| Complexity | Building Blocks | Example |
+|-----------|----------------|---------|
+| **Simple** | Prompt + Context | Paste a style guide and ask AI to rewrite an email in brand voice |
+| **Intermediate** | Project + Skill | A "Weekly Newsletter" project with a skill that drafts each edition from bullet-point inputs |
+| **Advanced** | Agent + MCP + Skill | An agent that pulls data from your CMS, drafts content using a brand-voice skill, and publishes drafts for review |
+
+## Use Cases
+
+| | |
+|---|---|
+| **Department** | Marketing |
+| **Autonomy level** | Collaborative |
+| **Building blocks** | Prompt, Context, Skill, Project |
+| **Problem** | Writing social posts for each platform takes 3+ hours per campaign — each channel has different format requirements, character limits, and tone expectations |
+| **Solution** | A project workspace with brand guidelines and platform specs as context. A skill takes a single campaign brief and produces platform-adapted drafts for LinkedIn, X, Instagram, and email |
+
+| | |
+|---|---|
+| **Department** | Sales |
+| **Autonomy level** | Collaborative |
+| **Building blocks** | Prompt, Context, Project |
+| **Problem** | Custom proposals take 4-6 hours each because reps start from scratch or copy outdated templates, leading to inconsistent messaging and missed value propositions |
+| **Solution** | A proposal project with winning past proposals, product sheets, and pricing guidelines as context. Reps provide client-specific details and get a structured first draft that follows the team's best patterns |
+
+| | |
+|---|---|
+| **Department** | HR |
+| **Autonomy level** | Deterministic |
+| **Building blocks** | Prompt, Context, Skill |
+| **Problem** | Job descriptions are inconsistent across teams — different formats, missing sections, and language that may not meet inclusivity standards |
+| **Solution** | A skill that takes role requirements as input and produces a consistently formatted job description with inclusive language, following the company's standard template and compliance requirements |
+
+## Common Mistakes
+
+**Skipping context and expecting brand-quality output.** Generic AI content sounds generic. The difference between "AI-generated" and "AI-assisted" content is the context you provide — brand voice docs, examples of good content, audience profiles, and style guides.
+
+**Using AI for final copy instead of first drafts.** AI-generated content should be a starting point, not a finished product. Plan for human review and editing, especially for external-facing content where accuracy and nuance matter.
+
+**One-size-fits-all content across channels.** A LinkedIn post is not a tweet is not a blog paragraph. Effective content creation workflows include format-specific instructions and examples, not just "make this shorter."
+
+## Related
+
+- [AI Use Cases Overview](index.md) — all six primitives at a glance
+- [Prompts](../agentic-building-blocks/prompts/index.md) — writing effective instructions for content generation
+- [Context](../agentic-building-blocks/context/index.md) — providing brand voice, style guides, and examples
+- [Skills](../agentic-building-blocks/skills/index.md) — packaging content creation workflows for reuse
+- [Projects](../agentic-building-blocks/projects/index.md) — persistent workspaces for recurring content workflows

--- a/docs/use-cases/data-analysis.md
+++ b/docs/use-cases/data-analysis.md
@@ -1,0 +1,100 @@
+---
+title: Data Analysis
+description: AI use cases for harmonizing data from multiple sources, identifying trends, and producing visualizations and insights
+---
+
+# Data Analysis
+
+## What Data Analysis Is
+
+Data analysis use cases have AI harmonize data from multiple sources, identify trends and patterns, and produce visualizations and insights. The AI handles the tedious work — cleaning, formatting, merging, and pattern recognition — while you direct the analysis and interpret the results.
+
+This primitive covers any workflow where the primary output is an insight derived from data: trend reports, anomaly detection, forecasting, benchmarking, and exploratory analysis. The data can come from spreadsheets, databases, APIs, or documents — the AI adapts to whatever format you provide.
+
+Data analysis is often the highest-value primitive for teams that have data but lack the time or technical skills to extract meaning from it. AI dramatically lowers the barrier to working with data, letting anyone ask questions of their datasets in plain language.
+
+*Data Analysis is one of six use case primitives identified in OpenAI's [Identifying and Scaling AI Use Cases](https://cdn.openai.com/business-guides-and-resources/identifying-and-scaling-ai-use-cases.pdf) guide. The examples here are adapted to be platform-agnostic and mapped to [Agentic Building Blocks](../agentic-building-blocks/index.md).*
+
+## Key Characteristics
+
+- **Output is insights, not raw data** — the deliverable is an interpretation, trend, pattern, or recommendation based on data
+- **Source data quality is everything** — AI can't fix garbage data, but it can identify inconsistencies and suggest cleanup steps
+- **Exploratory by nature** — the best data analysis is iterative: initial findings suggest new questions worth investigating
+- **Visual outputs are powerful** — charts, graphs, and dashboards often communicate insights more effectively than text summaries
+- **Combines well with other primitives** — data analysis frequently feeds into content creation (reports), ideation (strategy), and automation (alerting)
+
+## When to Apply This Primitive
+
+**Use Data Analysis when:**
+
+- You have data and need to extract meaning, patterns, or trends from it
+- You need to harmonize data from multiple sources into a single view
+- The deliverable is a chart, dashboard, trend report, or data-driven recommendation
+- You want to explore a dataset to find what's interesting before deciding what to investigate further
+
+**NOT the right primitive when:**
+
+- The main output is code or a reusable tool for analyzing data (that's [Coding](coding.md))
+- You're gathering qualitative information from documents and sources (that's [Research](research.md))
+- You're running a data pipeline on a schedule without human involvement (that's [Automation](automation.md))
+
+## Department Examples
+
+| Department | Use Case | What AI Does | Typical Building Blocks |
+|-----------|----------|-------------|------------------------|
+| Finance | Expense analysis | Harmonizes expense data from multiple systems, categorizes spending, and identifies anomalies | Prompt, Context, Skill |
+| Marketing | Campaign performance | Combines data from ad platforms, web analytics, and CRM to show what's working and what isn't | Prompt, Context, Agent |
+| Sales | Pipeline analysis | Analyzes deal stage durations, conversion rates, and win/loss patterns across the pipeline | Prompt, Context, Skill |
+| HR | Workforce analytics | Identifies retention patterns, compensation benchmarks, and headcount trends from HR data | Prompt, Context |
+| Product | Usage analytics | Analyzes product usage data to identify adoption patterns, feature engagement, and churn indicators | Prompt, Context, Agent |
+| Operations | Process efficiency | Measures cycle times, bottlenecks, and throughput across operational workflows | Prompt, Context, Skill |
+
+## Building Block Patterns
+
+| Complexity | Building Blocks | Example |
+|-----------|----------------|---------|
+| **Simple** | Prompt + Context | Upload a CSV and ask AI to identify the top trends, outliers, and patterns |
+| **Intermediate** | Skill + Context | A skill that takes monthly sales data, compares to previous periods, and produces a formatted performance report with charts |
+| **Advanced** | Agent + MCP + Skill | An agent that pulls data from multiple sources via MCP, harmonizes it, runs analysis, and produces a dashboard with commentary |
+
+## Use Cases
+
+| | |
+|---|---|
+| **Department** | Finance |
+| **Autonomy level** | Collaborative |
+| **Building blocks** | Prompt, Context, Skill |
+| **Problem** | Monthly expense reporting requires manually downloading data from three systems, reformatting columns, reconciling categories, and producing summary charts — a full day of work that delays month-end close |
+| **Solution** | A skill that takes the three data exports as input, harmonizes column names and categories, flags discrepancies, and produces a summary report with breakdowns by department, category, and variance from budget |
+
+| | |
+|---|---|
+| **Department** | Marketing |
+| **Autonomy level** | Collaborative |
+| **Building blocks** | Prompt, Context, Agent |
+| **Problem** | Campaign performance data lives in five different platforms (Google Ads, Meta, LinkedIn, HubSpot, GA4), making cross-channel comparison a manual spreadsheet exercise that's always out of date |
+| **Solution** | An agent that ingests data exports from each platform, normalizes metrics (impressions, clicks, conversions, cost), and produces a unified performance view with channel comparison and recommendations for budget reallocation |
+
+| | |
+|---|---|
+| **Department** | HR |
+| **Autonomy level** | Collaborative |
+| **Building blocks** | Prompt, Context |
+| **Problem** | Leadership wants quarterly retention and compensation insights but the HR team spends weeks pulling data, anonymizing it, and creating visualizations — by the time it's ready, the data is already old |
+| **Solution** | Upload anonymized HR data and ask AI to analyze retention patterns by department, tenure, and compensation band. AI identifies at-risk segments, produces visualizations, and suggests areas for deeper investigation |
+
+## Common Mistakes
+
+**Uploading data without explaining what it is.** A CSV with columns "A, B, C, D" gives the AI nothing to work with. Provide column descriptions, units, time periods, and what questions you want answered. The better you describe your data, the better the analysis.
+
+**Expecting AI to validate its own analysis.** AI can identify patterns, but it can't tell you whether those patterns are meaningful in your business context. A correlation in the data might be a real signal or a coincidence — that judgment requires your domain expertise.
+
+**Skipping data cleaning.** AI can work with messy data, but inconsistent formats, missing values, and duplicate records will produce unreliable results. Ask AI to identify data quality issues first, fix them, then run the analysis.
+
+## Related
+
+- [AI Use Cases Overview](index.md) — all six primitives at a glance
+- [Context](../agentic-building-blocks/context/index.md) — providing datasets and domain knowledge
+- [Skills](../agentic-building-blocks/skills/index.md) — packaging analysis workflows for repeatable use
+- [Coding](coding.md) — when the goal is the analysis tool itself, not the insight
+- [Automation](automation.md) — running analysis workflows on a schedule

--- a/docs/use-cases/ideation-and-strategy.md
+++ b/docs/use-cases/ideation-and-strategy.md
@@ -1,0 +1,100 @@
+---
+title: Ideation & Strategy
+description: AI use cases for brainstorming, planning, providing feedback, and running scenario analysis
+---
+
+# Ideation & Strategy
+
+## What Ideation & Strategy Is
+
+Ideation and strategy use cases have AI serve as a thinking partner — brainstorming ideas, planning approaches, providing structured feedback, and running scenario analysis. This is the most collaborative primitive. Rather than producing a finished deliverable, the AI helps you think through problems, explore possibilities, and stress-test your plans.
+
+This primitive covers any workflow where the primary output is a set of ideas, a plan, a recommendation, or an evaluation: campaign brainstorming, product roadmap planning, risk analysis, decision frameworks, and structured feedback on drafts or proposals.
+
+Unlike the other primitives where AI executes work, ideation and strategy is about augmenting your thinking. The AI brings breadth (more options than you'd generate alone), structure (frameworks and evaluation criteria), and perspective (challenging assumptions you didn't realize you were making).
+
+*Ideation & Strategy is one of six use case primitives identified in OpenAI's [Identifying and Scaling AI Use Cases](https://cdn.openai.com/business-guides-and-resources/identifying-and-scaling-ai-use-cases.pdf) guide. The examples here are adapted to be platform-agnostic and mapped to [Agentic Building Blocks](../agentic-building-blocks/index.md).*
+
+## Key Characteristics
+
+- **Output is ideas, plans, or evaluations** — the deliverable is thinking, not execution
+- **Highly interactive** — the best results come from multi-turn conversations where you refine direction as ideas develop
+- **Benefits from constraints** — "brainstorm marketing ideas" produces generic results; "brainstorm marketing ideas for a B2B SaaS launch with a $5K budget targeting enterprise CFOs" produces actionable ones
+- **Persistent context is key** — the more the AI knows about your goals, constraints, past decisions, and domain, the more relevant its suggestions become
+- **Pairs with every other primitive** — ideation often precedes content creation, research, coding, or data analysis
+
+## When to Apply This Primitive
+
+**Use Ideation & Strategy when:**
+
+- You need to generate options, alternatives, or creative approaches
+- You want structured feedback on a plan, draft, or proposal
+- You're making a decision that requires weighing multiple factors
+- You need to explore scenarios (what if X happens? what are the risks of Y?)
+
+**NOT the right primitive when:**
+
+- You need to find facts or gather information (that's [Research](research.md))
+- The deliverable is a finished document for an audience (that's [Content Creation](content-creation.md))
+- You're analyzing numerical data to find patterns (that's [Data Analysis](data-analysis.md))
+
+## Department Examples
+
+| Department | Use Case | What AI Does | Typical Building Blocks |
+|-----------|----------|-------------|------------------------|
+| Marketing | Campaign ideation | Brainstorms campaign concepts within budget, audience, and brand constraints | Prompt, Context, Project |
+| Product | Feature prioritization | Evaluates proposed features against a scoring framework (impact, effort, alignment) | Prompt, Context, Project |
+| Sales | Objection handling | Generates responses to common objections, tailored to specific deal contexts | Prompt, Context, Skill |
+| Finance | Scenario modeling | Explores what-if scenarios for budget decisions, investments, or pricing changes | Prompt, Context, Project |
+| Engineering | Architecture reviews | Evaluates proposed system designs against quality attributes (scalability, security, maintainability) | Prompt, Context |
+| HR | Program design | Brainstorms engagement initiatives, training programs, or policy changes with trade-off analysis | Prompt, Context, Project |
+
+## Building Block Patterns
+
+| Complexity | Building Blocks | Example |
+|-----------|----------------|---------|
+| **Simple** | Prompt + Context | Share a project brief and ask AI to brainstorm 10 approaches with pros and cons for each |
+| **Intermediate** | Project + Context | A strategy project with company goals, competitive landscape, and past decisions as persistent context — every brainstorming session builds on shared knowledge |
+| **Advanced** | Project + Agent + Context | A strategy project with a feedback agent that evaluates proposals against a scoring rubric, challenges assumptions, and suggests improvements |
+
+## Use Cases
+
+| | |
+|---|---|
+| **Department** | Marketing |
+| **Autonomy level** | Collaborative |
+| **Building blocks** | Prompt, Context, Project |
+| **Problem** | Campaign brainstorming sessions produce safe, repetitive ideas because the team defaults to what worked before — there's no structured way to explore new directions while staying within brand and budget constraints |
+| **Solution** | A strategy project loaded with brand guidelines, past campaign performance data, and audience research. Team members brainstorm with AI that suggests unexpected angles, challenges assumptions, and evaluates ideas against the constraints — producing a wider range of options than group brainstorming alone |
+
+| | |
+|---|---|
+| **Department** | Product |
+| **Autonomy level** | Collaborative |
+| **Building blocks** | Prompt, Context, Project |
+| **Problem** | Feature prioritization decisions are driven by the loudest voice in the room rather than structured analysis — the team lacks a consistent framework for evaluating trade-offs |
+| **Solution** | A project workspace with the product roadmap, OKRs, user research, and a prioritization framework (RICE, value/effort, or custom). For each proposed feature, AI evaluates it against the framework, identifies risks, and compares it to alternatives — giving the team data-informed starting points for discussion |
+
+| | |
+|---|---|
+| **Department** | Finance |
+| **Autonomy level** | Collaborative |
+| **Building blocks** | Prompt, Context, Project |
+| **Problem** | Budget planning is a linear process — the team builds one plan and defends it, rather than exploring multiple scenarios and understanding the trade-offs between them |
+| **Solution** | A project with financial data, company goals, and market assumptions as context. AI generates multiple budget scenarios (aggressive growth, conservative, balanced), identifies the key trade-offs between them, and highlights the assumptions each scenario depends on |
+
+## Common Mistakes
+
+**Under-constraining the brainstorm.** "Give me ideas" produces generic output. The more specific your constraints — budget, timeline, audience, brand, past failures to avoid — the more creative and useful the AI's suggestions become. Constraints don't limit creativity; they focus it.
+
+**Treating AI suggestions as decisions.** AI is a brainstorming partner, not a decision-maker. It generates options and analysis, but the judgment about which option to pursue requires your understanding of politics, relationships, timing, and context that the AI doesn't have.
+
+**Forgetting to share context about past decisions.** AI will suggest things you've already tried and rejected if it doesn't know your history. Use project workspaces with persistent context so the AI builds on your past thinking rather than starting from scratch every time.
+
+## Related
+
+- [AI Use Cases Overview](index.md) — all six primitives at a glance
+- [Projects](../agentic-building-blocks/projects/index.md) — persistent workspaces for ongoing strategic work
+- [Context](../agentic-building-blocks/context/index.md) — providing goals, constraints, and history
+- [Prompts](../agentic-building-blocks/prompts/index.md) — crafting effective brainstorming and evaluation prompts
+- [Phase 1 — Discover](../business-first-ai-framework/discover.md) — using ideation to find AI opportunities

--- a/docs/use-cases/index.md
+++ b/docs/use-cases/index.md
@@ -1,0 +1,117 @@
+---
+title: AI Use Cases
+description: Six use case primitives that cover what teams actually build with AI — content creation, research, coding, data analysis, ideation and strategy, and automation
+---
+
+# AI Use Cases
+
+OpenAI's analysis of over 600 enterprise AI deployments found that nearly all use cases fall into six primitives. These primitives describe the **type of work** AI does, not the tools or platforms involved. Understanding them helps you classify your own workflows and find the right building blocks faster.
+
+*The six primitives and department examples in this section are adapted from OpenAI's [Identifying and Scaling AI Use Cases: How Early Adopters Focus Their AI Efforts](https://cdn.openai.com/business-guides-and-resources/identifying-and-scaling-ai-use-cases.pdf) and made platform-agnostic.*
+
+!!! tip "Connecting to the Framework"
+    The [Business-First AI Framework](../business-first-ai-framework/index.md) helps you **find** opportunities (Phase 1 — Discover) and **deconstruct** them into building blocks (Phase 2). Use these six primitives to **classify** the opportunities you find — they tell you what type of AI work each opportunity involves, which makes choosing the right building blocks easier.
+
+## The Six Primitives
+
+| Primitive | What AI Does | Typical Building Blocks | Example |
+|-----------|-------------|------------------------|---------|
+| [**Content Creation**](content-creation.md) | Drafts, edits, translates, repurposes | Prompt, Context, Skill, Project | First-draft blog posts in brand voice |
+| [**Research**](research.md) | Searches, synthesizes, structures information | Prompt, Context, Agent, MCP | Multi-source competitive analysis |
+| [**Coding**](coding.md) | Generates, debugs, ports, explains code | Prompt, Context, Agent | Python scripts for non-coders |
+| [**Data Analysis**](data-analysis.md) | Harmonizes data, identifies trends, visualizes | Prompt, Context, Skill | Expense analysis across sources |
+| [**Ideation & Strategy**](ideation-and-strategy.md) | Brainstorms, plans, gives feedback, models scenarios | Prompt, Context, Project | Campaign ideation with constraints |
+| [**Automation**](automation.md) | Executes repeatable routine tasks with minimal human involvement | Skill, Agent, MCP | Weekly competitive update pipeline |
+
+## Content Creation
+
+AI drafts, edits, translates, and repurposes content across formats. This is the most common entry point for teams adopting AI — nearly every department produces written content, and AI can handle first drafts, formatting, and adaptation between audiences.
+
+Content creation works best when you provide context (brand voice, style guides, examples) so the AI produces output that matches your standards rather than generic copy.
+
+[:octicons-arrow-right-24: Content Creation detail](content-creation.md)
+
+---
+
+## Research
+
+AI searches, synthesizes, and structures information from multiple sources. Research use cases replace the hours spent gathering, reading, and summarizing — the AI handles the collection while you focus on judgment and decision-making.
+
+Research primitives are particularly powerful when combined with MCP connections to external data sources, letting the AI pull from your actual tools rather than just web search.
+
+[:octicons-arrow-right-24: Research detail](research.md)
+
+---
+
+## Coding
+
+AI generates, debugs, ports, and explains code. This primitive isn't limited to software engineers — it extends to anyone who needs to create scripts, formulas, queries, or technical artifacts as part of their work.
+
+Coding use cases range from simple formula generation (Excel, SQL) to full application development with agents that plan, write, test, and iterate autonomously.
+
+[:octicons-arrow-right-24: Coding detail](coding.md)
+
+---
+
+## Data Analysis
+
+AI harmonizes data from multiple sources, identifies trends, and produces visualizations. Data analysis use cases turn raw information into structured insights — the AI handles cleaning, formatting, and pattern recognition while you direct the analysis.
+
+This primitive often pairs with coding (generating analysis scripts) and research (interpreting results in context).
+
+[:octicons-arrow-right-24: Data Analysis detail](data-analysis.md)
+
+---
+
+## Ideation & Strategy
+
+AI brainstorms ideas, plans approaches, provides feedback, and runs scenario analysis. This is the most collaborative primitive — AI serves as a thinking partner rather than an executor, helping you explore possibilities you wouldn't consider alone.
+
+Ideation works best in project workspaces where the AI has persistent context about your goals, constraints, and past decisions.
+
+[:octicons-arrow-right-24: Ideation & Strategy detail](ideation-and-strategy.md)
+
+---
+
+## Automation
+
+AI executes repeatable routine tasks with minimal human involvement. Automation is the highest-autonomy primitive — once configured, these workflows run on schedule or in response to triggers, producing consistent results without manual intervention.
+
+Automation typically builds on the other primitives. A content creation workflow becomes automation when it runs on a schedule. A research workflow becomes automation when it monitors sources continuously.
+
+[:octicons-arrow-right-24: Automation detail](automation.md)
+
+## Classifying Your Use Cases
+
+When a use case seems to span multiple primitives, identify the **primary output** to pick the right one:
+
+| If the main output is... | The primary primitive is... | Even though it also involves... |
+|--------------------------|----------------------------|-------------------------------|
+| A written document | Content Creation | Research to gather source material |
+| A structured summary of findings | Research | Content creation to format the report |
+| A working script or application | Coding | Research to find the right approach |
+| Charts, trends, or insights from data | Data Analysis | Coding to build the analysis |
+| A plan, list of options, or recommendation | Ideation & Strategy | Research to inform the strategy |
+| A pipeline that runs without you | Automation | Any of the above as individual steps |
+
+Most real workflows combine two or three primitives. The classification helps you find the right starting point and examples — not a rigid box.
+
+## Primitives vs. Building Blocks
+
+These are different lenses on the same work:
+
+| Concept | What it answers | Where to learn more |
+|---------|----------------|-------------------|
+| **Primitives** (this section) | **What** type of work is AI doing? | You're here |
+| **Building Blocks** | **How** do you implement it? | [Agentic Building Blocks](../agentic-building-blocks/index.md) |
+| **Autonomy Levels** | **How much** AI involvement? | [Business-First AI Framework](../business-first-ai-framework/index.md) |
+
+Primitives help you browse use cases by category. Building blocks help you assemble the implementation. Autonomy levels help you decide how much control to hand over. All three work together.
+
+## Related
+
+- [Business-First AI Framework](../business-first-ai-framework/index.md) — find and prioritize AI opportunities
+- [Phase 1 — Discover](../business-first-ai-framework/discover.md) — structured audit to surface workflow candidates
+- [Agentic Building Blocks](../agentic-building-blocks/index.md) — the six components for implementing AI workflows
+- [Phase 3 — Build](../business-first-ai-framework/build/index.md) — worked examples across the autonomy spectrum
+- [Plugin Marketplace](../plugins/index.md) — pre-built agents and skills you can install

--- a/docs/use-cases/research.md
+++ b/docs/use-cases/research.md
@@ -1,0 +1,100 @@
+---
+title: Research
+description: AI use cases for searching, synthesizing, and structuring information from multiple sources
+---
+
+# Research
+
+## What Research Is
+
+Research use cases have AI search, synthesize, and structure information from multiple sources. Instead of spending hours reading, comparing, and summarizing, you direct the AI on what to investigate and it handles the collection and organization — you focus on interpretation and decisions.
+
+This primitive covers any workflow where the primary output is structured knowledge: competitive analysis, market research, literature reviews, due diligence reports, vendor comparisons, and internal knowledge synthesis. The AI gathers information, identifies patterns, and presents findings in a format you specify.
+
+Research becomes particularly powerful when paired with MCP connections to your actual data sources — the AI can pull from your CRM, project management tools, internal wikis, and external databases rather than relying solely on web search or uploaded documents.
+
+*Research is one of six use case primitives identified in OpenAI's [Identifying and Scaling AI Use Cases](https://cdn.openai.com/business-guides-and-resources/identifying-and-scaling-ai-use-cases.pdf) guide. The examples here are adapted to be platform-agnostic and mapped to [Agentic Building Blocks](../agentic-building-blocks/index.md).*
+
+## Key Characteristics
+
+- **Output is structured knowledge** — findings, summaries, comparisons, or recommendations derived from multiple sources
+- **Source quality matters** — the value of research depends on what sources the AI can access and how well it evaluates them
+- **Synthesis is the differentiator** — the hard part isn't finding information, it's combining insights from multiple sources into something actionable
+- **Benefits from iteration** — initial research reveals new questions worth investigating, making multi-turn conversations more effective than single prompts
+- **Scales with tool access** — research that connects to live data sources (via MCP or agents) is vastly more useful than research limited to the model's training data
+
+## When to Apply This Primitive
+
+**Use Research when:**
+
+- You need to gather and compare information from multiple sources
+- The deliverable is a summary, analysis, or structured set of findings
+- You're making a decision that requires understanding a landscape (vendors, competitors, options)
+- You need to monitor ongoing changes in a domain (market shifts, regulatory updates, competitive moves)
+
+**NOT the right primitive when:**
+
+- The main output is a written piece for an audience (that's [Content Creation](content-creation.md))
+- You're exploring ideas and strategies rather than gathering facts (that's [Ideation & Strategy](ideation-and-strategy.md))
+- You're analyzing structured numerical data (that's [Data Analysis](data-analysis.md))
+
+## Department Examples
+
+| Department | Use Case | What AI Does | Typical Building Blocks |
+|-----------|----------|-------------|------------------------|
+| Marketing | Competitive analysis | Monitors competitor websites, press releases, and social media for positioning changes | Agent, MCP, Skill |
+| Product | User research synthesis | Aggregates feedback from support tickets, surveys, and reviews into themed summaries | Prompt, Context, Agent |
+| Sales | Account research | Compiles prospect background, recent news, financial data, and mutual connections before calls | Agent, MCP, Skill |
+| Legal | Regulatory monitoring | Tracks regulatory changes relevant to the business and flags items requiring review | Agent, MCP |
+| Finance | Market intelligence | Synthesizes analyst reports, earnings calls, and market data into briefings | Prompt, Context, Agent |
+| IT/Operations | Vendor evaluation | Compares vendor capabilities, pricing, and reviews against requirements | Prompt, Context, Project |
+
+## Building Block Patterns
+
+| Complexity | Building Blocks | Example |
+|-----------|----------------|---------|
+| **Simple** | Prompt + Context | Upload three analyst reports and ask AI to compare their conclusions on a specific topic |
+| **Intermediate** | Project + Agent | A research project where an agent searches the web, reads sources, and produces a structured brief |
+| **Advanced** | Agent + MCP + Skill | An agent that monitors competitor websites via MCP, synthesizes changes weekly, and produces a formatted intelligence report using a skill |
+
+## Use Cases
+
+| | |
+|---|---|
+| **Department** | Sales |
+| **Autonomy level** | Autonomous |
+| **Building blocks** | Agent, MCP, Skill |
+| **Problem** | Reps spend 30+ minutes researching each prospect before calls — manually checking LinkedIn, news, company website, and CRM history — and still miss relevant context |
+| **Solution** | An agent that takes a prospect name and company, searches multiple sources (LinkedIn, news, CRM via MCP), and produces a structured one-page brief with company overview, recent events, mutual connections, and suggested talking points |
+
+| | |
+|---|---|
+| **Department** | Marketing |
+| **Autonomy level** | Autonomous |
+| **Building blocks** | Agent, MCP, Skill |
+| **Problem** | Competitive intelligence is always stale — the team only updates competitive positioning quarterly, missing real-time changes in competitor messaging, pricing, and features |
+| **Solution** | A scheduled agent monitors competitor websites and social channels weekly via MCP, compares changes against the previous snapshot, and produces a delta report highlighting what changed and why it matters |
+
+| | |
+|---|---|
+| **Department** | Product |
+| **Autonomy level** | Collaborative |
+| **Building blocks** | Prompt, Context, Agent |
+| **Problem** | User feedback is scattered across support tickets, NPS surveys, app reviews, and Slack channels — synthesizing it into actionable themes takes days of manual review |
+| **Solution** | An agent ingests feedback from multiple sources, categorizes it by theme and sentiment, and produces a prioritized summary with representative quotes and frequency data for each theme |
+
+## Common Mistakes
+
+**Treating AI research as authoritative without verification.** AI can synthesize information effectively, but it can also miss nuance, misinterpret sources, or lack access to the most current data. Use AI research as a starting point for human analysis, not a replacement.
+
+**Asking for research without specifying the decision it supports.** "Research our competitors" produces generic results. "Compare our top three competitors' pricing models so we can decide whether to offer a free tier" produces actionable analysis. Frame research around the decision you need to make.
+
+**Ignoring source limitations.** AI can only research what it can access. If your research requires proprietary databases, paywalled content, or internal systems, you need MCP connections or uploaded documents — not just a prompt asking the AI to "look into it."
+
+## Related
+
+- [AI Use Cases Overview](index.md) — all six primitives at a glance
+- [Agents](../agentic-building-blocks/agents/index.md) — autonomous AI that can plan and execute multi-step research
+- [MCP](../agentic-building-blocks/mcp/index.md) — connecting AI to external data sources for live research
+- [Context](../agentic-building-blocks/context/index.md) — providing source documents and background knowledge
+- [Automation](automation.md) — running research workflows on a schedule

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,6 +165,14 @@ nav:
       - Overview: agentic-building-blocks/agents/index.md
       - Resources: agentic-building-blocks/agents/resources.md
     - MCP: agentic-building-blocks/mcp/index.md
+  - Use Cases:
+    - Overview: use-cases/index.md
+    - Content Creation: use-cases/content-creation.md
+    - Research: use-cases/research.md
+    - Coding: use-cases/coding.md
+    - Data Analysis: use-cases/data-analysis.md
+    - Ideation & Strategy: use-cases/ideation-and-strategy.md
+    - Automation: use-cases/automation.md
   - Platforms:
     - Overview: platforms/index.md
     - Claude:


### PR DESCRIPTION
## Summary

- Adds a new top-level **Use Cases** section organized around six AI use case primitives (from OpenAI's [Identifying and Scaling AI Use Cases](https://cdn.openai.com/business-guides-and-resources/identifying-and-scaling-ai-use-cases.pdf) guide): Content Creation, Research, Coding, Data Analysis, Ideation & Strategy, and Automation
- Creates 7 new pages: overview with summary table + classification guidance, and 6 detail pages with consistent template (definition, department examples, building block patterns, seed use cases, common mistakes)
- Adds cross-links from 20 existing pages across Building Blocks, Framework, Build examples, Plugins, and the homepage
- Nav placement: after Agentic Building Blocks, before Platforms — bridging "I know the pieces" → "I know what to build"

## Test plan

- [ ] Run `mkdocs build` — verify zero new warnings (git-revision-date warnings for new files are expected)
- [ ] Verify all 7 new pages render correctly in local preview
- [ ] Confirm nav ordering: Home → Framework → Building Blocks → **Use Cases** → Platforms → ...
- [ ] Spot-check cross-links from existing pages (building blocks, framework, build examples)
- [ ] Verify OpenAI attribution renders correctly on overview page and all six detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)