### PR TITLE
Add Graymatter newsletter plug to homepage intro

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,8 @@ I built this open-source cookbook because I believe AI knowledge should be free 
 
 Practical guides, patterns, ready-made tools, and direct answers — everything you need to move from experimenting with AI to getting real results. Browse by platform, look up a topic, or work through a structured course.
 
+Master AI. Master yourself. Build what matters. That's what [Graymatter](https://graymatter.jamesgray.ai) is about — a free weekly newsletter with how-to videos, hands-on walkthroughs, and lessons from building in the open.
+
 ## Browse the Cookbook
 
 <div class="grid cards" markdown>


### PR DESCRIPTION
## Summary
- Adds a Graymatter newsletter plug as a standalone paragraph between the intro text and "Browse the Cookbook" grid
- Uses the Graymatter tagline ("Master AI. Master yourself. Build what matters.") with a brief description of the newsletter

## Test plan
- [ ] Verify the paragraph renders correctly on `mkdocs serve`
- [ ] Confirm the Graymatter link resolves to https://graymatter.jamesgray.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)