### PR TITLE
Add Context Graphs page and AI Engineering section

### DIFF
--- a/docs/agentic-building-blocks/context/context-graphs.md
+++ b/docs/agentic-building-blocks/context/context-graphs.md
@@ -1,0 +1,124 @@
+---
+title: Context Graphs
+description: Structured systems that capture reasoning, decisions, and relational context for agentic AI workflows
+---
+
+# Context Graphs
+
+> **Platforms:** `claude` `openai` `gemini` `m365-copilot`
+
+## What Context Graphs Are
+
+A **context graph** is a structured system that captures not just *what* information an AI agent uses, but *why* decisions were made and how facts relate to each other.
+
+Think of it this way: a document gives an AI agent information. A context graph gives it *understanding* — the connections between entities, the reasoning behind decisions, and the temporal sequence of events that led to the current state.
+
+Context graphs build on the concept of a **knowledge graph** (a network of entities connected by labeled relationships) but go further by encoding decision logic, confidence levels, and causal chains. In a knowledge graph, you might store that "Customer A bought Product B." In a context graph, you also capture *why* — the sales signal that triggered outreach, the objection that was overcome, and the precedent from a similar deal that informed the approach.
+
+## How Context Graphs Differ
+
+| Approach | What It Does | What It Misses |
+|----------|-------------|----------------|
+| **Context window** | Holds the text (measured in **tokens** — chunks of text the model processes) visible to the model in a single conversation | No structure, no persistence, limited size |
+| **RAG** | **Retrieval-Augmented Generation** — retrieves relevant documents from a database and injects them into the prompt | Finds *related* content but doesn't capture *relationships* between concepts |
+| **Knowledge graph** | Maps entities and their relationships in a structured network of **nodes** (things) and **edges** (connections) | Static structure, no decision reasoning or temporal context |
+| **Context graph** | Captures entities, relationships, decisions, reasoning chains, and temporal context in a queryable structure | Emerging technology, more complex to build and maintain |
+
+Each approach in this table builds on the ones above it. **RAG** helps an AI find relevant documents. A **knowledge graph** helps it understand how entities relate. A **context graph** helps it understand *why things happened* and *what led to decisions* — which is what agents need for multi-step reasoning.
+
+## Key Concepts
+
+### Nodes
+
+Nodes are the things in a context graph. Unlike a traditional knowledge graph where nodes are mostly entities (people, companies, products), context graph nodes include:
+
+| Node Type | What It Represents | Example |
+|-----------|--------------------|---------|
+| **Entity** | A person, organization, product, or concept | "Acme Corp", "Q4 Revenue Report" |
+| **Decision** | A choice that was made, with reasoning | "Chose vendor B because of compliance requirements" |
+| **Signal** | An event or data point that triggered action | "Customer satisfaction dropped below 80%" |
+| **State** | A snapshot of conditions at a point in time | "Pipeline status as of January 2026" |
+
+### Edges
+
+**Edges** are the connections between nodes — they describe *how* things relate. Context graphs use richer edge types than traditional knowledge graphs:
+
+| Edge Type | What It Captures | Example |
+|-----------|-----------------|---------|
+| **Causation** | One thing led to another | Signal "churn risk detected" → Decision "escalate to account manager" |
+| **Dependency** | One thing requires another | Task "generate report" depends on State "data refresh complete" |
+| **Precedent** | A past decision that informs a current one | Decision "pricing for Enterprise tier" references Decision "pricing for Mid-Market tier" |
+| **Temporal** | Sequence and timing of events | Signal A occurred before Signal B, 3 days apart |
+| **Confidence** | How certain a relationship is | Entity "likely competitor" connected with 0.7 confidence |
+
+### Relationships
+
+The combination of nodes and edges creates relationship patterns that agents can traverse:
+
+- **Temporal chains** — "What sequence of events led to this outcome?"
+- **Conditional logic** — "Under what conditions was this decision made?"
+- **Confidence-weighted paths** — "What's the most reliable chain of reasoning?"
+
+## Why They Matter for Agentic AI
+
+Context graphs address specific limitations that surface when AI agents handle multi-step, real-world workflows:
+
+- **Multi-step reasoning** — Agents can trace chains of causation and dependency rather than relying on whatever fits in the context window
+- **Structured memory** — Decisions and their rationale persist across conversations and sessions, giving agents institutional knowledge
+- **Auditability** — Every recommendation can be traced back through the graph to the signals and precedents that informed it
+- **Compounding organizational knowledge** — Each interaction adds to the graph, making the system more capable over time rather than starting fresh each session
+
+## The Context Engineering Shift
+
+The AI industry is undergoing a shift from **prompt engineering** (optimizing *how you ask*) to **context engineering** (optimizing *what information the model sees*).
+
+The core insight: a well-structured, relevant context makes even a simple prompt produce excellent results. A perfectly crafted prompt with poor context still produces poor results.
+
+This shift has practical implications:
+
+- **Where you invest time changes** — less on prompt syntax, more on building and curating the information your AI workflows consume
+- **What you build changes** — systems that assemble, filter, and structure context become more valuable than prompt template libraries
+- **How you measure quality changes** — success depends on whether the right context reached the model, not just whether the prompt was well-written
+
+Context graphs represent the most structured end of this spectrum — purpose-built systems for assembling exactly the right context for each agent action.
+
+## Tools and Frameworks
+
+| Tool | What It Does | Best For |
+|------|-------------|----------|
+| [TrustGraph](https://trustgraph.ai) | Extracts knowledge graphs from documents with AI, supports context graph queries | Document-heavy workflows needing structured extraction |
+| [Graphiti](https://github.com/getzep/graphiti) | Temporal knowledge graph library for building agent memory | Agents that need persistent, evolving memory across sessions |
+| [LangGraph](https://www.langchain.com/langgraph) | Framework for building stateful, multi-agent workflows with graph-based orchestration | Complex agent orchestration with branching logic |
+| [Neo4j](https://neo4j.com) | Graph database for storing and querying relationship-rich data | Enterprise-scale knowledge and context graph storage |
+| [MCP](../mcp/index.md) | **Model Context Protocol** — a standard for connecting AI models to external data sources and tools | Connecting agents to live context from APIs, databases, and services |
+
+## Relationship to Other Blocks
+
+Context graphs intersect with every other building block:
+
+- **[Prompts](../prompts/index.md)** — Context graphs provide the structured background that makes prompts effective. Instead of cramming context into a prompt, agents query the graph for exactly what's relevant.
+- **[Projects](../projects/index.md)** — Projects organize persistent context. Context graphs add structure *within* that context — not just "here are the files" but "here's how they relate."
+- **[Skills](../skills/index.md)** — Skills can use context graphs to make decisions based on precedent and historical patterns rather than just the instructions they contain.
+- **[Agents](../agents/index.md)** — Agents are the primary consumers of context graphs. Multi-step workflows benefit most from structured reasoning and memory.
+- **[MCP](../mcp/index.md)** — MCP servers can expose context graph data as tools and resources, giving agents structured access to organizational knowledge.
+
+## Further Reading
+
+- [AI's Trillion-Dollar Opportunity: Context Graphs](https://foundationcapital.com/context-graphs-ais-trillion-dollar-opportunity/) — Foundation Capital
+- [Context is the Next Data Platform](https://www.glean.com/blog/context-data-platform) — Glean
+- [What are Context Graphs](https://medium.com/modelmind/what-are-context-graphs-building-the-ai-that-trulyunderstands-e7e5db39138d) — Neural Notions
+- [Context Engineering for Agents](https://blog.langchain.com/context-engineering-for-agents/) — LangChain
+- [Context Graphs: A Practical Guide](https://medium.com/@adnanmasood/context-graphs-a-practical-guide-to-governed-context-for-llms-agents-and-knowledge-systems-c49610c8ff27) — Adnan Masood, PhD
+- [Effective Context Engineering for AI Agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) — Anthropic
+- [Context Graphs: AI-Optimized Knowledge Graphs](https://trustgraph.ai/guides/key-concepts/context-graphs/) — TrustGraph
+- [Graphiti](https://github.com/getzep/graphiti) — Temporal knowledge graph library for agent memory
+
+## Related
+
+- [Context Engineering](../../ai-engineering/context-engineering.md) — the broader discipline; context graphs are an advanced technique within it
+- [Context](index.md) — the Context building block overview
+- [Agentic Building Blocks](../index.md) — Context Graphs in the context of all six building blocks
+- [AI Use Cases](../../use-cases/index.md) — what teams build with context, organized by six primitives
+- [Agents](../agents/index.md) — autonomous workflows that benefit most from structured context
+- [MCP](../mcp/index.md) — the protocol for connecting agents to external context sources
+- [Prompts](../prompts/index.md) — the instructions that context enhances

--- a/docs/agentic-building-blocks/context/index.md
+++ b/docs/agentic-building-blocks/context/index.md
@@ -71,6 +71,7 @@ Context makes prompts smarter. Projects organize context persistently so you don
 
 ## Related
 
+- [Context Graphs](context-graphs.md) — structured decision and reasoning graphs for agentic AI
 - [Agentic Building Blocks](../index.md) — Context in the context of all six building blocks
 - [AI Use Cases](../../use-cases/index.md) — what teams build with context, organized by six primitives
 - [Prompts](../prompts/index.md) — the instructions that context enhances

--- a/docs/agentic-building-blocks/index.md
+++ b/docs/agentic-building-blocks/index.md
@@ -269,6 +269,7 @@ A project is an active workspace — it provides standing instructions, persiste
 - [Skills](skills/index.md) — reusable routines the AI invokes when relevant
 - [Agents](agents/index.md) — concepts for the Agent building block
 - [MCP](mcp/index.md) — connecting AI to external systems
+- [AI Engineering](../ai-engineering/index.md) — practices for designing and optimizing AI systems, including context engineering
 - [Patterns](../patterns/index.md) — reusable approaches across building blocks
 
 **Use cases:**

--- a/docs/agentic-building-blocks/prompts/index.md
+++ b/docs/agentic-building-blocks/prompts/index.md
@@ -72,6 +72,7 @@ Not every prompt needs all four elements. A simple question needs only the task.
 
 ## Related
 
+- [Context Engineering](../../ai-engineering/context-engineering.md) — the broader discipline that prompt engineering is part of
 - [Agentic Building Blocks](../index.md) — Prompts in the context of all six building blocks
 - [AI Use Cases](../../use-cases/index.md) — see how prompts are used across content creation, research, coding, data analysis, ideation, and automation
 - [Projects](../projects/index.md) — where prompts become persistent custom instructions

--- a/docs/ai-engineering/context-engineering.md
+++ b/docs/ai-engineering/context-engineering.md
@@ -1,0 +1,114 @@
+---
+title: Context Engineering
+description: The practice of designing and optimizing the entire context window — system prompts, instructions, tools, memory, and state — for AI systems
+---
+
+# Context Engineering
+
+> **Platforms:** `claude` `openai` `gemini` `m365-copilot`
+
+## What Context Engineering Is
+
+**Context engineering** is the practice of designing and optimizing everything an AI model sees when it generates a response. This goes well beyond writing a good prompt — it includes system prompts, instructions, user input handling, tool integrations, retrieved knowledge, memory, and state management.
+
+The term emerged as the industry recognized that a well-structured context makes even a simple prompt produce excellent results, while a perfectly crafted prompt with poor context still produces poor results. The focus shifted from *how you ask* to *what information the model sees*.
+
+## How It Extends Prompt Engineering
+
+**Prompt engineering** focuses on crafting the input text — choosing the right words, structure, and examples to get better outputs from a model. It's an important skill, but it's one component of a larger system.
+
+**Context engineering** takes a holistic view of the entire context window. It treats all the elements that influence a model's behavior as interconnected components that need to be designed together:
+
+| Component | Prompt Engineering | Context Engineering |
+|-----------|-------------------|-------------------|
+| **Scope** | The text of the prompt itself | Everything the model sees: system prompt, instructions, user input, tools, retrieved data, memory, state |
+| **Focus** | Word choice, structure, examples | Architecture of the information environment |
+| **Optimization** | Iterate on prompt wording | Design how components work together |
+| **Persistence** | Per-conversation | Across sessions, users, and workflows |
+
+Prompt engineering is a subset of context engineering — an essential one, but not the whole picture.
+
+## The Components
+
+Context engineering orchestrates multiple components that together shape model behavior. Each maps to one or more [building blocks](../agentic-building-blocks/index.md):
+
+### System Prompts
+
+The foundational layer that establishes the AI's role, capabilities, and behavioral parameters. System prompts define *who the AI is* for a given workflow — its expertise, tone, boundaries, and default behaviors.
+
+Effective system prompts include role definition, behavioral guidelines, and capability boundaries. They can incorporate conditional behavior (adapting based on context), persona switching, and output formatting standards.
+
+**Building blocks:** [Prompts](../agentic-building-blocks/prompts/index.md), [Projects](../agentic-building-blocks/projects/index.md)
+
+### Instructions
+
+Specific guidance for how the AI handles different types of tasks. While system prompts set the overall character, instructions direct behavior for particular scenarios — analysis tasks, creative work, technical tasks, and more.
+
+Well-designed instructions include priority hierarchies (what takes precedence when guidance conflicts), escalation procedures (what to do when the AI can't complete a request), and dynamic adaptation (adjusting depth based on user responses).
+
+**Building blocks:** [Prompts](../agentic-building-blocks/prompts/index.md), [Skills](../agentic-building-blocks/skills/index.md)
+
+### User Input Processing
+
+How the system interprets and enriches what users provide. This includes intent recognition (identifying what the user actually wants), context extraction (pulling implicit information from messages), and ambiguity resolution (strategies for handling unclear requests).
+
+**Building blocks:** [Prompts](../agentic-building-blocks/prompts/index.md)
+
+### Structured Inputs and Outputs
+
+Defining precise formats for complex requests and responses. JSON schemas, templates, and metadata structures make interactions more predictable and consistent. On the output side, standardized formats and progressive disclosure (layered detail levels) improve usability.
+
+**Building blocks:** [Prompts](../agentic-building-blocks/prompts/index.md), [Skills](../agentic-building-blocks/skills/index.md)
+
+### Tools
+
+Integrations that extend AI capabilities beyond text generation. Context engineering considers which tools are available, how they're described to the model, and how their outputs are integrated back into the context. Tool categories include information retrieval, computation, communication, and content creation.
+
+**Building blocks:** [MCP](../agentic-building-blocks/mcp/index.md), [Agents](../agentic-building-blocks/agents/index.md)
+
+### RAG and Memory
+
+Systems for accessing external knowledge and maintaining information across interactions. **Retrieval-Augmented Generation (RAG)** — retrieving relevant documents from a database and injecting them into the prompt — is one approach. Memory systems add persistence: short-term memory within a conversation, and long-term memory across sessions.
+
+This includes decisions about what to retrieve, how to rank results, and what to remember versus forget.
+
+**Building blocks:** [Context](../agentic-building-blocks/context/index.md), [Projects](../agentic-building-blocks/projects/index.md)
+
+### State and Historical Context
+
+Tracking the current status of interactions and learning from past ones. Conversation state (current topic, goals, progress), user state (expertise level, preferences), and task state (completed steps, blockers) all shape how the AI responds.
+
+Historical context adds pattern recognition — identifying recurring themes, successful approaches, and seasonal patterns that inform future interactions.
+
+**Building blocks:** [Context](../agentic-building-blocks/context/index.md), [Projects](../agentic-building-blocks/projects/index.md), [Agents](../agentic-building-blocks/agents/index.md)
+
+## Why Context Engineering Matters
+
+Context engineering addresses what happens when AI moves from simple chat interactions to production systems:
+
+- **Consistency** — Designed context produces reliable, repeatable results across users and sessions
+- **Scalability** — Systems that assemble context programmatically scale in ways that manual prompt crafting cannot
+- **Maintainability** — Separating components (system prompt, instructions, tools, memory) makes systems easier to update and debug
+- **Quality ceiling** — The upper bound of AI output quality is set by the context, not the prompt. Better context engineering raises that ceiling.
+
+## Relationship to Context Graphs
+
+[Context graphs](../agentic-building-blocks/context/context-graphs.md) are a specific technique *within* context engineering. Where context engineering is the overall discipline of designing what the model sees, context graphs are a structured approach to organizing relationships, decisions, and reasoning chains in that context.
+
+Think of it this way: context engineering is the practice; context graphs are one of the more advanced tools in that practice.
+
+## Further Reading
+
+- [Context Engineering Guide](https://claude.ai/public/artifacts/f498a4cc-4c45-481c-a6dd-8e1d196dadb0) — comprehensive guide to context engineering components and techniques
+- [Effective Context Engineering for AI Agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) — Anthropic
+- [Context Engineering for Agents](https://blog.langchain.com/context-engineering-for-agents/) — LangChain
+- [Context is the Next Data Platform](https://www.glean.com/blog/context-data-platform) — Glean
+
+## Related
+
+- [AI Engineering](index.md) — the parent discipline
+- [Agentic Building Blocks](../agentic-building-blocks/index.md) — the six components context engineering operates on
+- [Prompts](../agentic-building-blocks/prompts/index.md) — the most fundamental building block, and a key component of context engineering
+- [Context](../agentic-building-blocks/context/index.md) — the data and knowledge component
+- [Context Graphs](../agentic-building-blocks/context/context-graphs.md) — structured reasoning graphs, an advanced technique within context engineering
+- [Patterns](../patterns/index.md) — reusable approaches across building blocks

--- a/docs/ai-engineering/index.md
+++ b/docs/ai-engineering/index.md
@@ -1,0 +1,34 @@
+---
+title: AI Engineering
+description: The emerging discipline of designing, building, and optimizing AI systems — from context engineering to evaluation and beyond
+---
+
+# AI Engineering
+
+> **Platforms:** `claude` `openai` `gemini` `m365-copilot`
+
+## What AI Engineering Is
+
+AI engineering is the discipline of designing, building, and optimizing systems that use AI models effectively. It goes beyond writing prompts — it's about architecting the entire information environment that shapes how AI behaves.
+
+The [Agentic Building Blocks](../agentic-building-blocks/index.md) describe *what* the components of an AI workflow are. AI engineering describes *how* to work with those components — the practices, techniques, and principles that make the difference between a demo and a production system.
+
+## Practices
+
+| Practice | What It Covers | Status |
+|----------|---------------|--------|
+| **[Context Engineering](context-engineering.md)** | Designing and optimizing the entire context window — system prompts, instructions, tools, memory, and state | Available |
+| **Evaluation** | Measuring AI system quality, building test suites, comparing outputs | Coming soon |
+| **Observability** | Monitoring AI systems in production — tracing, logging, debugging agent behavior | Coming soon |
+
+## How AI Engineering Relates to Building Blocks
+
+The building blocks are your vocabulary — prompts, context, projects, skills, agents, MCP. AI engineering is the craft of assembling them well.
+
+A useful analogy: the building blocks are like construction materials (wood, steel, glass). AI engineering is architecture and structural engineering — the discipline of designing with those materials so the result actually works.
+
+## Related
+
+- [Agentic Building Blocks](../agentic-building-blocks/index.md) — the six components that AI engineering practices operate on
+- [Patterns](../patterns/index.md) — reusable approaches across building blocks
+- [AI Use Cases](../use-cases/index.md) — what teams build with these practices, organized by six primitives

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -185,7 +185,9 @@ nav:
         - Resources: agentic-building-blocks/prompts/prompt-engineering/resources.md
       - Questions:
         - What is a system prompt?: agentic-building-blocks/prompts/questions/what-is-a-system-prompt.md
-    - Context: agentic-building-blocks/context/index.md
+    - Context:
+      - Overview: agentic-building-blocks/context/index.md
+      - Context Graphs: agentic-building-blocks/context/context-graphs.md
     - Projects:
       - Overview: agentic-building-blocks/projects/index.md
       - Project Instructions: agentic-building-blocks/projects/workspace-instructions-meta-prompt.md
@@ -198,6 +200,9 @@ nav:
       - Overview: agentic-building-blocks/agents/index.md
       - Resources: agentic-building-blocks/agents/resources.md
     - MCP: agentic-building-blocks/mcp/index.md
+  - AI Engineering:
+    - Overview: ai-engineering/index.md
+    - Context Engineering: ai-engineering/context-engineering.md
   - Use Cases:
     - Overview: use-cases/index.md
     - Content Creation: use-cases/content-creation.md


### PR DESCRIPTION
## Summary

- **Context Graphs page** (`docs/agentic-building-blocks/context/context-graphs.md`) — new sub-page under the Context building block covering structured decision and reasoning graphs for agentic AI, including comparison tables, key concepts, tools/frameworks, and curated further reading
- **AI Engineering section** (`docs/ai-engineering/`) — new top-level nav section between Building Blocks and Use Cases, with Context Engineering as the first practice page covering the discipline of designing the entire context window (system prompts, instructions, tools, memory, state)
- **Cross-links** added from Context Graphs, Prompts, and Building Blocks overview pages to connect the new content
- **Nav updates** — Context expanded to nested structure; AI Engineering section added to `mkdocs.yml`

## Test plan

- [x] `mkdocs build` succeeds (all warnings pre-existing)
- [ ] Visual check with `mkdocs serve` — Context nav expands correctly, AI Engineering section appears between Building Blocks and Use Cases
- [ ] Verify cross-links resolve from Context Graphs, Prompts, and Building Blocks pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)