### PR TITLE
Rename AI Assets to AI Building Blocks in docs and skills

### DIFF
--- a/docs/builder-setup/notion-registry-setup.md
+++ b/docs/builder-setup/notion-registry-setup.md
@@ -1,6 +1,6 @@
 ---
 title: AI Registry Setup in Notion
-description: Set up the Notion AI Registry template to track business processes, workflows, and AI assets
+description: Set up the Notion AI Registry template to track business processes, workflows, and AI building blocks
 schema_type: HowTo
 howto_steps:
   - name: Get Notion
@@ -10,7 +10,7 @@ howto_steps:
   - name: Duplicate the template
     text: Click the Duplicate button in the top-right corner to copy the template to your workspace.
   - name: Review sample entries
-    text: Explore the four databases (Business Processes, Workflows, AI Assets, Apps) to understand the structure.
+    text: Explore the four databases (Business Processes, Workflows, AI Building Blocks, Apps) to understand the structure.
   - name: Customize databases
     text: Edit select fields in each database to match your business areas, workflow categories, and asset types.
   - name: Connect your AI tools
@@ -19,7 +19,7 @@ howto_steps:
 
 # AI Registry Setup
 
-The AI Registry is a Notion workspace template that gives you a structured system for tracking your business processes, workflows, AI assets, and connected applications. It serves as the central hub for your AI operations — a single place to document what you're building, how it works, and what tools are involved.
+The AI Registry is a Notion workspace template that gives you a structured system for tracking your business processes, workflows, AI building blocks, and connected applications. It serves as the central hub for your AI operations — a single place to document what you're building, how it works, and what tools are involved.
 
 This registry is also the foundation for the [AI Registry plugin](../plugins/index.md#ai-registry), a set of Claude Code skills that can read from and write to your registry automatically. Once your registry is set up and connected, Claude can name workflows, write SOPs, register skills, and keep everything in sync — anywhere on the Claude platform.
 
@@ -62,7 +62,7 @@ Select the workspace you want to copy the template into. The entire page — inc
 The template includes sample entries in each database so you can see how they work together. Explore a few entries to understand the structure:
 
 - Click into a **Business Process** to see its linked workflows
-- Click into a **Workflow** to see its linked AI assets and apps
+- Click into a **Workflow** to see its linked AI building blocks and apps
 - Notice how relations connect everything together
 
 When you're ready, delete the sample entries and start adding your own.
@@ -73,7 +73,7 @@ Tailor the registry to your business. Each database comes with sensible defaults
 
 - **Business Processes** — Edit the **Domain** select field to match your business areas (Sales, Marketing, Product, Operations, etc.)
 - **Workflows** — Update **Status** and **Type** options to fit your workflow categories
-- **AI Assets** — Customize **Asset Type** options (Skill, Prompt, Agent, Project, Context MD, etc.)
+- **AI Building Blocks** — Customize **Asset Type** options (Skill, Prompt, Agent, Project, Context MD, etc.)
 - **Apps** — Configure **Type** options for your integration patterns (API, MCP Server, Native Integration, Webhook, etc.)
 
 To edit a select field: click any cell with that property, then click **"Edit property"** to add, rename, or remove options.
@@ -100,7 +100,7 @@ Once connected, your AI tool can search, read, and update your registry database
 |----------|---------|------------|
 | **Business Processes** | High-level business functions and their domains | Domain, LOB, Description |
 | **Workflows** | Specific workflows within each process | Status, Type, Trigger, Process Outcome |
-| **AI Assets** | Skills, prompts, agents, and other AI components | Asset Type, Platform, Status, Dependencies |
+| **AI Building Blocks** | Skills, prompts, agents, and other AI components | Asset Type, Platform, Status, Dependencies |
 | **Apps** | Connected applications and integrations | Type, Auth Type, Connection Status |
 
 ### How Relations Work
@@ -108,12 +108,12 @@ Once connected, your AI tool can search, read, and update your registry database
 The databases are linked to show how your operations connect:
 
 ```
-Business Process → Workflows → AI Assets
+Business Process → Workflows → AI Building Blocks
                             ↘ Apps
 ```
 
 - Each **Business Process** contains multiple **Workflows**
-- Each **Workflow** can use multiple **AI Assets** and **Apps**
+- Each **Workflow** can use multiple **AI Building Blocks** and **Apps**
 - Changes propagate automatically through relations
 
 ## Using the AI Registry Plugin
@@ -131,7 +131,7 @@ The plugin includes five skills that automate common registry tasks:
 | `naming-workflows` | Generates consistent, outcome-focused workflow names and creates entries in the Workflows database |
 | `writing-workflow-sops` | Writes Standard Operating Procedure documentation for each workflow |
 | `writing-process-guides` | Documents how workflows fit together within a business process |
-| `registering-building-blocks` | Registers AI building blocks (Skills, Agents, Prompts, Context MDs) in the AI Assets database |
+| `registering-building-blocks` | Registers AI building blocks (Skills, Agents, Prompts, Context MDs) in the AI Building Blocks database |
 | `syncing-skills-to-github` | Commits skills to GitHub and updates Notion with repository URLs |
 
 ### Recommended workflow
@@ -139,7 +139,7 @@ The plugin includes five skills that automate common registry tasks:
 1. **Name** — Ask Claude to name a workflow and it creates a Notion entry
 2. **Document** — Ask Claude to write the SOP for that workflow
 3. **Connect** — Ask Claude to write a process guide linking workflows together
-4. **Register** — Ask Claude to register any skills you've built in the AI Assets database
+4. **Register** — Ask Claude to register any skills you've built in the AI Building Blocks database
 5. **Sync** — Ask Claude to push skills to GitHub with version tracking
 
 See the [AI Registry plugin page](../plugins/index.md#ai-registry) for full details and usage examples.

--- a/docs/plugins/ai-registry.md
+++ b/docs/plugins/ai-registry.md
@@ -159,16 +159,16 @@ Names are always 2-4 words, noun phrases (not verb phrases), in Title Case.
 !!! info "Migration note"
     This skill replaces `registering-skills` (v2.0.0). It handles all AI building block types — Skills, Agents, Prompts, and Context MDs — using the same registration workflow. If you previously used `registering-skills`, update your plugin to v3.0.0.
 
-**What it does:** Registers or updates any AI building block — Skills, Agents, Prompts, or Context MDs — in your Notion AI Assets database. Automatically resolves the asset type from your request, extracts metadata from the appropriate source file, generates a Quick Start Prompt, checks for duplicates, and creates or updates the registry entry.
+**What it does:** Registers or updates any AI building block — Skills, Agents, Prompts, or Context MDs — in your Notion AI Building Blocks database. Automatically resolves the asset type from your request, extracts metadata from the appropriate source file, generates a Quick Start Prompt, checks for duplicates, and creates or updates the registry entry.
 
-**When to use it:** Use this immediately after creating, packaging, or updating any Claude building block to keep your AI Assets database current. Also useful for batch-registering multiple building blocks at once (which can mix asset types).
+**When to use it:** Use this immediately after creating, packaging, or updating any Claude building block to keep your AI Building Blocks database current. Also useful for batch-registering multiple building blocks at once (which can mix asset types).
 
 **How it works:**
 
 1. Claude resolves the asset type from your request (keywords, file paths, or asks if ambiguous)
 2. Claude reads metadata from the appropriate source — `SKILL.md` frontmatter for skills, agent `.md` files for agents, or user input for prompts and context MDs
 3. Claude generates a Quick Start Prompt — a single, copy-paste-ready sentence that demonstrates the building block's primary use case (Context MDs typically skip this)
-4. Claude searches your Notion AI Assets database for an existing entry with the exact same name (to prevent duplicates)
+4. Claude searches your Notion AI Building Blocks database for an existing entry with the exact same name (to prevent duplicates)
 5. If found: updates the existing entry with the latest description and Quick Start Prompt
 6. If not found: creates a new entry with name, description, asset type, platform (Claude), and Quick Start Prompt
 
@@ -178,7 +178,7 @@ For batch registration, Claude searches for each building block individually fir
 
     "Register the email-response-drafting skill in Notion"
     → Reads the SKILL.md, generates a Quick Start Prompt, checks for
-      duplicates, and creates or updates the AI Assets entry
+      duplicates, and creates or updates the AI Building Blocks entry
 
     "Register the cookbook-question-answerer agent in Notion"
     → Reads the agent .md file, generates a Quick Start Prompt, and
@@ -188,7 +188,7 @@ For batch registration, Claude searches for each building block individually fir
     → Batch processes every building block, reporting X created and
       Y updated (broken down by asset type)
 
-**What you'll get:** An entry (or updated entry) in your Notion AI Assets database with: name, description, asset type (Skill, Agent, Prompt, or Context MD), platform, Quick Start Prompt, and GitHub URL (if applicable).
+**What you'll get:** An entry (or updated entry) in your Notion AI Building Blocks database with: name, description, asset type (Skill, Agent, Prompt, or Context MD), platform, Quick Start Prompt, and GitHub URL (if applicable).
 
 **Platform compatibility:** Claude Code &#10003; | Claude.ai &#10003; (Notion MCP required)
 
@@ -196,7 +196,7 @@ For batch registration, Claude searches for each building block individually fir
 
 #### `syncing-skills-to-github`
 
-**What it does:** Syncs Claude Skills from your local `~/.claude/skills/` directory to a GitHub repository. Detects changes, generates semantic commit messages, pushes to remote, and updates Notion AI Assets with GitHub URLs.
+**What it does:** Syncs Claude Skills from your local `~/.claude/skills/` directory to a GitHub repository. Detects changes, generates semantic commit messages, pushes to remote, and updates Notion AI Building Blocks with GitHub URLs.
 
 **When to use it:** Use this after creating or updating skills locally, after exporting skills from cloud to local, or as part of a weekly batch sync. This is Part 2 of the export-to-sync workflow (Part 1 is exporting skills from the cloud to your local machine).
 
@@ -208,7 +208,7 @@ For batch registration, Claude searches for each building block individually fir
 4. **Generate** semantic commit messages with prefixes: `[CREATE]`, `[UPDATE]`, `[FIX]`, `[SYNC]`, `[RETIRE]`
 5. **Commit** changes to the local git repository
 6. **Push** to GitHub remote
-7. **Update** Notion AI Assets database with GitHub URLs and set status to "Deployed"
+7. **Update** Notion AI Building Blocks database with GitHub URLs and set status to "Deployed"
 8. **Regenerate** the README.md skill index
 
 **Three usage modes:**
@@ -228,7 +228,7 @@ For batch registration, Claude searches for each building block individually fir
     → Previews the changes and generated commit message, asks for
       confirmation before proceeding
 
-**What you'll get:** Skills committed and pushed to GitHub with descriptive commit messages, Notion AI Assets entries updated with GitHub URLs, and an auto-generated README index.
+**What you'll get:** Skills committed and pushed to GitHub with descriptive commit messages, Notion AI Building Blocks entries updated with GitHub URLs, and an auto-generated README index.
 
 **Platform compatibility:** Claude Code &#10003; (requires terminal access and git credentials)
 
@@ -241,7 +241,7 @@ These skills work best in sequence, building from naming through to version cont
 1. **Name your workflow** — Use `naming-workflows` to create a consistent entry in Notion
 2. **Document the procedure** — Use `writing-workflow-sops` to write the SOP for the workflow
 3. **Connect workflows** — Use `writing-process-guides` to document how workflows fit together in a business process
-4. **Register your building blocks** — Use `registering-building-blocks` to track Skills, Agents, Prompts, and Context MDs in the AI Assets database
+4. **Register your building blocks** — Use `registering-building-blocks` to track Skills, Agents, Prompts, and Context MDs in the AI Building Blocks database
 5. **Version control everything** — Use `syncing-skills-to-github` to push skills to GitHub with Notion tracking
 
 ## FAQ

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -121,15 +121,15 @@ Document, name, register, and sync AI operational workflows and skills.
     | [`naming-workflows`](ai-registry.md#naming-workflows) | Generates consistent, outcome-focused names and descriptions for business workflows. Follows domain-specific naming patterns (Sales, Marketing, Product, etc.) and creates entries in the Notion Workflows database. |
     | [`writing-workflow-sops`](ai-registry.md#writing-workflow-sops) | Writes Standard Operating Procedure documentation for workflows. Adapts SOP templates for Manual, Augmented, and Automated workflow types. Saves SOPs to Notion workflow page bodies. |
     | [`writing-process-guides`](ai-registry.md#writing-process-guides) | Writes Business Process Guide documentation explaining when, why, and how to execute a complete business process with its component workflows. Covers strategic context while linking to individual SOPs for tactical details. |
-    | [`registering-building-blocks`](ai-registry.md#registering-building-blocks) | Registers or updates AI building blocks (Skills, Agents, Prompts, Context MDs) in the Notion AI Assets database. Resolves asset type automatically, extracts metadata, generates Quick Start Prompts, and handles duplicate detection. |
-    | [`syncing-skills-to-github`](ai-registry.md#syncing-skills-to-github) | Syncs skills from `~/.claude/skills/` to a GitHub repository. Detects changes, generates semantic commit messages, pushes to remote, and updates Notion AI Assets with GitHub URLs. |
+    | [`registering-building-blocks`](ai-registry.md#registering-building-blocks) | Registers or updates AI building blocks (Skills, Agents, Prompts, Context MDs) in the Notion AI Building Blocks database. Resolves asset type automatically, extracts metadata, generates Quick Start Prompts, and handles duplicate detection. |
+    | [`syncing-skills-to-github`](ai-registry.md#syncing-skills-to-github) | Syncs skills from `~/.claude/skills/` to a GitHub repository. Detects changes, generates semantic commit messages, pushes to remote, and updates Notion AI Building Blocks with GitHub URLs. |
 
 ??? workflow "Recommended workflow"
 
     1. **Name** — Use `naming-workflows` to create a consistent workflow entry in Notion
     2. **Document** — Use `writing-workflow-sops` to write the SOP for each workflow
     3. **Connect** — Use `writing-process-guides` to document how workflows fit together in a business process
-    4. **Register** — Use `registering-building-blocks` to track building blocks in Notion AI Assets
+    4. **Register** — Use `registering-building-blocks` to track building blocks in Notion AI Building Blocks
     5. **Sync** — Use `syncing-skills-to-github` to version-control everything in GitHub
 
     ```
@@ -143,7 +143,7 @@ Document, name, register, and sync AI operational workflows and skills.
     → writing-process-guides documents the end-to-end process
 
     "Register the email-response-drafting skill in Notion"
-    → registering-building-blocks adds it to the AI Assets database
+    → registering-building-blocks adds it to the AI Building Blocks database
 
     "Sync all changed skills to GitHub"
     → syncing-skills-to-github commits and pushes with Notion tracking

--- a/plugins/ai-registry/skills/registering-building-blocks/SKILL.md
+++ b/plugins/ai-registry/skills/registering-building-blocks/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: registering-building-blocks
-description: Register or update AI building blocks (Skills, Agents, Prompts, Context MDs) in the Notion AI Assets database. Use this skill immediately after creating, packaging, or updating any Claude building block to add or update it in the AI Assets tracking database. Triggers after skill creation, agent creation, prompt authoring, context MD updates, or when user asks to register/add/track a building block in Notion.
+description: Register or update AI building blocks (Skills, Agents, Prompts, Context MDs) in the Notion AI Building Blocks database. Use this skill immediately after creating, packaging, or updating any Claude building block to add or update it in the AI Building Blocks tracking database. Triggers after skill creation, agent creation, prompt authoring, context MD updates, or when user asks to register/add/track a building block in Notion.
 ---
 
 # Registering AI Building Blocks
 
-After creating, packaging, or updating any AI building block — Skill, Agent, Prompt, or Context MD — register or update it in the AI Assets database.
+After creating, packaging, or updating any AI building block — Skill, Agent, Prompt, or Context MD — register or update it in the AI Building Blocks database.
 
 ## Asset Type Resolution
 

--- a/plugins/ai-registry/skills/syncing-skills-to-github/SKILL.md
+++ b/plugins/ai-registry/skills/syncing-skills-to-github/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: syncing-skills-to-github
-description: Sync Claude Agent Skills from ~/.claude/skills/ (local) to GitHub repository using git commands. Skills are stored in a flat directory structure. Commits changes, pushes to remote, and updates Notion AI Assets with GitHub URLs. Designed for Claude Code with access to terminal and git credentials.
+description: Sync Claude Agent Skills from ~/.claude/skills/ (local) to GitHub repository using git commands. Skills are stored in a flat directory structure. Commits changes, pushes to remote, and updates Notion AI Building Blocks with GitHub URLs. Designed for Claude Code with access to terminal and git credentials.
 ---
 
 # Syncing Skills to GitHub
@@ -24,7 +24,7 @@ Trigger this skill after:
 4. **Generate** semantic commit messages based on changes
 5. **Commit** to local git repository
 6. **Push** to GitHub remote
-7. **Update** Notion AI Assets database with GitHub URLs
+7. **Update** Notion AI Building Blocks database with GitHub URLs
 8. **Report** summary of sync operation
 
 ## Prerequisites
@@ -36,7 +36,7 @@ Trigger this skill after:
 - Remote: `git@github.com:jamesgray007/agent-skills.git` or `https://github.com/jamesgray007/agent-skills.git`
 
 ### Notion
-- AI Assets database ID: `2d5edcfd-b924-80cf-a0a0-000ba0164e40`
+- AI Building Blocks database ID: `2d5edcfd-b924-80cf-a0a0-000ba0164e40`
 - Notion API access configured
 
 ### Directory Structure
@@ -186,7 +186,7 @@ git push origin main
 # git push --force origin main
 ```
 
-### Step 7: Update Notion AI Assets
+### Step 7: Update Notion AI Building Blocks
 
 For each skill that was synced, update the GitHub URL in Notion.
 
@@ -194,7 +194,7 @@ For each skill that was synced, update the GitHub URL in Notion.
 
 For each changed skill directory (e.g., "exporting-skills-from-claude"):
 
-1. **Search for the skill in Notion AI Assets:**
+1. **Search for the skill in Notion AI Building Blocks:**
    - Use tool: `Notion:notion-search`
    - Parameters:
      - `query`: The skill directory name (e.g., "exporting-skills-from-claude")
@@ -225,7 +225,7 @@ For each changed skill directory (e.g., "exporting-skills-from-claude"):
      ```
 
 5. **Handle errors:**
-   - If skill not found in search: Log warning "⚠️ {skill-name} not found in AI Assets"
+   - If skill not found in search: Log warning "⚠️ {skill-name} not found in AI Building Blocks"
    - If update fails: Log error with details
    - Continue with next skill regardless
 
@@ -302,7 +302,7 @@ Generating commit message...
 📝 Commit: abc123f
 🔗 https://github.com/jamesgray007/agent-skills/tree/main/writing-linkedin-posts
 
-[Updating Notion AI Assets...]
+[Updating Notion AI Building Blocks...]
 ✅ Updated GitHub URL in Notion
 
 Complete!
@@ -349,7 +349,7 @@ Generating commit message...
 📝 Commit: def456g
 🔗 https://github.com/jamesgray007/agent-skills
 
-[Updating Notion AI Assets for 3 skills...]
+[Updating Notion AI Building Blocks for 3 skills...]
 ✅ Updated exporting-skills-from-claude
 ✅ Updated writing-linkedin-posts
 ✅ Updated creating-video-content
@@ -458,7 +458,7 @@ Would you like me to show the conflicts?
 
 Skills synced to GitHub: 3
 Notion updates failed: 1
-- exporting-skills-from-claude (not found in AI Assets)
+- exporting-skills-from-claude (not found in AI Building Blocks)
 
 GitHub URL: https://github.com/jamesgray007/agent-skills
 
@@ -523,10 +523,10 @@ Local (~/.claude/skills/)
     ↓ [Sync] ← This skill
 GitHub (github.com/jamesgray007/agent-skills)
     ↓ [Update URLs]
-Notion (AI Assets database)
+Notion (AI Building Blocks database)
 ```
 
-### With Notion AI Assets
+### With Notion AI Building Blocks
 After successful GitHub sync:
 - Updates GitHub property with URL
 - Sets Status to "Deployed"
@@ -568,7 +568,7 @@ User: Create a skill for aggregating HubSpot metrics for weekly reviews
 
 Claude: [Creates skill in Claude.ai]
 [Skill saved to /mnt/skills/user/hubspot-metrics-aggregation/]
-[Registered in Notion AI Assets]
+[Registered in Notion AI Building Blocks]
 ```
 
 **End of Day (Claude Desktop):**
@@ -670,7 +670,7 @@ Claude: [Detects changes in importing-maven-students]
 - Claude Code (terminal access with git credentials)
 - Git installed and configured
 - GitHub repository: `jamesgray007/agent-skills`
-- Notion API access for AI Assets database
+- Notion API access for AI Building Blocks database
 - Bash shell for git commands
 
 ## Notes

--- a/plugins/ai-registry/skills/syncing-skills-to-github/references/QUICK-REFERENCE.md
+++ b/plugins/ai-registry/skills/syncing-skills-to-github/references/QUICK-REFERENCE.md
@@ -31,7 +31,7 @@
 5. **README**: Auto-generated skill index
 6. **Commit**: Detailed commit message created
 7. **Push**: Changes pushed to GitHub
-8. **Notion**: GitHub URLs updated in AI Assets
+8. **Notion**: GitHub URLs updated in AI Building Blocks
 
 ## Repository Information
 
@@ -72,7 +72,7 @@ Skills updated:
 ## Notion Integration
 
 After each sync:
-- **Search**: AI Assets database for each synced skill
+- **Search**: AI Building Blocks database for each synced skill
 - **Update**: GitHub property with skill URL
 - **Format**: `https://github.com/jamesgray007/agent-skills/tree/main/skills/[skill-name]`
 - **Not Found**: Offer to register skill first
@@ -151,7 +151,7 @@ agent-skills/
 ✅ README.md generated  
 ✅ Commit created with message  
 ✅ Push to GitHub successful  
-✅ Notion AI Assets updated  
+✅ Notion AI Building Blocks updated  
 
 ## Integration Points
 
@@ -176,7 +176,7 @@ agent-skills/
 1. Create or update skill in Claude
 2. Say: "Sync to GitHub"
 3. Verify success message
-4. Check Notion AI Assets for GitHub URL
+4. Check Notion AI Building Blocks for GitHub URL
 5. (Optional) Pull to desktop clone
 
 ## Best Practices


### PR DESCRIPTION
## Summary

- Rename all references to the Notion "AI Assets" database to "AI Building Blocks" across docs and plugin skill files
- Aligns documentation with the renamed Notion database and the site's building blocks terminology
- No functional changes — only user-facing text updated

## Test plan

- [ ] Grep codebase for "AI Assets" — only generic references in `courses/`, `github-setup.md`, and auto-generated `llms-full.txt` should remain
- [ ] Run `mkdocs serve` and verify docs render correctly
- [ ] Confirm `registering-building-blocks` and `syncing-skills-to-github` skill descriptions reference "AI Building Blocks"

🤖 Generated with [Claude Code](https://claude.com/claude-code)