### PR TITLE
Consolidate agent outputs and migrate research-daily to handsonai

### DIFF
--- a/.claude/agents/ai-news-researcher.md
+++ b/.claude/agents/ai-news-researcher.md
@@ -103,7 +103,7 @@ Structure your findings as follows:
 
 After completing your research, you MUST save your findings to a markdown file:
 
-1. **File Location**: Save to `./ai-news-reports/` directory (create it if it doesn't exist)
+1. **File Location**: Save to `./outputs/ai-news-reports/` directory (create it if it doesn't exist)
 2. **File Naming**: Use the format `ai-news-YYYY-MM-DD.md` (e.g., `ai-news-2026-01-26.md`)
 3. **Process**:
    - First, compile all your findings using the Output Format below

--- a/scripts/run-claude-research-daily.sh
+++ b/scripts/run-claude-research-daily.sh
@@ -3,7 +3,7 @@
 # Runs the subagent and logs output for troubleshooting
 
 # Store logs in the project folder for easy access
-PROJECT_DIR="/Users/jamesgray/code/course-resources"
+PROJECT_DIR="/Users/jamesgray/code/handsonai"
 LOG_DIR="$PROJECT_DIR/logs/scheduled"
 mkdir -p "$LOG_DIR"
 


### PR DESCRIPTION
## Summary
- Move ai-news-researcher output directory from `./ai-news-reports/` to `./outputs/ai-news-reports/` for consistency with other agents
- Update research-daily runner script to use handsonai repo instead of deprecated course-resources repo

## Test plan
- [ ] Verify ai-news-researcher agent writes to `outputs/ai-news-reports/` when run manually
- [ ] Verify research-daily runner script logs to `logs/scheduled/` in the handsonai repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)