### PR TITLE
Add weekly release notes agent and What's New page

### DIFF
--- a/.claude/agents/release-notes-generator.md
+++ b/.claude/agents/release-notes-generator.md
@@ -1,0 +1,107 @@
+---
+name: release-notes-generator
+description: "Use this agent to automatically generate weekly release notes from git history and publish them as a GitHub Release. Designed to run on a schedule (Sunday evenings) but can also be triggered manually.\n\nExamples:\n\n<example>\nContext: Scheduled weekly run via launchd.\nuser: \"Run the release-notes-generator agent\"\nassistant: \"I'll generate release notes from recent commits and publish a GitHub Release.\"\n<commentary>\nThe agent reads the git log since the last tag, categorizes changes into reader-friendly sections, and publishes a GitHub Release.\n</commentary>\n</example>\n\n<example>\nContext: User wants to manually trigger release notes.\nuser: \"Generate release notes for this week's changes\"\nassistant: \"I'll use the release-notes-generator agent to create and publish release notes from the recent commits.\"\n<commentary>\nSince the user wants release notes generated, launch the release-notes-generator agent.\n</commentary>\n</example>"
+model: sonnet
+color: green
+---
+
+You are the Release Notes Generator for the Hands-on AI Cookbook (handsonai.info). Your job is to read the git log since the last release, translate commits into reader-friendly release notes, and publish a GitHub Release.
+
+## Step 1: Find the Baseline
+
+Run:
+```bash
+git tag --sort=-creatordate | head -1
+```
+
+- If a tag exists, use it as the baseline.
+- If no tags exist, use the full git history (omit the tag range from git log).
+
+## Step 2: Check for New Commits
+
+Run:
+```bash
+git log <last-tag>..HEAD --oneline
+```
+
+(If no tag, run `git log --oneline`.)
+
+**If there are no new commits since the last tag, output "No changes since last release — skipping." and stop. Do not create a release.**
+
+## Step 3: Gather Detailed Changes
+
+Run both:
+```bash
+git log <last-tag>..HEAD --oneline
+git diff --stat <last-tag>..HEAD
+```
+
+The `--stat` output shows which files changed, which helps you categorize accurately.
+
+## Step 4: Categorize and Rewrite
+
+Sort changes into these **reader-facing sections**. Use the commit messages AND the file paths to categorize:
+
+- **New Guides** — New pages added to `docs/` (look for new files in `docs/`)
+- **Updated Content** — Changes to existing content pages in `docs/`
+- **New Q&As** — New question pages (files in `questions/` directories)
+- **New Plugins & Skills** — Changes to `plugins/` or `.claude/skills/`
+- **Site Improvements** — Config, styling, nav, CI/CD changes
+
+### Rewriting Rules
+
+- **Translate for readers**: "Add builder-setup guide" → "Added a step-by-step Builder Stack Setup guide with installation instructions for Terminal, Git, VS Code, and Claude Code"
+- **Drop internal-only changes**: Skip commits that only touch CI workflows (`.github/`), scripts (`scripts/`), `.gitignore`, `.claude/agents/`, or other non-user-facing files. If ALL commits are internal-only, output "No user-facing changes since last release — skipping." and stop.
+- **Combine related commits**: If multiple commits update the same page or feature, combine them into one bullet.
+- **Omit empty sections**: Only include sections that have items.
+
+## Step 5: Generate Tag and Title
+
+- **Tag format**: `vYYYY.MM.DD` using today's date
+- **Title format**: `Week of Month Day, Year` (e.g., "Week of February 7, 2026")
+
+If the tag already exists, append a suffix: `vYYYY.MM.DD.2`, `.3`, etc. Check with:
+```bash
+git tag -l "vYYYY.MM.DD*"
+```
+
+## Step 6: Publish the Release
+
+Run:
+```bash
+gh release create <tag> --title "<title>" --notes "<body>"
+```
+
+The body should be the categorized, rewritten release notes from Step 4.
+
+## Step 7: Log the Result
+
+Print the release URL so it appears in the log file:
+```
+Release published: https://github.com/jamesgray-ai/handsonai/releases/tag/<tag>
+```
+
+## Example Output
+
+```markdown
+### New Guides
+
+- Added the **Builder Stack Setup Guide** — a 7-step checklist for installing Terminal, Git, VS Code, Claude Code, and other developer tools
+- Added **Voice-to-Text Setup** guide for hands-free AI workflows
+
+### Updated Content
+
+- Improved the **Prompts** building block page with new examples and clearer structure
+- Updated the homepage with a newsletter sign-up section
+
+### Site Improvements
+
+- Added styled checkboxes to setup guide checklists
+- Improved navigation with "Step N —" prefixes in the Builder Stack Setup section
+```
+
+## Important Notes
+
+- Always run from the repository root directory
+- The `gh` CLI must be authenticated (it is in this environment)
+- After this release is published, the next `git push` to `main` triggers the deploy workflow, which runs `generate_whats_new.py` — the new release will automatically appear on the What's New page

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,5 +24,10 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
+      - name: Generate What's New page
+        run: python scripts/generate_whats_new.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Deploy to GitHub Pages
         run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ dist/
 # Temporary files
 *.tmp
 *.temp
+
+# Generated at build time
+docs/whats-new.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,6 +87,7 @@ See what others are saying on the [Wall of Love](wall-of-love.md).
 | Explore AI use cases by type | [Use Case Primitives](use-cases/) |
 | Install Claude Code plugins | [Plugin Marketplace](plugins/) |
 | Take a structured course | [Courses](courses/) |
+| See recent updates | [What's New](whats-new.md) |
 
 ## About
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,6 +134,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - "What's New": whats-new.md
   - Business-First AI Framework:
     - Overview: business-first-ai-framework/index.md
     - "Phase 1 — Discover": business-first-ai-framework/discover.md

--- a/scripts/generate_whats_new.py
+++ b/scripts/generate_whats_new.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Generate docs/whats-new.md from GitHub Releases.
+
+Fetches published (non-draft) releases from the GitHub API and writes a
+Markdown page suitable for MkDocs.  Uses only Python stdlib — no pip
+installs required.
+
+For local preview:
+    python scripts/generate_whats_new.py && mkdocs serve
+
+Set GITHUB_TOKEN for a higher API rate limit (automatic in GitHub Actions).
+"""
+
+import json
+import os
+import ssl
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+
+REPO = "jamesgray-ai/handsonai"
+API_URL = f"https://api.github.com/repos/{REPO}/releases"
+OUTPUT = Path(__file__).resolve().parent.parent / "docs" / "whats-new.md"
+
+FRONTMATTER = """\
+---
+title: "What's New"
+description: Recent updates to the Hands-on AI Cookbook — new guides, updated content, and new Q&As.
+---
+"""
+
+INTRO = """\
+# What's New
+
+Recent updates to the Hands-on AI Cookbook. This page is generated
+automatically from [GitHub Releases](https://github.com/{repo}/releases)
+— subscribe to the repo or check back here to stay current.
+
+---
+
+""".format(repo=REPO)
+
+PLACEHOLDER = """\
+No updates published yet — check back soon!
+"""
+
+
+def _ssl_context():
+    """Build an SSL context, trying certifi first for macOS compatibility."""
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except ImportError:
+        return ssl.create_default_context()
+
+
+def fetch_releases():
+    """Return a list of published (non-draft, non-prerelease) releases."""
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    req = urllib.request.Request(API_URL, headers=headers)
+    ctx = _ssl_context()
+    with urllib.request.urlopen(req, context=ctx) as resp:
+        data = json.loads(resp.read().decode())
+
+    return [
+        r for r in data
+        if not r.get("draft") and not r.get("prerelease")
+    ]
+
+
+def format_release(release):
+    """Format a single release as a Markdown section."""
+    name = release.get("name") or release.get("tag_name", "Untitled")
+    published = release.get("published_at", "")
+    body = (release.get("body") or "").strip()
+
+    date_str = ""
+    if published:
+        dt = datetime.strptime(published, "%Y-%m-%dT%H:%M:%SZ")
+        date_str = f"{dt.strftime('%B')} {dt.day}, {dt.year}"
+
+    lines = [f"## {name}"]
+    if date_str:
+        lines.append(f"\n*{date_str}*")
+    if body:
+        lines.append(f"\n{body}")
+    lines.append("")  # trailing newline
+    return "\n".join(lines)
+
+
+def main():
+    releases = fetch_releases()
+
+    parts = [FRONTMATTER, INTRO]
+    if releases:
+        parts.extend(format_release(r) for r in releases)
+    else:
+        parts.append(PLACEHOLDER)
+
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text("\n".join(parts))
+    print(f"Wrote {OUTPUT} ({len(releases)} release(s))")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run-release-notes-generator.sh
+++ b/scripts/run-release-notes-generator.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Wrapper script for release-notes-generator subagent
+# Runs the subagent and logs output for troubleshooting
+
+# Store logs in the project folder for easy access
+PROJECT_DIR="/Users/jamesgray/code/handsonai"
+LOG_DIR="$PROJECT_DIR/logs/scheduled"
+mkdir -p "$LOG_DIR"
+
+TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
+LOG_FILE="$LOG_DIR/release-notes-generator_$TIMESTAMP.log"
+
+echo "=== Release Notes Generator ===" >> "$LOG_FILE"
+echo "Started: $(date)" >> "$LOG_FILE"
+echo "" >> "$LOG_FILE"
+
+# Change to the repo directory
+cd "$PROJECT_DIR"
+
+# Run the subagent (using full path for launchd compatibility)
+# --dangerously-skip-permissions allows headless operation with tool use
+/Users/jamesgray/.local/bin/claude -p "Generate and publish release notes for any changes since the last release." --agent release-notes-generator --dangerously-skip-permissions >> "$LOG_FILE" 2>&1
+
+echo "" >> "$LOG_FILE"
+echo "Finished: $(date)" >> "$LOG_FILE"

--- a/scripts/setup-release-notes-schedule.sh
+++ b/scripts/setup-release-notes-schedule.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Install a macOS launchd plist to run the release-notes-generator
+# every Sunday at 9 PM (21:00) local time.
+#
+# Usage: bash scripts/setup-release-notes-schedule.sh
+
+LABEL="com.jamesgray.release-notes-generator"
+PLIST_PATH="$HOME/Library/LaunchAgents/$LABEL.plist"
+SCRIPT_PATH="/Users/jamesgray/code/handsonai/scripts/run-release-notes-generator.sh"
+
+# Unload existing plist if present
+if launchctl list "$LABEL" &>/dev/null; then
+    echo "Unloading existing schedule..."
+    launchctl unload "$PLIST_PATH" 2>/dev/null
+fi
+
+cat > "$PLIST_PATH" << 'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.jamesgray.release-notes-generator</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/jamesgray/code/handsonai/scripts/run-release-notes-generator.sh</string>
+    </array>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <!-- Sunday = 0, 9 PM -->
+        <key>Weekday</key>
+        <integer>0</integer>
+        <key>Hour</key>
+        <integer>21</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/jamesgray/code/handsonai</string>
+
+    <key>StandardOutPath</key>
+    <string>/Users/jamesgray/code/handsonai/logs/scheduled/launchd-release-notes.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/jamesgray/code/handsonai/logs/scheduled/launchd-release-notes.err.log</string>
+</dict>
+</plist>
+EOF
+
+echo "Installed plist at: $PLIST_PATH"
+
+# Load the plist
+launchctl load "$PLIST_PATH"
+echo "Schedule loaded. Verify with:"
+echo "  launchctl list | grep release-notes"


### PR DESCRIPTION
## Summary

- Adds a **scheduled Claude Code agent** (`release-notes-generator`) that runs every Sunday at 9 PM via macOS launchd to generate reader-friendly release notes from git history and publish them as GitHub Releases
- Adds `generate_whats_new.py` to the deploy workflow so new releases automatically appear on the **What's New** page
- Moves "What's New" to position 2 in the nav (right after Home) for better visibility
- Fixes `%-d` strftime portability issue in `generate_whats_new.py`

## Test plan

- [x] Ran `bash scripts/run-release-notes-generator.sh` — agent successfully read git log and published [v2026.02.08](https://github.com/jamesgray-ai/handsonai/releases/tag/v2026.02.08)
- [x] Ran `python3 scripts/generate_whats_new.py` — confirmed new release appears in `docs/whats-new.md` with correct date formatting
- [ ] Verify `mkdocs build` succeeds with the new nav order
- [ ] Run `bash scripts/setup-release-notes-schedule.sh` to install the launchd schedule
- [ ] Verify schedule with `launchctl list | grep release-notes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)