### PR TITLE
Add Builder Stack Setup Guide with checklist overview

### DIFF
--- a/docs/builder-setup/claude-code-install.md
+++ b/docs/builder-setup/claude-code-install.md
@@ -1,6 +1,6 @@
 ---
-title: Claude Code Installation Guide
-description: Install Claude Code extension and CLI on macOS, Linux, or Windows with step-by-step instructions
+title: AI Coding CLI Installation Guide
+description: Install Claude Code and other AI coding CLIs (OpenAI Codex, Gemini CLI) on macOS, Linux, or Windows
 schema_type: HowTo
 howto_steps:
   - name: Install the Claude Code extension
@@ -15,11 +15,11 @@ howto_steps:
     text: Run 'claude --version' to confirm the CLI is working, then start an interactive session.
 ---
 
-# Claude Code Setup Guide
+# AI Coding CLI Setup Guide
 
 Quick reference for setting up Claude Code in your editor and terminal.
 
-**Official docs:** [claude.ai/code/docs/quickstart](https://code.claude.com/docs/en/quickstart)
+**Official docs:** [code.claude.com/docs/en/quickstart](https://code.claude.com/docs/en/quickstart)
 
 ## Prerequisites
 
@@ -28,6 +28,9 @@ Quick reference for setting up Claude Code in your editor and terminal.
 - Claude Pro, Max, or Team subscription
 
 ## Part 1: Install the Claude Code Extension
+
+!!! tip "Already done?"
+    If you installed the Claude Code extension during Step 2 (Editor Setup), skip to Part 2.
 
 The Claude Code extension works the same in both Cursor and VS Code.
 
@@ -66,7 +69,9 @@ curl -fsSL https://claude.ai/install.cmd -o install.cmd && install.cmd && del in
 
 ## Set Up Your PATH
 
-After installation, you may need to configure your PATH so the `claude` command works from any directory.
+Your PATH is a list of folders your computer checks when you type a command. If Claude Code's folder isn't in that list, your terminal won't recognize the `claude` command.
+
+After installation, you may need to configure your PATH so `claude` works from any directory.
 
 ### macOS / Linux
 
@@ -106,10 +111,12 @@ To add it manually:
 4. Click New and add %USERPROFILE%\.local\bin
 5. Restart your terminal
 
-Other things to note on Windows:
-You need https://git-scm.com/downloads/win installed (provides Git Bash, which Claude Code requires).
-If Git Bash isn't detected, you may also need to set:
-$env:CLAUDE_CODE_GIT_BASH_PATH="C:\Program Files\Git\bin\bash.exe"
+!!! note "Windows users"
+    You need [Git for Windows](https://git-scm.com/downloads/win) installed — it provides Git Bash, which Claude Code requires. If Git Bash isn't detected, open PowerShell and run:
+
+    ```powershell
+    $env:CLAUDE_CODE_GIT_BASH_PATH="C:\Program Files\Git\bin\bash.exe"
+    ```
 
 ## Log In
 
@@ -131,10 +138,10 @@ Test that everything is working:
 claude --version
 ```
 
-Then start an interactive session:
+Then start a conversation with Claude:
 
 ```bash
-cd /path/to/your/project
+cd ~/Desktop/my-project  # replace with your actual project folder
 claude
 ```
 
@@ -182,11 +189,62 @@ Ask Claude a question to confirm it's working:
 
 ## Next Steps
 
-- Review the course slide deck for detailed walkthrough
-- Try the common workflows in the official docs
-- Post in Slack if you encounter issues
+- Explore the [Claude Code documentation](https://code.claude.com/docs/en/quickstart) for more workflows
+- Try asking Claude to explain a project, commit changes, or write tests
 
 ## Resources
 
 - [Claude Code Quickstart](https://code.claude.com/docs/en/quickstart)
 - [Claude Code CLI Reference](https://code.claude.com/docs/en/cli-reference)
+
+---
+
+## Other AI Coding CLIs
+
+Claude Code is the primary CLI covered in this cookbook, but you may also want to install these alternatives.
+
+### OpenAI Codex CLI
+
+OpenAI's command-line coding agent.
+
+**Prerequisites:** Requires [Node.js](https://nodejs.org/) 22+ (which includes npm, the package manager used to install it) and an OpenAI API key.
+
+**Install (macOS / Linux):**
+
+```bash
+npm install -g @openai/codex
+```
+
+**Verify:**
+
+```bash
+codex --version
+```
+
+**Authenticate:**
+
+```bash
+export OPENAI_API_KEY="your-api-key"
+```
+
+See the [Codex CLI documentation](https://github.com/openai/codex) for full setup.
+
+### Gemini CLI
+
+Google's command-line AI coding assistant.
+
+**Prerequisites:** Requires [Node.js](https://nodejs.org/) 18+ (which includes npm) and a Google account.
+
+**Install (macOS / Linux):**
+
+```bash
+npm install -g @google/gemini-cli
+```
+
+**Verify:**
+
+```bash
+gemini --version
+```
+
+See the [Gemini CLI documentation](https://github.com/google-gemini/gemini-cli) for full setup.

--- a/docs/builder-setup/editor-setup.md
+++ b/docs/builder-setup/editor-setup.md
@@ -4,11 +4,13 @@ description: Install Cursor or VS Code as your code editor for AI development
 schema_type: HowTo
 howto_steps:
   - name: Choose your editor
-    text: Pick Cursor (AI-first editing) or VS Code (free, familiar). Both work for course exercises.
+    text: Pick Cursor (AI-first editing) or VS Code (free, familiar). Both work for AI development.
   - name: Download and install
     text: Go to cursor.com or code.visualstudio.com, download for your OS, and run the installer.
   - name: Verify installation
     text: Open your editor, go to File > Open Folder, and confirm you can navigate files and folders.
+  - name: Install AI extensions
+    text: Add AI coding extensions — Claude Code (recommended), OpenAI Codex, or Gemini Code Assist.
 ---
 
 # Code Editor Setup Guide
@@ -17,11 +19,11 @@ Quick reference for installing your code editor.
 
 ## Choose Your Editor
 
-Both options work well for course exercises:
+Both options work well:
 
 | Editor | Best For | Cost |
 |--------|----------|------|
-| **Cursor** | AI-first editing experience | Free tier available |
+| **Cursor** | Built-in AI editing | Free tier available |
 | **VS Code** | Familiar editor + extensions | Free |
 
 ## Option 1: Cursor
@@ -47,14 +49,50 @@ Cursor is VS Code with AI capabilities built in.
 ## Verify Installation
 
 1. Open your editor
-2. Go to **File → Open Folder** (or use Git: Clone to open a repository)
+2. Go to **File → Open Folder**
 3. Confirm you can navigate files and folders
+
+## Install AI Extensions
+
+After installing your editor, add the AI coding extensions for your workflow.
+
+### Claude Code (Recommended)
+
+The Claude Code extension connects your editor to Claude's AI capabilities.
+
+1. Open the Extensions panel (**Cmd/Ctrl + Shift + X**)
+2. Search for **Claude Code**
+3. Click **Install**
+4. Follow any sign-in prompts
+
+The Claude Code extension also includes an integrated terminal panel. See the [Claude Code Installation guide](claude-code-install.md) for CLI (command-line tool) setup.
+
+### OpenAI Codex (Optional)
+
+OpenAI's coding assistant extension for VS Code and Cursor.
+
+1. Open the Extensions panel (**Cmd/Ctrl + Shift + X**)
+2. Search for **Codex** (by OpenAI)
+3. Click **Install**
+4. Sign in with your OpenAI account when prompted
+
+Requires an OpenAI API account. See [OpenAI Codex documentation](https://openai.com/index/codex/) for details.
+
+### Gemini Code Assist (Optional)
+
+Google's AI coding assistant extension.
+
+1. Open the Extensions panel (**Cmd/Ctrl + Shift + X**)
+2. Search for **Gemini Code Assist**
+3. Click **Install**
+4. Sign in with your Google account when prompted
+
+Requires a Google Cloud account. See [Gemini Code Assist documentation](https://cloud.google.com/products/gemini-code-assist) for details.
 
 ## Next Steps
 
-- Clone the course repository (see GitHub Setup Guide)
-- Configure Claude Code (see Claude Code Setup Guide)
-- Post in Slack if you encounter issues
+- Set up Git (see [Git Installation Guide](git-install.md))
+- Install AI coding CLIs (see [Claude Code Installation Guide](claude-code-install.md))
 
 ## Resources
 

--- a/docs/builder-setup/git-install.md
+++ b/docs/builder-setup/git-install.md
@@ -58,7 +58,7 @@ brew install git
 
 ### Important Settings During Install
 
-- **Default editor**: Choose your preferred editor or keep the default
+- **Default editor**: Select **VS Code** or **Cursor** if listed — avoid the default (Vim) unless you're familiar with it
 - **PATH environment**: Select "Git from the command line and also from 3rd-party software" (recommended)
 - **Line endings**: Select "Checkout Windows-style, commit Unix-style line endings" (recommended)
 
@@ -81,7 +81,7 @@ git config --global user.name "Your Name"
 git config --global user.email "your.email@example.com"
 ```
 
-Use the same email address associated with your GitHub account.
+Use the email address you plan to use for your GitHub account (set up in the next step).
 
 ## Troubleshooting
 
@@ -100,9 +100,8 @@ Use the same email address associated with your GitHub account.
 
 ## Next Steps
 
-- Set up your GitHub account (see GitHub Setup Guide)
-- Install your code editor (see Editor Setup Guide)
-- Post in Slack if you encounter issues
+- Set up your GitHub account (see [GitHub Setup Guide](github-setup.md))
+- Install Claude Code (see [Claude Code Installation Guide](claude-code-install.md))
 
 ## Resources
 

--- a/docs/builder-setup/github-setup.md
+++ b/docs/builder-setup/github-setup.md
@@ -11,12 +11,13 @@ howto_steps:
 
 # GitHub Setup Guide
 
-Quick reference for setting up GitHub and version control for your AI assets.
+Quick reference for setting up GitHub for your projects.
 
 ## Prerequisites
 
 - Email address for GitHub account
-- Cursor or VS Code installed
+- Cursor or VS Code installed (see [Editor Setup Guide](editor-setup.md))
+- Git installed (see [Git Installation Guide](git-install.md))
 
 ## 1. Create a GitHub Account
 
@@ -29,13 +30,13 @@ Quick reference for setting up GitHub and version control for your AI assets.
 
 ## 2. Clone a Repository
 
-Use your code editor to clone course repositories.
+Use your code editor to download (clone) repositories from GitHub.
 
 ### In Cursor or VS Code
 
 1. Open the Command Palette (Cmd/Ctrl + Shift + P)
 2. Type **Git: Clone**
-3. Paste the repository URL (e.g., `https://github.com/jamesgray-ai/claude-for-builders.git`)
+3. Paste the repository URL (e.g., `https://github.com/username/project-name.git`)
 4. Choose a local folder location
 5. Open the cloned repository when prompted
 
@@ -83,9 +84,8 @@ Claude Code handles the Git commands for you.
 
 ## Next Steps
 
-- Review the course slide deck for detailed walkthrough with screenshots
-- Set up Claude Code CLI to manage Git operations
-- Post in Slack if you encounter issues
+- Install Claude Code to manage Git operations with natural language (see [AI Coding CLIs Guide](claude-code-install.md))
+- Try cloning a public repository to practice the workflow
 
 ## Resources
 

--- a/docs/builder-setup/index.md
+++ b/docs/builder-setup/index.md
@@ -1,0 +1,201 @@
+---
+title: Builder Stack Setup Guide
+description: Step-by-step checklist for setting up your complete AI builder toolkit — terminal, editor, Git, GitHub, AI coding CLIs, and more
+---
+
+# Builder Stack Setup Guide
+
+This page walks you through every tool you need for an AI builder workflow. Later steps depend on earlier ones, so work through them in order. Budget about **75 minutes** to complete the required steps (longer if you include the optional ones).
+
+Use the checkboxes to track your progress as you go.
+
+## At a Glance
+
+| Step | Tool | Time | Status |
+|------|------|------|--------|
+| 1 | Terminal Basics | ~15 min | Required |
+| 2 | AI Code Editor + Extensions | ~15 min | Required |
+| 3 | Git | ~10 min | Required |
+| 4 | GitHub | ~15 min | Required |
+| 5 | AI Coding CLIs (Command-Line Tools) | ~15 min | Required (Claude Code); Optional (Codex, Gemini) |
+| 6 | AI Registry + Plugins | ~20 min | Optional |
+| 7 | Voice to Text | ~10 min | Optional |
+
+---
+
+## Step 1: Terminal Basics
+
+**What:** Learn to navigate your computer's command line.
+**Time:** ~15 minutes
+**Requires:** Nothing — this is where you start.
+
+Every tool in this stack runs through the terminal. You don't need to be an expert — just comfortable opening it, navigating folders, and running commands.
+
+[:octicons-arrow-right-24: Go to Terminal Basics guide](terminal-basics.md)
+
+**You're done when:** You can open a terminal, run `pwd`, and navigate to a folder with `cd`.
+
+- [ ] Terminal Basics — complete
+
+---
+
+## Step 2: AI Code Editor + Extensions
+
+**What:** Install a code editor and add AI coding extensions.
+**Time:** ~15 minutes
+**Requires:** Step 1 (Terminal Basics)
+
+Your editor is where you'll read, write, and edit code. This guide covers Cursor (has AI built in) and VS Code (free), plus AI extensions for Claude Code, OpenAI Codex, and Gemini Code Assist.
+
+[:octicons-arrow-right-24: Go to Editor Setup guide](editor-setup.md)
+
+**You're done when:** You can open your editor, navigate files and folders, and see the Claude Code extension installed.
+
+- [ ] AI Code Editor — installed
+- [ ] AI extensions — installed
+
+---
+
+## Step 3: Git
+
+**What:** Install Git for version control.
+**Time:** ~10 minutes
+**Requires:** Step 1 (Terminal Basics)
+
+Git tracks changes to your files and lets you collaborate on code. Claude Code and GitHub both depend on it.
+
+[:octicons-arrow-right-24: Go to Git Installation guide](git-install.md)
+
+**You're done when:** Opening your terminal and typing `git --version` prints a version number.
+
+- [ ] Git — installed
+
+---
+
+## Step 4: GitHub
+
+**What:** Create a GitHub account and connect it to your editor.
+**Time:** ~15 minutes
+**Requires:** Steps 2 (Editor) and 3 (Git)
+
+GitHub hosts your projects (called *repositories*) in the cloud. You'll use it to download projects, upload your changes, and collaborate.
+
+[:octicons-arrow-right-24: Go to GitHub Setup guide](github-setup.md)
+
+**You're done when:** You can download (clone) a project from GitHub into your editor.
+
+- [ ] GitHub — account created and connected
+
+---
+
+## Step 5: AI Coding CLIs
+
+**What:** Install Claude Code and (optionally) other AI coding CLIs — command-line tools that let you use AI directly from your terminal.
+**Time:** ~15 minutes
+**Requires:** Steps 2 (Editor) and 3 (Git)
+
+Claude Code is the primary AI coding CLI used throughout this cookbook. The guide also covers OpenAI Codex CLI and Gemini CLI as optional alternatives.
+
+[:octicons-arrow-right-24: Go to AI Coding CLIs guide](claude-code-install.md)
+
+**You're done when:** Running `claude --version` prints a version number, and typing `claude` starts a conversation with Claude in your terminal.
+
+- [ ] Claude Code CLI — installed and authenticated
+- [ ] OpenAI Codex CLI — installed (optional)
+- [ ] Gemini CLI — installed (optional)
+
+---
+
+## Step 6: AI Registry + Plugins
+
+**What:** Add the Hands-on AI plugin marketplace, set up the AI Registry, and install plugins.
+**Time:** ~20 minutes
+**Requires:** Step 5 (AI Coding CLIs) — plugin commands run inside Claude Code
+
+This step has three parts:
+
+!!! tip "These commands run inside Claude Code"
+    The `/plugin` commands below are typed inside a Claude Code session, not in a regular terminal. Start Claude Code first by typing `claude` in your terminal, then run the `/plugin` commands.
+
+**1. Add the plugin marketplace.** Register the Hands-on AI marketplace so Claude Code knows where to find plugins. You only need to do this once:
+
+```bash
+/plugin marketplace add jamesgray-ai/handsonai
+```
+
+See the [Getting Started with Plugins](../plugins/getting-started.md) guide for the full walkthrough.
+
+**2. Set up the AI Registry.** The AI Registry is a Notion workspace template that gives you a structured system for tracking your workflows, AI building blocks, and connected applications. Once it's connected, Claude can name workflows, write SOPs (Standard Operating Procedures), and register skills directly in Notion.
+
+[:octicons-arrow-right-24: Go to AI Registry Setup guide](notion-registry-setup.md)
+
+**3. Install plugins.** With the marketplace added, install plugins to give Claude domain expertise:
+
+```bash
+/plugin install business-first-ai@handsonai
+/plugin install ai-registry@handsonai
+```
+
+The **Business-First AI** plugin is required for a guided experience on the Claude platform using skills — it includes agents and skills for discovering AI opportunities, deconstructing workflows, and building with AI. The **AI Registry** plugin is required for Claude users who want to integrate seamlessly with the Notion registry — it lets Claude name workflows, write SOPs, and register building blocks directly in your workspace.
+
+Browse all available plugins on the [Plugin Marketplace](../plugins/index.md).
+
+!!! info "Using skills in Claude.ai (web)"
+    After installing plugins, agents and skills work automatically in **Claude Code** and **Cowork**. However, if you want to use skills in **Claude.ai** (the web interface), there's an extra step: you need to zip each skill folder and upload it manually through Settings > Capabilities > Upload skill. See the [Using Skills in Claude.ai](../plugins/using-plugins.md#using-skills-in-claudeai-web) guide for step-by-step instructions.
+
+**You're done when:** You've completed the parts above that apply to your workflow.
+
+- [ ] Plugin marketplace — registered
+- [ ] AI Registry — Notion template duplicated and connected (optional)
+- [ ] AI Registry plugin — installed (optional)
+- [ ] Business-First AI plugin — installed (optional)
+
+---
+
+## Step 7: Voice to Text
+
+**What:** Set up voice dictation for faster input.
+**Time:** ~10 minutes
+**Requires:** Nothing — this step is fully independent.
+
+Voice input can speed up how you write prompts, notes, and messages. This is optional but useful for anyone who thinks faster than they type.
+
+[:octicons-arrow-right-24: Go to Voice to Text Setup guide](voice-to-text-setup.md)
+
+**You're done when:** You can dictate text into any input field on your computer.
+
+- [ ] Voice to Text — set up (optional)
+
+---
+
+## What's Next?
+
+With your builder stack in place, you're ready to start building with AI.
+
+<div class="grid cards" markdown>
+
+-   :material-lightbulb:{ .lg .middle } **Learn the Building Blocks**
+
+    ---
+
+    Understand the six components of every AI workflow — prompts, context, projects, skills, agents, and MCP (connections to external tools).
+
+    [:octicons-arrow-right-24: Agentic Building Blocks](../agentic-building-blocks/index.md)
+
+-   :material-puzzle-outline:{ .lg .middle } **Install Plugins**
+
+    ---
+
+    Pre-built Claude Code agents and skills you can install in one command.
+
+    [:octicons-arrow-right-24: Plugin Marketplace](../plugins/index.md)
+
+-   :material-school:{ .lg .middle } **Take a Course**
+
+    ---
+
+    Structured learning that walks you through building with AI step by step.
+
+    [:octicons-arrow-right-24: Browse Courses](../courses/index.md)
+
+</div>

--- a/docs/builder-setup/notion-registry-setup.md
+++ b/docs/builder-setup/notion-registry-setup.md
@@ -21,7 +21,7 @@ howto_steps:
 
 The AI Registry is a Notion workspace template that gives you a structured system for tracking your business processes, workflows, AI building blocks, and connected applications. It serves as the central hub for your AI operations — a single place to document what you're building, how it works, and what tools are involved.
 
-This registry is also the foundation for the [AI Registry plugin](../plugins/index.md#ai-registry), a set of Claude Code skills that can read from and write to your registry automatically. Once your registry is set up and connected, Claude can name workflows, write SOPs, register skills, and keep everything in sync — anywhere on the Claude platform.
+This registry is also the foundation for the [AI Registry plugin](../plugins/index.md#ai-registry), a set of Claude Code skills that can read from and write to your registry automatically. Once your registry is set up and connected, Claude can name workflows, write SOPs (Standard Operating Procedures), register skills, and keep everything in sync — anywhere on the Claude platform.
 
 !!! note "Platform support"
     The AI Registry plugin is powered by Claude Agent skills, which are currently only supported on the **Claude** platform. Agent skills are an open standard, and many companies are already working to adopt them — as support broadens, the same skills will work across tools. The Notion connector ([Step 7](#step-7-connect-your-ai-tools)) works on both Claude and ChatGPT for basic read/write access.
@@ -118,7 +118,7 @@ Business Process → Workflows → AI Building Blocks
 
 ## Using the AI Registry Plugin
 
-Once your registry is connected via MCP, install the companion plugin to let Claude work with it directly:
+Once your registry is connected via the Notion connector, install the companion plugin to let Claude work with it directly:
 
 ```bash
 /plugin install ai-registry@handsonai
@@ -153,7 +153,7 @@ See the [AI Registry plugin page](../plugins/index.md#ai-registry) for full deta
 
 **Can't find the template?**
 
-- The template must be shared publicly. Contact the course instructor if the link doesn't work.
+- The template must be shared publicly. If the link doesn't work, check for updates on [GitHub](https://github.com/jamesgray-ai/handsonai/issues).
 
 **AI tool can't see your registry?**
 

--- a/docs/builder-setup/terminal-basics.md
+++ b/docs/builder-setup/terminal-basics.md
@@ -21,7 +21,7 @@ Get comfortable with the command line before diving into developer tools.
 
 The terminal is a text-based way to talk to your computer. Instead of clicking through menus and windows, you type commands and press Enter.
 
-Why does this matter for this course? Most developer tools — Git, Claude Code, package managers — are designed to run from the terminal. Every setup guide that follows assumes you can open a terminal and type a command.
+Why does this matter? Most developer tools — Git, Claude Code, and other builder tools — are designed to run from the terminal. Every setup guide that follows assumes you can open a terminal and type a command.
 
 The good news: you only need a handful of commands to get started.
 
@@ -44,6 +44,9 @@ The good news: you only need a handful of commands to get started.
     You'll see a window with a line ending in `>` and a blinking cursor. That's your **prompt** — it means the terminal is ready for a command.
 
 ## Open the Terminal in Your Editor
+
+!!! note "Come back after Step 2"
+    This section requires a code editor. If you're following the [Builder Stack Setup Guide](index.md) in order, complete Step 2 (Editor Setup) first, then return here.
 
 Once you have Cursor or VS Code installed, you can use the terminal directly inside your editor. This is where you'll spend most of your time — running commands without switching windows.
 
@@ -91,7 +94,7 @@ These are the commands you'll use most often. macOS/Linux and Windows PowerShell
 
 ## Try It Yourself
 
-Open your terminal and follow along. This short exercise builds muscle memory with commands you'll use throughout the course.
+Open your terminal and follow along. This short exercise builds muscle memory with commands you'll use throughout these guides.
 
 === "macOS / Linux"
 
@@ -194,7 +197,7 @@ Start typing a file or folder name and press ++tab++. The terminal will auto-com
 
 **"command not found" or "not recognized"**
 
-- The tool you're trying to use isn't installed, or it isn't in your PATH
+- The tool you're trying to use isn't installed, or your system doesn't know where to find it
 - Follow the relevant installation guide, then try again
 
 **"Permission denied"**

--- a/docs/builder-setup/voice-to-text-setup.md
+++ b/docs/builder-setup/voice-to-text-setup.md
@@ -107,8 +107,7 @@ Claude Desktop launches with your transcribed prompt and responds.
 ## Next Steps
 
 - Practice dictating a few prompts to get comfortable
-- Review the course slide deck for detailed walkthrough
-- Post in Slack if you encounter issues
+- Explore the official documentation for your chosen tool
 
 ## Resources
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ Master AI. Master yourself. Build what matters. That's what [Graymatter](https:/
 
     Essential tools for your AI builder workflow — terminal, Git, editor, Claude Code, and more
 
-    [:octicons-arrow-right-24: Set up your stack](builder-setup/claude-code-install.md)
+    [:octicons-arrow-right-24: Set up your stack](builder-setup/index.md)
 
 -   :material-puzzle-outline:{ .lg .middle } **Plugins**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,8 @@ markdown_extensions:
   - tables
   - attr_list
   - md_in_html
+  - pymdownx.tasklist:
+      custom_checkbox: true
   - toc:
       permalink: true
 
@@ -218,14 +220,15 @@ nav:
     - Using Plugins: plugins/using-plugins.md
     - Business-First AI: plugins/business-first-ai.md
     - AI Registry: plugins/ai-registry.md
-  - Builder Setup:
-    - Terminal Basics: builder-setup/terminal-basics.md
-    - Claude Code Installation: builder-setup/claude-code-install.md
-    - Editor Setup: builder-setup/editor-setup.md
-    - Git Installation: builder-setup/git-install.md
-    - GitHub Setup: builder-setup/github-setup.md
-    - AI Registry: builder-setup/notion-registry-setup.md
-    - Voice to Text: builder-setup/voice-to-text-setup.md
+  - Builder Stack Setup:
+    - Overview: builder-setup/index.md
+    - "Step 1 — Terminal Basics": builder-setup/terminal-basics.md
+    - "Step 2 — AI Code Editor": builder-setup/editor-setup.md
+    - "Step 3 — Git": builder-setup/git-install.md
+    - "Step 4 — GitHub": builder-setup/github-setup.md
+    - "Step 5 — AI Coding CLIs": builder-setup/claude-code-install.md
+    - "Step 6 — AI Registry": builder-setup/notion-registry-setup.md
+    - "Step 7 — Voice to Text": builder-setup/voice-to-text-setup.md
   - Patterns: patterns/index.md
   - Courses:
     - Overview: courses/index.md


### PR DESCRIPTION
## Summary

- **New page:** `docs/builder-setup/index.md` — numbered, checklist-style overview of the full 7-step builder stack with at-a-glance table, dependency info, styled checkboxes, plugin/registry setup, and What's Next cards
- **Expanded:** Editor setup with AI extensions section (Claude Code, Codex, Gemini Code Assist); Claude Code guide with alternative CLI section (Codex CLI, Gemini CLI)
- **Clarity pass across all 7 guides:** Defined jargon (CLI, PATH, repositories, clone, SOP, MCP) on first use; removed all course-specific language; fixed prerequisite sequencing; warned about Vim default in Git installer; added npm/Node.js prerequisites before install commands; reformatted Windows notes into admonitions
- **mkdocs.yml:** Added `pymdownx.tasklist` extension for styled checkboxes; reordered Builder Stack Setup nav with step numbers and overview entry
- **Homepage:** Updated Builder Setup card to point to new overview page

## Test plan

- [ ] Run `mkdocs serve` and verify builder-setup/ loads the new overview page
- [ ] Confirm checkboxes render as styled checkboxes (not literal `[ ]`)
- [ ] Verify all 7 guide links work from the overview
- [ ] Check nav shows numbered steps in correct order
- [ ] Confirm editor setup page shows all 3 extension install sections
- [ ] Confirm Claude Code page shows Codex and Gemini CLI sections
- [ ] Verify homepage "Set up your stack" link goes to the new overview
- [ ] Spot-check that admonitions render correctly (tip boxes, info boxes, note boxes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)