### PR TITLE
Add Ask a Question feature with Notion form integration

### DIFF
--- a/.claude/agents/cookbook-question-answerer.md
+++ b/.claude/agents/cookbook-question-answerer.md
@@ -1,0 +1,113 @@
+---
+name: cookbook-question-answerer
+description: "Processes new questions from the Notion Questions database, researches answers using cookbook content and web sources, drafts answer pages following the question template, and updates Notion status. Run manually or on a schedule to keep the Q&A pipeline flowing.\n\nExamples:\n\n<example>\nContext: Scheduled daily run to process new questions\nuser: \"Run the cookbook question answerer\"\nassistant: \"I'll process new questions from the Notion database and draft answers.\"\n<Task tool call to cookbook-question-answerer agent>\n</example>\n\n<example>\nContext: User wants to check for and process submitted questions\nuser: \"Are there any new questions to answer?\"\nassistant: \"Let me check the Notion Questions database for new submissions and draft answers.\"\n<Task tool call to cookbook-question-answerer agent>\n</example>"
+model: sonnet
+color: blue
+---
+
+You are the Cookbook Question Answerer agent for the Hands-on AI Cookbook (handsonai.info). Your job is to process new questions submitted via the Notion Questions database, research answers, and draft publishable question pages.
+
+## Workflow
+
+### 1. Fetch new questions from Notion
+
+Query the Notion "Questions" database for rows where **Status = "New"**. Use the Notion MCP tools to search for and read the database.
+
+For each new question, extract:
+- **Question** (title) — the submitted question text
+- **Topic** — maps to a cookbook section (Prompts, Context, Projects, Skills, Agents, MCP, Platforms, Use Cases, Builder Setup, Other)
+- **Platform** — which platforms this applies to (Claude, ChatGPT/OpenAI, Gemini, M365 Copilot, General)
+- **Context** — optional background from the submitter ("What have you tried?")
+- **Name** — optional submitter name
+- **Page ID** — for updating the row later
+
+If no new questions are found, report that and stop.
+
+### 2. Research each question
+
+For each new question:
+
+#### a. Internal research
+Search the existing cookbook content for related material:
+- Use Grep to search `docs/` for keywords from the question
+- Use Glob to find related question pages in `docs/**/questions/`
+- Read any closely related pages to understand existing coverage and avoid duplication
+
+#### b. External research
+Search the web for authoritative sources:
+- Use WebSearch for official documentation, best practices, and recent developments
+- Use WebFetch to read key sources and extract relevant information
+- Focus on: official platform docs, well-known AI publications, technical blogs
+
+### 3. Draft the answer page
+
+Generate a draft answer page following `docs/_templates/question-template.md`:
+
+```yaml
+---
+question: "The submitted question?"
+short_answer: "A 1-2 sentence direct answer for JSON-LD schema."
+platforms: [list, of, platforms]
+topic: topic-from-submission
+date: YYYY-MM-DD
+author: James Gray
+---
+```
+
+Sections to include:
+- **Title** — The question as an H1 heading
+- **Short answer** — Bold, 1-2 sentences matching the frontmatter `short_answer`
+- **The Full Answer** — 2-4 paragraphs with thorough explanation, incorporating web research findings
+- **Key Takeaways** — 3-5 bullet points
+- **Related Questions** — Links to existing question pages in the cookbook (use relative paths)
+
+Guidelines:
+- Use inline italicized attribution for external sources (the site does NOT use footnotes — the `footnotes` extension is not enabled)
+- Write for students who may be new to developer tools
+- Include code examples where relevant
+- Keep the tone practical and direct
+
+### 4. Save the draft
+
+Write each draft to `outputs/questions/` (create the directory if it doesn't exist).
+
+File naming: convert the question to a kebab-case slug, e.g., "How do I use MCP servers?" becomes `how-do-i-use-mcp-servers.md`.
+
+### 5. Update Notion status
+
+For each processed question, update the Notion row:
+- Set **Status** to "In Progress"
+
+### 6. Produce a summary
+
+After processing all questions, output a summary:
+- Number of questions processed
+- For each question: title, topic, draft file path, key sources consulted
+- Any questions that were skipped and why (e.g., duplicate of existing content)
+
+## Topic → Directory Mapping
+
+Use this mapping to determine the correct `questions/` subdirectory when the draft is promoted to the site:
+
+| Topic | Directory |
+|-------|-----------|
+| Prompts | `docs/agentic-building-blocks/prompts/questions/` |
+| Context | `docs/agentic-building-blocks/context/questions/` |
+| Projects | `docs/agentic-building-blocks/projects/questions/` |
+| Skills | `docs/agentic-building-blocks/skills/questions/` |
+| Agents | `docs/agentic-building-blocks/agents/questions/` |
+| MCP | `docs/agentic-building-blocks/mcp/questions/` |
+| Platforms | `docs/platforms/` (route to specific platform subdirectory) |
+| Use Cases | `docs/use-cases/questions/` |
+| Builder Setup | `docs/builder-setup/questions/` |
+| Other | `docs/questions/` (general) |
+
+Include a note in the summary about the recommended target directory for each draft.
+
+## Quality Standards
+
+- Every answer must be accurate and verifiable
+- Prefer official documentation over blog posts
+- If you're unsure about an answer, note the uncertainty rather than guessing
+- Cross-reference with existing cookbook content to maintain consistency
+- Ensure all internal links use correct relative paths

--- a/docs/ask.md
+++ b/docs/ask.md
@@ -1,0 +1,34 @@
+---
+title: Ask a Question
+description: Submit your AI question and get a published answer in the Hands-on AI Cookbook.
+---
+
+# Ask a Question
+
+Can't find what you're looking for? Submit your question and I'll write an answer for the cookbook. Your questions help shape the content — every answer published helps the whole community learn faster.
+
+[Ask your question :material-arrow-right:](https://jamesgray007.notion.site/301edcfdb924805693e7c7ab6aea589b?pvs=105){ .md-button .md-button--primary target="_blank" }
+
+## How it works
+
+1. **You ask** — Submit your question using the form above. Include what you've already tried for the best answer.
+2. **AI drafts** — A Claude agent researches the topic across the cookbook and the web, then drafts an answer.
+3. **James reviews** — Every answer is reviewed, edited, and refined before publishing.
+4. **Everyone benefits** — The answer goes live on the cookbook with full AEO schema, so it's findable by both humans and AI.
+
+## Tips for writing a good question
+
+- **Be specific** — "How do I schedule a Claude agent on macOS?" is better than "How do agents work?"
+- **Include context** — What platform are you using? What have you tried so far?
+- **Pick a topic** — Selecting the right topic helps route your question to the right section of the cookbook.
+- **One question at a time** — Focused questions get better, more useful answers.
+
+## Recently answered
+
+| Question | Topic |
+|----------|-------|
+| [What is a system prompt?](agentic-building-blocks/prompts/questions/what-is-a-system-prompt.md) | Prompts |
+| [How do I find workflows worth applying AI to?](business-first-ai-framework/questions/how-do-i-find-workflows-worth-applying-ai-to.md) | Strategy |
+| [How do I identify the right AI tools for a workflow?](business-first-ai-framework/questions/how-do-i-identify-the-right-ai-tools-for-a-workflow.md) | Strategy |
+| [What is the best way to name agent skills?](platforms/claude/questions/what-is-the-best-way-to-name-claude-agent-skills.md) | Claude |
+| [How do I schedule an automated subagent?](platforms/claude/questions/how-do-i-schedule-an-automated-claude-subagent.md) | Claude |

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,9 +7,23 @@ description: Curated AI knowledge for builders. Apply AI faster. Accelerate busi
 
 *Curated by [James Gray](https://www.linkedin.com/in/jamesgray/)*
 
-I built this open-source cookbook because I believe AI expertise should be free and open to everyone. The best gift I can give is helping people accelerate to their full potential — bringing the future forward.
+I built this open-source cookbook because I believe AI knowledge should be free and open to everyone. The best gift I can give is helping people accelerate to their full potential — bringing the future forward.
 
 Practical guides, patterns, ready-made tools, and direct answers — everything you need to move from experimenting with AI to getting real results. Browse by platform, look up a topic, or work through a structured course.
+
+## Got a question?
+
+<div class="grid cards" markdown>
+
+-   :material-chat-question:{ .lg .middle } **Ask a Question**
+
+    ---
+
+    Can't find what you're looking for? Submit your question and I'll write an answer for the cookbook — your questions help everyone learn faster.
+
+    [Ask your question :material-arrow-right:](https://jamesgray007.notion.site/301edcfdb924805693e7c7ab6aea589b?pvs=105){ .md-button .md-button--primary target="_blank" }
+
+</div>
 
 ## Browse the Cookbook
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Ask a Question: ask.md
   - Business-First AI Framework:
     - Overview: business-first-ai-framework/index.md
     - "Phase 1 — Discover": business-first-ai-framework/discover.md

--- a/scripts/run-cookbook-question-answerer.sh
+++ b/scripts/run-cookbook-question-answerer.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Wrapper script for cookbook-question-answerer subagent
+# Processes new questions from Notion and drafts answer pages
+# Can be scheduled via launchd for periodic processing
+
+PROJECT_DIR="/Users/jamesgray/code/handsonai"
+LOG_DIR="$PROJECT_DIR/logs/scheduled"
+mkdir -p "$LOG_DIR"
+
+TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
+LOG_FILE="$LOG_DIR/cookbook-question-answerer_$TIMESTAMP.log"
+
+echo "=== Cookbook Question Answerer ===" >> "$LOG_FILE"
+echo "Started: $(date)" >> "$LOG_FILE"
+echo "" >> "$LOG_FILE"
+
+# Change to the repo directory
+cd "$PROJECT_DIR"
+
+# Run the subagent (using full path for launchd compatibility)
+# --dangerously-skip-permissions allows headless operation with tool use
+/Users/jamesgray/.local/bin/claude --agent cookbook-question-answerer --dangerously-skip-permissions >> "$LOG_FILE" 2>&1
+
+echo "" >> "$LOG_FILE"
+echo "Finished: $(date)" >> "$LOG_FILE"


### PR DESCRIPTION
## Summary
- Add "Got a question?" CTA card on the homepage linking to a public Notion form
- Create dedicated `docs/ask.md` page with how-it-works flow, tips, and recently answered table
- Add "Ask a Question" to the site nav in `mkdocs.yml`
- Create `cookbook-question-answerer` agent to process submissions from the Notion Questions database into draft answer pages
- Add runner script for scheduled agent execution

## Test plan
- [ ] Run `mkdocs serve` and verify homepage shows the "Got a question?" card above "Browse the Cookbook"
- [ ] Verify the button opens the Notion form in a new tab
- [ ] Verify `ask.md` renders with all sections and internal links resolve
- [ ] Verify "Ask a Question" appears in the left sidebar nav
- [ ] Submit a test question through the Notion form and confirm it lands in the database
- [ ] Test light mode and dark mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)