### PR TITLE
Switch to collapsible nav sections with dark mode fix

### DIFF
--- a/docs/assets/stylesheets/custom.css
+++ b/docs/assets/stylesheets/custom.css
@@ -300,6 +300,13 @@
   background-color: var(--md-default-fg-color);
 }
 
+/* Nav section labels — make collapsible section titles readable in dark mode */
+[data-md-color-scheme="slate"] .md-nav__item--nested > .md-nav__container > a,
+[data-md-color-scheme="slate"] .md-nav__item--nested > .md-nav__container > label,
+[data-md-color-scheme="slate"] .md-nav > .md-nav__title {
+  color: rgba(255, 255, 255, 0.7);
+}
+
 /* Typography - Inter font weight adjustments */
 .md-typeset h1,
 .md-typeset h2,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,7 @@ theme:
   features:
     - navigation.instant
     - navigation.tracking
-    - navigation.sections
+    - navigation.indexes
     - navigation.top
     - search.suggest
     - search.highlight
@@ -257,7 +257,15 @@ nav:
     - Using Plugins: plugins/using-plugins.md
     - Business-First AI: plugins/business-first-ai.md
     - AI Registry: plugins/ai-registry.md
-  - Builder Stack Setup: builder-setup/index.md
+  - Builder Stack Setup:
+    - builder-setup/index.md
+    - "Step 1 — Terminal Basics": builder-setup/terminal-basics.md
+    - "Step 2 — AI Code Editor": builder-setup/editor-setup.md
+    - "Step 3 — Git": builder-setup/git-install.md
+    - "Step 4 — GitHub": builder-setup/github-setup.md
+    - "Step 5 — AI Coding CLIs": builder-setup/claude-code-install.md
+    - "Step 6 — AI Registry": builder-setup/notion-registry-setup.md
+    - "Step 7 — Voice to Text": builder-setup/voice-to-text-setup.md
   - Patterns: patterns/index.md
   - Courses:
     - Overview: courses/index.md


### PR DESCRIPTION
## Summary

- Replace `navigation.sections` (always-expanded) with collapsible chevron sections — all top-level nav sections can now be collapsed/expanded
- Enable `navigation.indexes` so section index pages become the clickable section title (no separate "Overview" child)
- Add CSS fix for dark mode: section labels were nearly invisible on the slate background, now at readable 70% white opacity

## Test plan

- [ ] All nav sections collapse/expand with chevron click
- [ ] Section titles (Platforms, Plugins, Builder Stack Setup, etc.) are readable in dark mode
- [ ] Clicking a section title navigates to the section's index page
- [ ] Light mode unaffected
- [ ] `mkdocs build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)