### PR TITLE
Add 14 prompt engineering pattern pages

### DIFF
--- a/docs/agentic-building-blocks/prompts/prompt-engineering/chain-of-thought.md
+++ b/docs/agentic-building-blocks/prompts/prompt-engineering/chain-of-thought.md
@@ -1,0 +1,144 @@
+---
+title: Chain-of-Thought Prompting
+description: How to improve LLM reasoning by asking the model to show its work step by step before answering.
+---
+
+# Chain-of-Thought Prompting
+
+> **Platforms:** `claude` `openai` `gemini` `m365-copilot`
+
+## What It Is
+
+Chain-of-Thought (CoT) prompting asks the model to work through a problem step by step before giving a final answer. Instead of jumping straight to a conclusion, the model shows its reasoning — making it more likely to arrive at a correct answer and allowing you to verify the logic along the way.
+
+## Why It Works
+
+When an LLM (large language model) generates intermediate reasoning steps, each step provides context for the next. This breaks complex problems into simpler sub-problems the model can handle more reliably. Without CoT, the model attempts to compute the answer in a single forward pass — essentially trying to "think" the entire solution at once — which fails for multi-step reasoning tasks like math, logic, and comparative analysis.
+
+## When to Use It
+
+- Math and numerical reasoning
+- Multi-step logic problems
+- Comparing options with tradeoffs
+- Debugging and root cause analysis
+- Any task where the reasoning matters as much as the answer
+
+## The Pattern
+
+```text
+{Problem statement}
+
+Think through this step by step:
+1. First, {identify/analyze the key elements}
+2. Then, {work through the logic}
+3. Finally, {arrive at your conclusion}
+
+Show your reasoning before giving your final answer.
+```
+
+**Zero-Shot CoT variation** — just append this to any prompt:
+
+```text
+Let's think step by step.
+```
+
+This simple addition can dramatically improve reasoning performance without any examples (Kojima et al. 2022).
+
+**Filled-in example:**
+
+```text
+A company has 150 employees. 40% are remote, 30% are hybrid, and the rest
+are in-office. Hybrid workers share desks at a 3:1 ratio (3 hybrid workers
+per desk). How many desks does the office need?
+
+Think through this step by step. Show your reasoning before giving your
+final answer.
+```
+
+## Examples in Practice
+
+### Business decision
+
+**Context:** Your team is evaluating CRM vendors and needs a structured comparison that accounts for multiple constraints.
+
+```text
+We're choosing between three vendors for our CRM migration:
+- Vendor A: $50K cost, 6-month timeline
+- Vendor B: $35K cost, 12-month timeline
+- Vendor C: $45K cost, 4-month timeline
+
+Our current CRM contract expires in 8 months. We have a $48K budget.
+
+Think through the tradeoffs step by step, considering cost, timeline risk,
+and transition complexity. Then recommend the best option with your reasoning.
+```
+
+**Why this works:** It forces the model to weigh multiple factors systematically rather than jumping to the cheapest or fastest option.
+
+### Debugging
+
+**Context:** Your engineering team noticed a performance regression after a deployment and needs to narrow down the cause.
+
+```text
+Our API response times increased from 200ms to 800ms after last week's
+deployment. The deployment included: a database schema migration, an upgrade
+to the authentication library, and a new logging middleware.
+
+Walk through potential causes step by step, starting with the most likely.
+For each cause, explain how we could verify or rule it out.
+```
+
+**Why this works:** Debugging requires sequential elimination of hypotheses. CoT prevents the model from fixating on one cause and ignoring others.
+
+### Math with multiple calculations
+
+**Context:** You need to calculate office space requirements based on employee work patterns.
+
+```text
+A company has 150 employees. 40% are remote, 30% are hybrid, and the rest
+are in-office. Hybrid workers share desks at a 3:1 ratio (3 hybrid workers
+per 1 desk). In-office workers each need their own desk.
+
+How many desks does the office need? Show your work.
+```
+
+**Why this works:** The model needs to track multiple calculations — percentages, different desk ratios for different groups, then a final total. Showing work prevents arithmetic errors that commonly occur when the model tries to compute everything at once.
+
+!!! tip "Platform tip"
+
+    Claude's extended thinking mode is essentially automated Chain-of-Thought — the model reasons internally before responding. OpenAI's o1/o3 model family does this natively. Enable these features when tackling complex reasoning tasks, especially math and multi-step analysis.
+
+## Common Pitfalls
+
+!!! warning "Using CoT for simple tasks"
+
+    **Problem:** "What is the capital of France? Let's think step by step." wastes tokens and adds no value. CoT is overhead for tasks that don't involve multi-step reasoning.
+
+    **Fix:** Reserve CoT for problems that actually require working through multiple steps — math, comparisons, debugging, planning. For simple factual questions, use [zero-shot prompting](zero-shot-prompting.md).
+
+!!! warning "Not verifying the reasoning"
+
+    **Problem:** The model's intermediate steps can look logical and well-structured but still contain errors — especially in arithmetic or when applying domain-specific rules.
+
+    **Fix:** Read the intermediate steps, not just the final answer. If the reasoning is wrong at step 2, the final answer will be wrong too. This is the whole point of CoT: it makes errors visible and auditable.
+
+!!! warning "Confusing CoT with Self-Consistency"
+
+    **Problem:** A single CoT trace shows one reasoning path. If that path happens to go wrong, you get a confidently wrong answer. Self-Consistency (Wang et al. 2022) is a separate technique that samples multiple reasoning paths and takes the majority answer.
+
+    **Fix:** For high-stakes decisions, consider asking the model for multiple approaches: "Solve this problem using two different methods, then compare your answers." See [Self-Consistency and Reflection](self-consistency-and-reflection.md).
+
+## Related Techniques
+
+- [Zero-Shot Prompting](zero-shot-prompting.md) — Zero-Shot CoT ("Let's think step by step") bridges these two techniques
+- [Self-Consistency and Reflection](self-consistency-and-reflection.md) — sample multiple reasoning paths for higher accuracy
+- [Direct Instruction](direct-instruction.md) — combine with CoT by explicitly specifying the reasoning steps
+- [Prompt Engineering Overview](index.md)
+- [Research use case](../../../use-cases/research.md)
+
+## Further Reading
+
+- Wei et al. 2022 — *Chain-of-Thought Prompting Elicits Reasoning in Large Language Models* — [arxiv.org/abs/2201.11903](https://arxiv.org/abs/2201.11903)
+- Kojima et al. 2022 — *Large Language Models are Zero-Shot Reasoners* — [arxiv.org/abs/2205.11916](https://arxiv.org/abs/2205.11916)
+- Wang et al. 2022 — *Self-Consistency Improves Chain of Thought Reasoning in Language Models* — [arxiv.org/abs/2203.11171](https://arxiv.org/abs/2203.11171)
+- Yao et al. 2023 — *Tree of Thoughts: Deliberate Problem Solving with Large Language Models* — [arxiv.org/abs/2305.10601](https://arxiv.org/abs/2305.10601)

--- a/docs/agentic-building-blocks/prompts/prompt-engineering/contextual-prompting.md
+++ b/docs/agentic-building-blocks/prompts/prompt-engineering/contextual-prompting.md
@@ -1,0 +1,141 @@
+---
+title: Contextual Prompting
+description: How to provide relevant background information in your prompt so the model gives specific, tailored responses instead of generic advice.
+---
+
+# Contextual Prompting
+
+> **Platforms:** `claude` `openai` `gemini` `m365-copilot`
+
+!!! info "Contextual Prompting vs. the Context Building Block"
+
+    This page covers **contextual prompting** — the technique of including relevant information *within your prompt text*. This is different from the broader [Context building block](../../context/index.md), which covers attaching files, knowledge bases, system prompts, and other external context sources. Think of contextual prompting as one way to provide context; the Context building block covers all the ways.
+
+## What It Is
+
+Contextual prompting means providing relevant background information directly in your prompt so the model can give informed, specific responses. Instead of asking a generic question, you embed the who, what, where, when, and why that shape the right answer. The result is output tailored to your exact situation rather than one-size-fits-all advice.
+
+## Why It Works
+
+LLMs (large language models) don't have access to your specific situation — your company, your audience, your constraints, your data. Context fills that gap. When you provide relevant details, the model can tailor its output to your exact needs. Without context, the model defaults to the most common interpretation of your request, which is rarely the one you actually want.
+
+## When to Use It
+
+- Domain-specific tasks where generic answers won't work
+- When the model needs to know your audience, industry, or constraints
+- Personalizing output to a specific situation
+- When you have relevant data the model should factor into its response
+
+## The Pattern
+
+```text
+Context:
+- {Who: role, audience, stakeholders}
+- {What: topic, product, situation}
+- {Constraints: budget, timeline, regulations}
+- {Goal: what success looks like}
+
+Task: {What you need the model to do}
+```
+
+**Filled-in example:**
+
+```text
+Context:
+- I'm a marketing manager at a B2B SaaS company selling project management software
+- Target audience: mid-size construction firms (50-200 employees)
+- Monthly content budget: $5,000
+- Goal: increase organic search traffic by 30% over 3 months
+
+Task: Create a 3-month content calendar focused on SEO-driven blog posts
+that address pain points specific to construction project management.
+```
+
+## Examples in Practice
+
+### Industry-specific advice
+
+**Context:** You run a small dental practice and need software recommendations that account for your staff's technical comfort level and your budget.
+
+```text
+Context:
+- I run a 15-person dental practice in suburban Austin, TX
+- We currently use paper scheduling and want to go digital
+- Staff are mostly non-technical (ages 35-55)
+- Budget: under $500/month
+- Must integrate with our existing billing system (Dentrix)
+
+Task: Recommend 3 scheduling software options with pros and cons
+for my specific situation. Prioritize ease of use and Dentrix integration.
+```
+
+**Why this works:** The constraints — staff technical level, budget ceiling, specific billing system — eliminate generic recommendations and force the model to give advice that actually applies.
+
+### Audience-aware content
+
+**Context:** You're writing for a specialized academic audience that expects a specific register and evidence standard.
+
+```text
+Context:
+- Writing for a medical journal audience (physicians and researchers)
+- Topic: the impact of AI on diagnostic radiology
+- Readers expect evidence-based claims with citations
+- Journal word limit for abstracts: 300 words
+
+Task: Write a 300-word abstract covering current applications,
+limitations, and future directions of AI in diagnostic radiology.
+Use formal academic tone throughout.
+```
+
+**Why this works:** Specifying the audience (physicians and researchers), the evidence standard (evidence-based with citations), and the format (300-word abstract) sets the register, depth, and structure the model should target.
+
+### Data-informed analysis
+
+**Context:** You have specific business metrics and need the model to analyze a trend rather than speculate.
+
+```text
+Context:
+- Our Q3 revenue was $2.1M (up 15% from Q2)
+- Customer churn increased from 3.2% to 4.8% during Q3
+- We launched a new pricing tier in July
+- Support tickets related to billing increased 40% since the new tier launch
+- No changes to product features during this period
+
+Task: Analyze the likely causes of the churn increase and suggest
+3 specific actions we can take in Q4 to reverse the trend.
+```
+
+**Why this works:** The data points — revenue growth alongside churn increase, billing ticket spike correlating with pricing change — create a foundation for specific analysis. Without this data, the model would produce generic churn reduction advice.
+
+## Common Pitfalls
+
+!!! warning "Irrelevant context overload"
+
+    **Problem:** Including your entire company history, org chart, and mission statement when asking about a specific email. Too much context dilutes the signal and wastes tokens.
+
+    **Fix:** Include only the context that directly affects the output. Ask yourself: "If I removed this detail, would the answer change?" If not, leave it out.
+
+!!! warning "Missing key constraints"
+
+    **Problem:** Asking for a marketing plan without mentioning budget, timeline, team size, or target audience. The model fills in assumptions that may not match your reality.
+
+    **Fix:** Always include constraints that would change the recommendation. Budget, timeline, audience, and existing tools/systems are almost always relevant.
+
+!!! warning "Assuming shared knowledge"
+
+    **Problem:** Using internal jargon, acronyms, or referencing processes without defining them. "Optimize our CSAT flow for the T2 queue" means nothing to the model without definitions.
+
+    **Fix:** Spell out anything the model hasn't been told about. Define acronyms on first use, describe internal processes briefly, and name specific tools rather than assuming the model knows your stack.
+
+## Related Techniques
+
+- [Context building block](../../context/index.md) — the comprehensive guide to all forms of context (files, knowledge bases, system prompts, and more)
+- [Role Prompting](role-prompting.md) — set the model's perspective as a form of context
+- [Direct Instruction](direct-instruction.md) — combine clear commands with rich context for the best results
+- [Prompt Engineering Overview](index.md)
+- [Research use case](../../../use-cases/research.md)
+
+## Further Reading
+
+- Dong et al. 2022 — *A Survey on In-context Learning* — [arxiv.org/abs/2301.00234](https://arxiv.org/abs/2301.00234)
+- Lewis et al. 2020 — *Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks* — [arxiv.org/abs/2005.11401](https://arxiv.org/abs/2005.11401)

--- a/docs/agentic-building-blocks/prompts/prompt-engineering/direct-instruction.md
+++ b/docs/agentic-building-blocks/prompts/prompt-engineering/direct-instruction.md
@@ -1,0 +1,119 @@
+---
+title: Direct Instruction
+description: How to write clear, explicit commands that tell the model exactly what to do, minimizing ambiguity and guesswork.
+---
+
+# Direct Instruction
+
+> **Platforms:** `claude` `openai` `gemini` `m365-copilot`
+
+## What It Is
+
+Direct instruction means giving the model clear, explicit commands in imperative language. Instead of hinting at what you want ("It would be nice if...") or asking open-ended questions, you tell the model exactly what to do: "Write a...", "List the...", "Analyze the...". This is the foundation of effective prompting — a baseline technique that improves every other pattern.
+
+## Why It Works
+
+Modern LLMs (large language models) are specifically trained to follow instructions through a process called instruction tuning and RLHF (Reinforcement Learning from Human Feedback). Direct, unambiguous commands align perfectly with this training. The more explicit your instruction, the less the model has to guess about what you want — and guessing is where errors, hallucinations, and off-target responses happen.
+
+## When to Use It
+
+- Every prompt (this is a baseline technique, not situational)
+- When [zero-shot](zero-shot-prompting.md) results are close but not quite right
+- When you need precise control over what the model does and doesn't do
+- When working with others who will reuse your prompts
+
+## The Pattern
+
+```text
+{Action verb} {specific task}.
+{Constraints: length, format, audience, tone}.
+{What to include or exclude}.
+```
+
+**Filled-in example:**
+
+```text
+Write a 150-word product description for a wireless Bluetooth speaker.
+Target audience: tech-savvy millennials.
+Tone: casual and enthusiastic.
+Include: battery life, water resistance, sound quality.
+Exclude: technical specifications and pricing.
+```
+
+## Examples in Practice
+
+### Structured risk assessment
+
+**Context:** You need a concise risk analysis for a cloud migration proposal that your team can review quickly.
+
+```text
+List the top 5 risks of migrating from on-premise to cloud infrastructure.
+For each risk, provide:
+- A one-sentence description
+- Likelihood (high/medium/low)
+- One mitigation strategy
+
+Format as a numbered list.
+```
+
+**Why this works:** Every aspect of the output is specified — the number of items, the structure of each item, and the format. The model has no room to deviate.
+
+### Readability rewrite
+
+**Context:** You're adapting a technical report for a general-audience newsletter and need to lower the reading level.
+
+```text
+Rewrite the following paragraph for a 9th-grade reading level. Keep the
+same meaning but simplify vocabulary and shorten sentences. Do not add
+new information.
+
+[paste paragraph here]
+```
+
+**Why this works:** The constraints are explicit and measurable — reading level, meaning preservation, no additions. The "Do not add new information" instruction prevents the model from elaborating.
+
+### Constrained comparison
+
+**Context:** Your engineering team is choosing between two databases and needs a focused comparison, not a general overview.
+
+```text
+Compare PostgreSQL and MongoDB for a real-time analytics workload processing
+10,000 events per second. Focus only on: write throughput, query flexibility,
+and operational complexity. Respond in a two-column table.
+```
+
+**Why this works:** The comparison dimensions are locked down to three specific criteria, the workload is quantified, and the output format is specified. This prevents the model from producing a generic "pros and cons" list.
+
+## Common Pitfalls
+
+!!! warning "Polite hedging"
+
+    **Problem:** "Could you maybe write something about..." or "I was wondering if you might be able to..." gives the model too much latitude. Hedging language signals uncertainty, and the model may mirror that uncertainty in its output.
+
+    **Fix:** Use imperative verbs — "Write", "List", "Analyze", "Compare", "Summarize". You can still be polite, but lead with the action: "Please write a 200-word summary of..."
+
+!!! warning "Contradictory instructions"
+
+    **Problem:** "Be concise. Include all details." creates tension that the model resolves unpredictably. Similarly, "Write a short, comprehensive overview" sends mixed signals.
+
+    **Fix:** Prioritize when constraints conflict — "Be concise. Prioritize the three most important details and omit the rest." Make trade-offs explicit so the model doesn't have to guess your preference.
+
+!!! warning "Missing constraints"
+
+    **Problem:** "Write an email" without specifying length, tone, or audience produces generic output that rarely matches what you actually need.
+
+    **Fix:** Include at least three constraints: **audience** (who will read this), **tone** (formal, casual, persuasive), and **length** (word count or "keep it to 2-3 paragraphs"). Add format and content constraints as needed.
+
+## Related Techniques
+
+- [Zero-Shot Prompting](zero-shot-prompting.md) — direct instruction makes zero-shot prompts sharper
+- [Output Formatting](output-formatting.md) — specify exactly how the model should structure its response
+- [Contextual Prompting](contextual-prompting.md) — combine with context for domain-specific direct instructions
+- [Prompt Engineering Overview](index.md)
+- [Content Creation use case](../../../use-cases/content-creation.md)
+
+## Further Reading
+
+- Ouyang et al. 2022 — *Training Language Models to Follow Instructions with Human Feedback* — [arxiv.org/abs/2203.02155](https://arxiv.org/abs/2203.02155)
+- Wei et al. 2021 — *Finetuned Language Models Are Zero-Shot Learners (FLAN)* — [arxiv.org/abs/2109.01652](https://arxiv.org/abs/2109.01652)
+- Zhang et al. 2023 — *Instruction Tuning for Large Language Models: A Survey* — [arxiv.org/abs/2308.10792](https://arxiv.org/abs/2308.10792)

--- a/docs/agentic-building-blocks/prompts/prompt-engineering/emotional-prompting.md
+++ b/docs/agentic-building-blocks/prompts/prompt-engineering/emotional-prompting.md
@@ -1,0 +1,122 @@
+---
+title: Emotional Prompting
+description: Add motivational or stakes-based language to prompts to encourage the model to produce more thorough and engaged responses.
+---
+
+# Emotional Prompting
+
+> **Platforms:** `claude` `openai` `gemini` `m365-copilot`
+
+## What It Is
+
+Emotional prompting means adding motivational, stakes-based, or emotionally charged language to your prompts to encourage the model to produce more thorough and engaged responses. Instead of a neutral request, you convey *why* the task matters or what is at stake. The goal is to signal importance in a way that shifts the model's output toward greater care and completeness.
+
+## Why It Works
+
+The EmotionPrompt paper (Li et al. 2023) showed that adding emotional stimuli to prompts improved LLM (large language model) performance by over 10% on several benchmarks. The likely mechanism is that emotional language activates patterns from training data where humans wrote more carefully — important emails, critical reports, heartfelt communications. Models trained via RLHF (reinforcement learning from human feedback) may also associate high-stakes framing with the kind of careful, thorough responses that human raters rewarded during training. However, this effect varies by model and task — it works more consistently on generative tasks than on factual retrieval.
+
+## When to Use It
+
+- Tasks where thoroughness and effort matter more than speed
+- Creative writing where engagement affects quality
+- When you notice the model giving generic or low-effort responses
+- High-stakes outputs that need extra care and attention to detail
+- Review and analysis tasks where missing something has consequences
+
+**Do NOT use it for:**
+
+- Simple factual queries (e.g., "What is the capital of France?")
+- When precision matters more than thoroughness — emotional framing may introduce bias
+- As a substitute for clear instructions — stakes language supplements good prompts, it doesn't replace them
+
+## The Pattern
+
+```text
+{Task description}
+
+{Emotional stake or motivation}
+```
+
+**Filled-in example:**
+
+```text
+Review this database migration script for potential data loss issues.
+
+This migration runs against our production database with 3 years of customer data.
+If anything goes wrong, we could lose records that are impossible to recreate.
+Check every operation carefully.
+```
+
+## Examples in Practice
+
+### Example 1 — Job application
+
+**Context:** You're applying for a competitive role and need the cover letter to stand out.
+
+```text
+Write a cover letter for this job application. Here is my resume: [resume text]
+Here is the job posting: [job posting text]
+
+This is for my dream job at a company I've admired for years — the letter needs to
+stand out from hundreds of applicants. Make every sentence count.
+```
+
+**Why this works:** The personal stakes encourage the model to be more thoughtful and deliberate, avoiding generic filler and focusing on differentiation.
+
+### Example 2 — Contract review
+
+**Context:** You need a thorough review of a legal clause before signing a major deal.
+
+```text
+Review this contract clause for potential risks:
+
+[paste contract clause here]
+
+This is a $2M deal and my client is counting on me to catch anything that could
+hurt them. Be thorough and flag even minor concerns that could become problems
+down the line.
+```
+
+**Why this works:** The financial stakes and responsibility framing promote careful, exhaustive analysis rather than a surface-level summary.
+
+### Example 3 — Code debugging
+
+**Context:** A payroll function needs to be bulletproof because errors affect real people.
+
+```text
+Debug this Python function that calculates payroll:
+
+[paste function here]
+
+This runs for 500 employees every two weeks and any error means people get paid
+incorrectly. Check every edge case — overtime calculations, rounding, tax
+brackets, part-time vs. full-time distinctions.
+```
+
+**Why this works:** The real-world consequences (people being paid incorrectly) encourage exhaustive edge-case checking that a neutral prompt might not elicit.
+
+## Common Pitfalls
+
+!!! warning "Overuse dilutes impact"
+    **Problem:** Adding emotional stakes to every prompt makes none of them feel important — the model (and you) become desensitized to the framing.
+    **Fix:** Reserve emotional prompting for tasks that genuinely need extra care. If everything is "critical" and "high-stakes," nothing is.
+
+!!! warning "Emotional manipulation over clarity"
+    **Problem:** Relying on emotional language instead of clear instructions. "This is really important, please do a good job" doesn't tell the model *what* to do well.
+    **Fix:** Write clear, specific instructions first, then add stakes framing. Emotional prompting supplements a well-structured prompt — it doesn't replace one.
+
+!!! warning "Results vary by model"
+    **Problem:** The EmotionPrompt results were on specific benchmarks with specific models. The effect size may differ with different models, tasks, and prompt formulations.
+    **Fix:** Test with and without emotional framing on your specific use case. If the output quality is the same either way, the technique isn't adding value for that task.
+
+## Related Techniques
+
+- [Role Prompting](role-prompting.md) — assign a persona whose role implies high stakes
+- [Direct Instruction](direct-instruction.md) — be explicit about what thoroughness means for your task
+- [Contextual Prompting](contextual-prompting.md) — provide background that naturally conveys importance
+- [Prompt Engineering Overview](index.md)
+- [Content Creation use case](../../../use-cases/content-creation.md) — emotional prompting is particularly effective for creative and communication tasks
+
+## Further Reading
+
+- Li et al. 2023 — *EmotionPrompt: Leveraging Psychology for Large Language Models Enhancement via Emotional Stimulus* — [arxiv.org/abs/2307.11760](https://arxiv.org/abs/2307.11760)

--- a/docs/agentic-building-blocks/prompts/prompt-engineering/few-shot-learning.md
+++ b/docs/agentic-building-blocks/prompts/prompt-engineering/few-shot-learning.md
@@ -1,0 +1,181 @@
+---
+title: Few-Shot Learning
+description: How to teach an LLM new patterns by providing a few examples directly in your prompt.
+---
+
+# Few-Shot Learning
+
+> **Platforms:** `claude` `openai` `gemini` `m365-copilot`
+
+## What It Is
+
+Few-shot learning means providing the model with a few examples of the task before asking it to perform on new input. The model learns the pattern from your demonstrations — the format, tone, reasoning approach, or classification rules — and applies it to the input you actually care about. This technique is sometimes called "in-context learning."
+
+## Why It Works
+
+LLMs (large language models) perform in-context learning: they recognize patterns in the examples you provide and apply those patterns to new inputs. This works because the model's core training objective is to predict the next token in a sequence, so it naturally continues patterns it sees. Your examples effectively "program" the model's behavior for the current conversation without any fine-tuning.
+
+## When to Use It
+
+- Custom output formats the model wouldn't produce naturally
+- Classification tasks with your own categories or taxonomy
+- Matching a specific tone or writing style
+- Tasks where showing is easier than describing
+- When [zero-shot prompting](zero-shot-prompting.md) produces the right idea but the wrong format
+
+## The Pattern
+
+```text
+{Task description}
+
+Example 1:
+Input: {example input 1}
+Output: {example output 1}
+
+Example 2:
+Input: {example input 2}
+Output: {example output 2}
+
+Example 3:
+Input: {example input 3}
+Output: {example output 3}
+
+Now:
+Input: {actual input}
+Output:
+```
+
+**Filled-in example:**
+
+```text
+Classify each customer review using NPS-style labels: Promoter, Passive, or Detractor.
+
+Example 1:
+Input: "Absolutely love this product, already recommended it to three friends!"
+Output: Promoter
+
+Example 2:
+Input: "It works fine, nothing special."
+Output: Passive
+
+Example 3:
+Input: "Broke after two weeks. Waste of money."
+Output: Detractor
+
+Now:
+Input: "Good quality but shipping took forever. Might order again if delivery improves."
+Output:
+```
+
+## Examples in Practice
+
+### Sentiment classification with custom labels
+
+**Context:** Your team uses NPS-style categories (Promoter, Passive, Detractor) instead of the generic positive/negative/neutral labels most models default to.
+
+```text
+Classify each customer review using our NPS labels: Promoter, Passive, or Detractor.
+
+Example 1:
+Input: "Best purchase I've made all year. 10/10 would buy again."
+Output: Promoter
+
+Example 2:
+Input: "Does what it says. Nothing more, nothing less."
+Output: Passive
+
+Example 3:
+Input: "Customer support was unhelpful and the product is mediocre."
+Output: Detractor
+
+Now:
+Input: "The interface is confusing but once you learn it, the features are solid."
+Output:
+```
+
+**Why this works:** The examples define a custom taxonomy the model wouldn't use by default, and they show the boundary between categories through demonstration.
+
+### Data extraction to structured format
+
+**Context:** You receive unstructured emails and need to extract contact details into a consistent JSON format for your CRM.
+
+```text
+Extract the contact information from the text and return it as JSON.
+
+Example 1:
+Input: "Hey, this is Mike Chen from Acuity Labs. Reach me at mike@acuitylabs.io"
+Output: {"name": "Mike Chen", "email": "mike@acuitylabs.io", "company": "Acuity Labs"}
+
+Example 2:
+Input: "Sarah Lopez, Director of Ops at Bridgewell Inc — sarah.lopez@bridgewell.com"
+Output: {"name": "Sarah Lopez", "email": "sarah.lopez@bridgewell.com", "company": "Bridgewell Inc"}
+
+Example 3:
+Input: "Contact: James Rivera (james@deltaforge.co), he's with DeltaForge"
+Output: {"name": "James Rivera", "email": "james@deltaforge.co", "company": "DeltaForge"}
+
+Now:
+Input: "Got a referral from Priya Patel at Nimbus Health — her email is priya.p@nimbushealth.org"
+Output:
+```
+
+**Why this works:** The examples define the exact JSON structure, field names, and formatting conventions you need, removing all ambiguity about the output format.
+
+### Tone matching
+
+**Context:** You need to rewrite formal documentation into casual Slack messages for your team.
+
+```text
+Rewrite the formal text as a casual Slack message.
+
+Example 1:
+Input: "Please be advised that the server maintenance window has been scheduled for Saturday, March 15th, from 02:00 to 06:00 UTC."
+Output: "Heads up — servers will be down Saturday 3/15 from 2-6am UTC for maintenance"
+
+Example 2:
+Input: "We would like to inform all stakeholders that the Q2 budget review meeting has been rescheduled to Thursday at 14:00."
+Output: "Q2 budget review got moved to Thursday at 2pm — see you there"
+
+Example 3:
+Input: "It has come to our attention that several team members have not completed the mandatory security training module."
+Output: "Friendly nudge: a few folks still need to finish the security training. Please knock it out when you get a chance"
+
+Now:
+Input: "We are pleased to announce that the organization has successfully achieved SOC 2 Type II compliance certification."
+Output:
+```
+
+**Why this works:** Tone and style are notoriously hard to describe in words but easy to demonstrate through examples. The model picks up on the pattern of shortening, de-formalizing, and adding conversational markers.
+
+## Common Pitfalls
+
+!!! warning "Too few or too many examples"
+
+    **Problem:** One example isn't enough to establish a reliable pattern. Ten or more examples waste tokens and can confuse the model.
+
+    **Fix:** Three to five examples is the sweet spot for most tasks. Use the minimum number that consistently produces the output format you want.
+
+!!! warning "Example order effects"
+
+    **Problem:** Research shows that the order of examples affects output quality. The model pays more attention to examples near the end of the sequence.
+
+    **Fix:** Put your most representative example last (closest to the actual input). If results seem biased toward one category, vary the order and check whether outputs change.
+
+!!! warning "Inconsistent examples"
+
+    **Problem:** Examples that contradict each other or use different formats confuse the model and produce unreliable output.
+
+    **Fix:** Ensure all examples follow the exact same format, use the same field names, and apply the same logic. Review your examples as a set before including them.
+
+## Related Techniques
+
+- [Zero-Shot Prompting](zero-shot-prompting.md) — try this first when you don't need examples
+- [Chain-of-Thought](chain-of-thought.md) — add reasoning steps to your examples for complex tasks
+- [Output Formatting](output-formatting.md) — other ways to control the shape of model output
+- [Prompt Engineering Overview](index.md)
+- [Data Analysis use case](../../../use-cases/data-analysis.md)
+
+## Further Reading
+
+- Brown et al. 2020 — *Language Models are Few-Shot Learners* — [arxiv.org/abs/2005.14165](https://arxiv.org/abs/2005.14165)
+- Dong et al. 2022 — *A Survey on In-context Learning* — [arxiv.org/abs/2301.00234](https://arxiv.org/abs/2301.00234)

--- a/docs/agentic-building-blocks/prompts/prompt-engineering/index.md
+++ b/docs/agentic-building-blocks/prompts/prompt-engineering/index.md
@@ -1,34 +1,82 @@
 ---
 title: Prompt Engineering
-description: Core prompting concepts — context windows, system prompts, few-shot learning, and chain-of-thought
+description: A practical guide to 14 prompt engineering techniques — patterns you can apply immediately to get better results from any AI platform
 ---
 
 # Prompt Engineering
 
-Concepts and techniques for effective prompting.
+Prompt engineering is the practice of structuring your input to an AI model so that it produces the output you actually need. It is not about memorizing magic phrases — it is about understanding how models interpret instructions and providing the right context, structure, and constraints to guide their responses.
 
-## Topics
+These techniques work across all major AI platforms (Claude, ChatGPT, Gemini, Copilot) because they address how large language models process language, not platform-specific features.
 
-*Topics will be listed here as they are added.*
+## Core Principles
 
-<!-- Example format:
-- [Context Windows](./context-windows.md)
-- [System Prompts](./system-prompts.md)
-- [Few-Shot Learning](./few-shot-learning.md)
-- [Chain of Thought](./chain-of-thought.md)
--->
+Before diving into specific techniques, these principles apply to all prompt engineering:
 
-## Key Concepts
+1. **Be specific** — Vague prompts produce vague outputs. Say exactly what you want.
+2. **Provide context** — The model only knows what you tell it. Include relevant background.
+3. **Show, don't just tell** — Examples are more powerful than descriptions of what you want.
+4. **Structure your output** — Tell the model what format you need (bullets, table, JSON, etc.).
+5. **Constrain the scope** — Boundaries improve quality. Set word limits, define the audience, specify what to exclude.
+6. **Iterate** — Your first prompt is a draft. Refine based on what comes back.
+7. **Break complex tasks down** — One clear instruction per prompt beats a wall of requirements.
+8. **Match the technique to the task** — Not every technique suits every situation. Choose based on what you need.
 
-- **Context Windows** - Understanding token limits and context management
-- **System Prompts** - Setting behavior and constraints
-- **Few-Shot Learning** - Teaching through examples
-- **Chain of Thought** - Reasoning step by step
-- **Output Formatting** - Controlling response structure
-- **Prompt Injection** - Security considerations
+## Technique Catalog
+
+### Foundational Techniques
+
+These are the building blocks — techniques you will use daily.
+
+| Technique | What It Does | Best For |
+|-----------|-------------|----------|
+| [Zero-Shot Prompting](zero-shot-prompting.md) | Ask the model to perform a task with no examples | Simple, well-defined tasks |
+| [Few-Shot Learning](few-shot-learning.md) | Provide examples so the model learns the pattern | Custom formats, tone matching, classification |
+| [Chain-of-Thought](chain-of-thought.md) | Ask the model to reason step by step | Math, logic, analysis, complex decisions |
+| [Direct Instruction](direct-instruction.md) | Give explicit, imperative commands | Any task where clarity matters |
+
+### Shaping Techniques
+
+These techniques control *how* the model approaches your task.
+
+| Technique | What It Does | Best For |
+|-----------|-------------|----------|
+| [Contextual Prompting](contextual-prompting.md) | Embed background information in the prompt | Domain-specific tasks, personalized output |
+| [Role Prompting](role-prompting.md) | Assign the model a persona or expertise | Specialized knowledge, audience-appropriate tone |
+| [Output Formatting](output-formatting.md) | Specify the structure and format of the response | Reports, data extraction, structured content |
+| [Multi-Turn Conversation](multi-turn-conversation.md) | Build on previous exchanges to refine results | Exploration, iterative refinement, complex projects |
+
+### Quality Techniques
+
+These techniques improve the reliability and depth of outputs.
+
+| Technique | What It Does | Best For |
+|-----------|-------------|----------|
+| [Self-Consistency and Reflection](self-consistency-and-reflection.md) | Ask the model to check and critique its own work | High-stakes decisions, error reduction |
+| [Emotional Prompting](emotional-prompting.md) | Add motivational or stakes-based language | Tasks where engagement and effort matter |
+| [Reframing Prompts](reframing-prompts.md) | Rephrase a question to approach it differently | When initial prompts give poor results |
+
+### Specialized Techniques
+
+These techniques solve specific types of problems.
+
+| Technique | What It Does | Best For |
+|-----------|-------------|----------|
+| [Style Unbundling](style-unbundling.md) | Decompose a writing style into separate attributes | Matching a specific voice or tone |
+| [Summarization and Distillation](summarization-and-distillation.md) | Compress or restructure information | Long documents, research synthesis |
+| [Real-World Constraints](real-world-constraints.md) | Embed business rules and practical limits into prompts | Feasible plans, budget-aware output |
+
+## Where to Start
+
+**New to prompting?** Start with [Zero-Shot Prompting](zero-shot-prompting.md) and [Direct Instruction](direct-instruction.md) — these two techniques cover most everyday tasks.
+
+**Want better results?** Add [Few-Shot Learning](few-shot-learning.md) to teach the model your preferred format, then use [Chain-of-Thought](chain-of-thought.md) for anything requiring reasoning.
+
+**Working on something complex?** Combine techniques — for example, use [Role Prompting](role-prompting.md) + [Contextual Prompting](contextual-prompting.md) + [Output Formatting](output-formatting.md) to get expert-level, structured responses grounded in your specific domain.
 
 ## Related
 
-- [Prompts](../index.md)
-- [Agentic Building Blocks](../../index.md)
-- [Patterns](../../../patterns/index.md)
+- [Prompts](../index.md) — The Prompts building block overview
+- [Resources](resources.md) — Academic papers and platform documentation
+- [Patterns](../../../patterns/index.md) — Reusable AI patterns and best practices
+- [Use Cases](../../../use-cases/index.md) — See these techniques applied to real tasks

--- a/docs/agentic-building-blocks/prompts/prompt-engineering/multi-turn-conversation.md
+++ b/docs/agentic-building-blocks/prompts/prompt-engineering/multi-turn-conversation.md
@@ -1,0 +1,142 @@
+---
+title: Multi-Turn Conversation
+description: Use iterative back-and-forth exchanges to progressively build, refine, and improve model output through dialogue.
+---
+
+# Multi-Turn Conversation
+
+> **Platforms:** `claude` `openai` `gemini` `m365-copilot`
+
+## What It Is
+
+Multi-turn conversation means using a series of back-and-forth exchanges to iteratively build, refine, and improve the model's output. Instead of crafting one perfect prompt, you have a conversation — starting broad, then narrowing in on what you need through follow-up messages. This mirrors how human collaboration works: through dialogue, not monologue.
+
+## Why It Works
+
+Each turn adds to the conversation context, allowing you to build on previous responses, correct course, and progressively refine the output. The LLM (large language model) sees the entire conversation history and can adjust based on your feedback. This is especially powerful for tasks where you don't know exactly what "good" looks like until you start seeing output — the conversation itself becomes a discovery process.
+
+## When to Use It
+
+- Complex tasks that benefit from iterative refinement
+- Exploratory work where you don't know the exact output upfront
+- When you want to guide the model through a multi-step process
+- Creative work where direction emerges through collaboration
+- Tasks that are too large or nuanced for a single prompt
+
+## The Pattern
+
+```text
+Turn 1: {High-level request or exploration}
+Turn 2: {Refine based on the response — zoom in, redirect, or expand}
+Turn 3: {Further refinement or specific adjustments}
+Turn N: {Final polish or specific modifications}
+```
+
+Conversation forking (for exploring alternatives):
+
+```text
+"Let's pause here. I want to explore a different direction.
+Going back to your {earlier suggestion}, what if we {alternative approach}?"
+```
+
+**Filled-in example:**
+
+```text
+Turn 1: "What are the main strategies for improving API response times?"
+Turn 2: "Let's focus on caching. What caching layers would you recommend
+         for a Django REST API with PostgreSQL?"
+Turn 3: "Good. Now write the implementation for the Redis caching layer
+         you described, including cache invalidation logic."
+```
+
+## Examples in Practice
+
+### Example 1 — Business strategy
+
+**Context:** You're developing a customer retention strategy and want to drill down from broad options to a specific deliverable.
+
+```text
+Turn 1: "What are the main approaches to reducing customer churn for a SaaS product?"
+```
+
+```text
+Turn 2: "Let's focus on the proactive outreach approach. What signals should we
+monitor to identify at-risk customers?"
+```
+
+```text
+Turn 3: "Good. Now draft a playbook for our customer success team based on those
+signals. Include specific email templates for each risk tier."
+```
+
+**Why this works:** Each turn narrows scope based on the previous response, moving from broad strategy to a concrete deliverable.
+
+### Example 2 — Writing refinement
+
+**Context:** You're drafting executive communications and want to polish through iteration.
+
+```text
+Turn 1: "Draft an executive summary for our Q3 board report. Revenue was $2.1M,
+up 15% QoQ. We launched two new features and expanded into the UK market."
+```
+
+```text
+Turn 2: "Good start. Make the tone more confident and add a forward-looking
+statement about Q4 pipeline."
+```
+
+```text
+Turn 3: "Shorten to 150 words and lead with the growth metric."
+```
+
+**Why this works:** Writing benefits from progressive refinement — each turn addresses a specific dimension (tone, content, length) without overloading a single prompt.
+
+### Example 3 — Problem exploration with forking
+
+**Context:** You're investigating a performance bottleneck and want to compare approaches.
+
+```text
+Turn 1: "Our deployment pipeline takes 45 minutes. Walk me through common bottlenecks."
+```
+
+```text
+Turn 2: "The test suite sounds like the issue. How would you approach parallelizing
+integration tests without sacrificing reliability?"
+```
+
+```text
+Turn 3: "Fork: instead of parallelizing, what if we moved to a trunk-based development
+model with feature flags? How would that change our testing strategy?"
+```
+
+**Why this works:** Conversation forking lets you compare two distinct approaches (parallelization vs. architectural change) while preserving the context of the original problem.
+
+## Common Pitfalls
+
+!!! warning "Context window exhaustion"
+    **Problem:** Long conversations can exceed the model's context window (the amount of text it can process at once), causing it to "forget" earlier details or instructions.
+    **Fix:** Periodically summarize the conversation state: "To recap what we've decided so far: [summary]. Now let's move on to..." This preserves key decisions while freeing up context space.
+
+!!! warning "Drift without anchoring"
+    **Problem:** The conversation wanders and loses focus on the original goal, producing output that doesn't serve the intended purpose.
+    **Fix:** Start with a clear objective and reference it periodically: "Coming back to our goal of reducing churn, let's now..." Consider stating the objective in your first message.
+
+!!! warning "Never finishing"
+    **Problem:** Endlessly refining without reaching a usable output — each revision feels like it could be better.
+    **Fix:** Set a target upfront: "In 3-4 exchanges, I want a final version I can send to the team." Define "done" before you start iterating.
+
+!!! info "Conversation summarization"
+    For very long conversations, ask the model to summarize the key decisions and context before continuing. For example: "Before we continue, summarize the key decisions we've made so far in a bullet list." This preserves important information while keeping the conversation manageable.
+
+## Related Techniques
+
+- [Chain-of-Thought](chain-of-thought.md) — explicit step-by-step reasoning within a single turn
+- [Self-Consistency and Reflection](self-consistency-and-reflection.md) — have the model critique and revise its own output
+- [Reframing Prompts](reframing-prompts.md) — restructure a problem mid-conversation to get a better angle
+- [Prompt Engineering Overview](index.md)
+- [Ideation and Strategy use case](../../../use-cases/ideation-and-strategy.md) — multi-turn conversation is the natural mode for strategic exploration
+
+## Further Reading
+
+- Yi et al. 2024 — *A Survey on Recent Advances in LLM-Based Multi-turn Dialogue Systems* — [arxiv.org/abs/2402.18013](https://arxiv.org/abs/2402.18013)
+- Zheng et al. 2025 — *LLMs Get Lost In Multi-Turn Conversation* — [arxiv.org/abs/2505.06120](https://arxiv.org/abs/2505.06120)

--- a/docs/agentic-building-blocks/prompts/prompt-engineering/output-formatting.md
+++ b/docs/agentic-building-blocks/prompts/prompt-engineering/output-formatting.md
@@ -1,0 +1,128 @@
+---
+title: Output Formatting
+description: Tell the model exactly how to structure its response — tables, JSON, templates, or any format you define.
+---
+
+# Output Formatting
+
+> **Platforms:** `claude` `openai` `gemini` `m365-copilot`
+
+## What It Is
+
+Output formatting means telling the model exactly how to structure its response — whether that's a table, JSON, bullet list, specific sections, or a template you define. Instead of hoping the model picks a useful format, you specify it upfront. This makes outputs immediately usable without manual reformatting.
+
+## Why It Works
+
+LLMs (large language models) are very good at following structural instructions because they've seen millions of formatted documents during training. Specifying format reduces ambiguity about what "a good response" looks like, and makes outputs immediately usable in downstream workflows. However, note that format restrictions can sometimes degrade reasoning performance — Tam et al. (2024) found a tradeoff between structure and thinking quality. For complex analysis, consider letting the model reason freely first, then reformatting.
+
+## When to Use It
+
+- Output needs to feed into another system (JSON, CSV, XML)
+- Reports or analyses that need consistent structure across runs
+- Comparing multiple items side-by-side (tables)
+- When you'll reuse the same prompt and need predictable output
+- When output will be parsed programmatically
+
+## The Pattern
+
+```text
+{Task description}
+
+Format your response as:
+{Format specification — template, example structure, or explicit format name}
+```
+
+**Filled-in example:**
+
+```text
+Summarize the three main risks of migrating our database from MySQL to PostgreSQL.
+
+Format your response as a markdown table with these columns:
+| Risk | Likelihood (High/Med/Low) | Impact | Mitigation |
+```
+
+## Examples in Practice
+
+### Example 1 — Table format
+
+**Context:** You need to compare tools and want a scannable side-by-side view.
+
+```text
+Compare the following 4 project management tools on these dimensions: price, team size
+limit, integrations, and learning curve. Tools: Asana, Linear, Monday.com, Notion.
+
+Present as a markdown table with tools as columns and dimensions as rows.
+```
+
+**Why this works:** Tables make comparisons scannable, and specifying rows vs. columns removes ambiguity about the layout.
+
+### Example 2 — JSON output
+
+**Context:** You're extracting structured data from unstructured text for use in an application.
+
+```text
+Extract the following fields from this job posting: title, company, location,
+salary_range, required_skills (as an array), experience_years.
+
+Return as valid JSON with no additional text or explanation.
+
+Job posting:
+[paste job posting text here]
+```
+
+**Why this works:** The schema is fully specified — field names, types (array for skills), and the instruction to return only JSON ensures clean, parseable output.
+
+### Example 3 — Template-based
+
+**Context:** You want a consistent format for a recurring report.
+
+```text
+Write a weekly status update following this exact structure:
+
+## Completed This Week
+- [bullet items]
+
+## In Progress
+- [bullet items with % complete]
+
+## Blocked
+- [bullet items with blocker description]
+
+## Next Week
+- [planned items]
+
+Here's what happened this week: shipped the auth module, 60% done with the dashboard
+redesign, waiting on API credentials from the vendor, and next week we start load testing.
+```
+
+**Why this works:** The exact template is provided, so the model fills in the structure rather than inventing its own — ensuring consistency across weeks.
+
+## Common Pitfalls
+
+!!! warning "Format over substance"
+    **Problem:** Heavy formatting constraints on reasoning-intensive tasks can reduce output quality. Tam et al. (2024) showed this empirically.
+    **Fix:** For complex analysis, let the model reason freely first, then ask it to reformat in a follow-up prompt. Separate the *thinking* step from the *formatting* step.
+
+!!! warning "Underspecified format"
+    **Problem:** "Give me a table" without specifying columns, rows, or what goes in each cell leaves too much ambiguity.
+    **Fix:** Define the exact columns, rows, and what information belongs in each cell. The more specific the format spec, the more useful the output.
+
+!!! warning "Incompatible formats"
+    **Problem:** Asking for "a brief paragraph" and "include all details" simultaneously creates a contradiction.
+    **Fix:** Choose the format that matches your information density needs. If you need comprehensive detail, use a structured format (table, sections) that can hold more information than a paragraph.
+
+!!! info "Platform tip"
+    Claude supports structured output via tool use and JSON mode. OpenAI has a JSON mode and function calling for guaranteed JSON output. For strict schema adherence, use these platform features rather than relying on prompt instructions alone.
+
+## Related Techniques
+
+- [Direct Instruction](direct-instruction.md) — be explicit about what you want the model to do
+- [Few-Shot Learning](few-shot-learning.md) — show format by example
+- [Summarization and Distillation](summarization-and-distillation.md) — formatting is especially important for summaries
+- [Prompt Engineering Overview](index.md)
+- [Data Analysis use case](../../../use-cases/data-analysis.md) — structured output is critical for data workflows
+
+## Further Reading
+
+- Tam et al. 2024 — *Let Me Speak Freely? A Study on the Impact of Format Restrictions on Performance* — [arxiv.org/abs/2408.02442](https://arxiv.org/abs/2408.02442)
+- Liu et al. 2024 — *"We Need Structured Output": Towards User-centered Constraints on LLM Output* — [arxiv.org/abs/2404.07362](https://arxiv.org/abs/2404.07362)

--- a/docs/agentic-building-blocks/prompts/prompt-engineering/real-world-constraints.md
+++ b/docs/agentic-building-blocks/prompts/prompt-engineering/real-world-constraints.md
@@ -1,0 +1,159 @@
+---
+title: Real-World Constraints
+description: Embed practical business constraints like budget, timeline, and team size into prompts to get actionable recommendations instead of ideal-world advice.
+---
+
+# Real-World Constraints
+
+> **Platforms:** `claude` `openai` `gemini` `m365-copilot`
+
+## What It Is
+
+Embedding practical business constraints — budget, timeline, team size, regulations, existing systems, stakeholder preferences — directly into your prompts. This grounds the model's output in reality instead of producing ideal-world recommendations that cannot actually be implemented.
+
+The core idea is simple: advice without constraints is just theory. A plan within constraints is actionable.
+
+## Why It Works
+
+Without constraints, large language models (LLMs) default to "best case" recommendations — unlimited budget, ideal team, greenfield environment. Real decisions happen within constraints. When you include them in the prompt, the model has to optimize within boundaries, producing output that is actually actionable. This is the difference between advice and a plan.
+
+Constraints also reduce hallucination risk by anchoring the model to specific, verifiable details rather than letting it generate plausible-sounding but ungrounded suggestions.
+
+## When to Use It
+
+- Strategic planning and business decisions
+- Project scoping and resource allocation
+- Technology selection and vendor evaluation
+- Any task where feasibility matters as much as quality
+- When previous AI suggestions were impractical
+
+## The Pattern
+
+```text
+{Task description}
+
+Constraints:
+- Budget: {amount or range}
+- Timeline: {deadline or duration}
+- Team: {size, skills, availability}
+- Technical: {existing systems, required integrations, platform limitations}
+- Regulatory: {compliance requirements, industry standards}
+- Stakeholder: {who needs to approve, political considerations}
+
+Optimize for: {primary objective within these constraints}
+```
+
+Here is a filled-in example:
+
+```text
+Recommend a monitoring and alerting stack for our web application.
+
+Constraints:
+- Budget: $500/month maximum
+- Timeline: Must be operational within 2 weeks
+- Team: 1 DevOps engineer, part-time (also handles deployments)
+- Technical: Running on AWS ECS, PostgreSQL, Redis. Must integrate with our existing Slack for alerts.
+- Regulatory: No data can leave the US region
+- Stakeholder: CTO wants minimal vendor lock-in
+
+Optimize for: Fastest time to value with lowest ongoing maintenance burden.
+```
+
+## Examples in Practice
+
+### Example 1: Project Planning
+
+**Context:** You need a migration plan, but unrestricted advice would suggest a 12-month rewrite with a team of 10.
+
+```text
+Create a plan to migrate our customer portal from PHP to React.
+
+Constraints:
+- Budget: $75,000 total
+- Timeline: Must launch by Q3 (4 months)
+- Team: 2 frontend developers (mid-level, no React experience) and
+  1 senior fullstack dev (React expert)
+- Technical: Must maintain the existing REST API, no backend changes.
+  Must support IE11 for 20% of our users.
+- Regulatory: SOC 2 compliance required
+
+Optimize for: Minimizing risk to existing customers during migration.
+```
+
+**Why this works:** Every constraint shapes the plan differently — the team skill gap means training time must be factored in, the IE11 requirement eliminates certain React features, and the risk optimization criterion pushes toward a phased rollout rather than a big-bang launch.
+
+### Example 2: Vendor Selection
+
+**Context:** You need a CRM recommendation, but generic "top 10 CRM" lists do not account for your specific situation.
+
+```text
+Recommend a CRM for our sales team.
+
+Constraints:
+- Budget: Under $50/user/month for 25 users
+- Must integrate with our existing HubSpot marketing automation
+  (non-negotiable)
+- Team has no technical admin — must be configurable by
+  non-developers
+- We're in healthcare, so HIPAA compliance is required
+- Our sales cycle is 6-12 months with 3+ stakeholders per deal
+
+Optimize for: Ease of adoption (our last CRM rollout failed due to
+poor adoption).
+```
+
+**Why this works:** The constraints eliminate most options and the "optimize for" criterion ranks the remaining ones — the model cannot just list popular CRMs; it must evaluate each against your specific requirements.
+
+### Example 3: Event Planning
+
+**Context:** You are planning a team offsite where the real challenge is not logistics but human dynamics.
+
+```text
+Plan a team offsite for 30 people.
+
+Constraints:
+- Budget: $15,000 all-in
+- Timeline: 3 weeks to plan
+- Location: Within 2 hours of Chicago
+- Duration: 2 days, 1 night
+- Dietary: 4 vegetarians, 2 gluten-free, 1 kosher
+- Goals: Team building for a recently merged department where the
+  two teams don't know each other well
+
+Optimize for: Maximum interaction between the two teams (avoid
+activities where people stick with their existing group).
+```
+
+**Why this works:** The human dynamic constraint drives the activity design — the model must propose activities that deliberately mix the two teams, not just list generic team-building exercises.
+
+## Common Pitfalls
+
+!!! warning "Incomplete constraints"
+    **Problem:** Listing budget and timeline but forgetting team skills, existing systems, or regulatory requirements. The model fills in gaps with optimistic assumptions.
+
+    **Fix:** Use the constraint categories as a checklist — budget, timeline, team, technical, regulatory, stakeholder. You do not need all six for every prompt, but scanning the list helps you catch important ones you might have omitted.
+
+!!! warning "Conflicting constraints without priority"
+    **Problem:** "We need it fast, cheap, and high quality." The model cannot optimize for all three simultaneously and will either pick one silently or produce a muddled compromise.
+
+    **Fix:** Identify which constraint is most flexible — "Budget is firm, but timeline could extend 2 weeks if needed." Explicit trade-off priorities produce better recommendations.
+
+!!! warning "Artificial constraints"
+    **Problem:** Including constraints that are not real limitations — they reduce the solution space unnecessarily and may exclude the best options.
+
+    **Fix:** For each constraint, ask "What happens if we relax this?" If the answer is "nothing significant," remove it. Every constraint you include narrows the output; make sure each one is genuine.
+
+## Related Techniques
+
+- [Contextual Prompting](contextual-prompting.md) — constraints are a specific type of context
+- [Direct Instruction](direct-instruction.md) — clear instructions pair well with clear constraints
+- [Chain-of-Thought](chain-of-thought.md) — ask the model to reason through constraint trade-offs explicitly
+- [Prompt Engineering Overview](index.md)
+- [Automation use case](../../../use-cases/automation.md) — real-world constraints are critical when designing automated workflows
+
+## Further Reading
+
+This is primarily a practitioner pattern. No specific seminal paper exists on embedding business constraints in LLM prompts — the academic literature on constrained generation focuses on technical format constraints rather than business feasibility constraints. The following platform guides discuss the principle in the context of effective prompting:
+
+- Anthropic — *Prompt Engineering Overview* — [https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview)
+- OpenAI — *Prompt Engineering Best Practices* — [https://platform.openai.com/docs/guides/prompt-engineering](https://platform.openai.com/docs/guides/prompt-engineering)

--- a/docs/agentic-building-blocks/prompts/prompt-engineering/reframing-prompts.md
+++ b/docs/agentic-building-blocks/prompts/prompt-engineering/reframing-prompts.md
@@ -1,0 +1,116 @@
+---
+title: Reframing Prompts
+description: Change how you phrase a question to activate different reasoning patterns and get fundamentally better AI responses.
+---
+
+# Reframing Prompts
+
+> **Platforms:** `claude` `openai` `gemini` `m365-copilot`
+
+## What It Is
+
+Changing how you phrase a question or task to get a fundamentally different (and often better) response. When your initial prompt isn't producing good results, reframing approaches the same problem from a different angle — changing the perspective, reversing the question, narrowing the scope, or shifting the abstraction level.
+
+Reframing is not about adding more detail to a bad prompt. It is about asking a *different* question that leads to the same destination through a better path.
+
+## Why It Works
+
+The way you frame a question determines which knowledge and reasoning patterns the model activates. A prompt framed as "What are the risks?" activates different thinking than "What would make this fail?" even though both seek similar information. This happens because large language models (LLMs) associate different framings with different types of responses based on their training data. Reframing gives you access to different parts of the model's capabilities.
+
+## When to Use It
+
+- When your initial prompt produces generic or unhelpful responses
+- When you're stuck and need a fresh approach
+- When you want to explore a problem from multiple angles
+- When the obvious question isn't yielding useful answers
+
+## The Pattern
+
+```text
+Original: {Initial prompt that isn't working well}
+
+Reframed options:
+- Inversion: "Instead of {original question}, what would {opposite}?"
+- Specificity: "Instead of {broad question}, {narrower question}?"
+- Perspective shift: "How would {different person/role} approach {topic}?"
+- Analogy: "What is {topic} equivalent to in {different domain}?"
+- Constraint: "If you could only {limitation}, how would you {task}?"
+```
+
+Here is a filled-in example using the inversion strategy:
+
+```text
+Original: How can I improve my resume?
+
+Reframed (Inversion): You're a hiring manager who's been reviewing
+resumes for 8 hours. What would make you immediately reject this
+resume? What would make you stop and read it carefully?
+```
+
+## Examples in Practice
+
+### Example 1: Inversion
+
+**Context:** You want to improve your resume but generic advice ("use action verbs," "quantify achievements") isn't helping.
+
+```text
+You're a hiring manager who's been reviewing resumes for 8 hours.
+What would make you immediately reject this resume? What would make
+you stop and read it carefully?
+```
+
+**Why this works:** The inverted perspective reveals specific, actionable issues rather than generic advice, because the model draws on different training patterns when simulating a fatigued reviewer versus offering improvement tips.
+
+### Example 2: Specificity
+
+**Context:** You need growth advice for your business, but "How do I grow my business?" produces vague platitudes.
+
+```text
+My SaaS product has 200 users and a 5% month-over-month growth rate.
+What are three specific actions I can take this month to accelerate
+growth to 10% MoM, given that my marketing budget is $2,000?
+```
+
+**Why this works:** Specific constraints force specific recommendations — the model cannot fall back on generic advice when the numbers, timeline, and budget are defined.
+
+### Example 3: Analogy
+
+**Context:** You need to restructure your engineering team but organizational design questions produce textbook answers.
+
+```text
+My engineering team is like a restaurant kitchen. We have 12 people
+and need to serve different "dishes" (products) simultaneously. How
+would a head chef organize this kitchen for maximum throughput without
+burning anyone out?
+```
+
+**Why this works:** Analogies unlock reasoning patterns the model might not apply to the literal question — restaurant kitchen management involves well-understood workflows, shift patterns, and specialization tradeoffs that translate directly to team design.
+
+## Common Pitfalls
+
+!!! warning "Reframing without purpose"
+    **Problem:** Changing the phrasing randomly without understanding why the original prompt failed.
+
+    **Fix:** Diagnose the issue first — is the prompt too vague? Too broad? Wrong perspective? Then choose a reframing strategy that addresses that specific issue.
+
+!!! warning "Losing the original intent"
+    **Problem:** The reframed question is more interesting but doesn't answer what you actually need.
+
+    **Fix:** After reframing, check — "Does this new question still help me achieve my original goal?"
+
+!!! warning "Only trying one reframe"
+    **Problem:** The first reframe may not be the best one.
+
+    **Fix:** Try 2-3 different reframing strategies and compare the quality of responses. Inversion, specificity, and analogy often produce very different outputs from the same starting point.
+
+## Related Techniques
+
+- [Role Prompting](role-prompting.md) — perspective shifts are a form of reframing through a specific persona
+- [Multi-Turn Conversation](multi-turn-conversation.md) — iterative refinement across turns
+- [Self-Consistency and Reflection](self-consistency-and-reflection.md) — related approach for evaluating multiple framings
+- [Prompt Engineering Overview](index.md)
+- [Ideation and Strategy use case](../../../use-cases/ideation-and-strategy.md) — reframing is especially powerful for brainstorming and strategic exploration
+
+## Further Reading
+
+- Ma et al. 2023 — *Query Rewriting for Retrieval-Augmented Large Language Models* — [https://arxiv.org/abs/2305.14283](https://arxiv.org/abs/2305.14283)

--- a/docs/agentic-building-blocks/prompts/prompt-engineering/resources.md
+++ b/docs/agentic-building-blocks/prompts/prompt-engineering/resources.md
@@ -1,11 +1,111 @@
 ---
 title: Prompt Engineering Resources
-description: Recommended articles, documentation, and courses for learning prompt engineering
+description: Academic papers, platform documentation, and practitioner references for prompt engineering techniques
 ---
 
 # Prompt Engineering Resources
 
-Recommended articles, docs, and courses for prompt engineering.
+Academic papers, platform guides, and practitioner references organized by technique. Each pattern page links to its most relevant papers; this page collects them all in one place.
 
-| Resource | Type | Note |
-|----------|------|------|
+## Platform Documentation
+
+These official guides are maintained by the AI platform teams and reflect current best practices.
+
+| Platform | Guide | Notes |
+|----------|-------|-------|
+| Anthropic (Claude) | [Prompt Engineering Guide](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/overview) | Comprehensive guide covering all major techniques |
+| OpenAI (ChatGPT) | [Prompt Engineering Best Practices](https://platform.openai.com/docs/guides/prompt-engineering) | Strategies and tactics for better results |
+| Google Cloud | [Prompt Engineering Overview and Guide](https://cloud.google.com/discover/what-is-prompt-engineering#prompt-engineering-overview-and-guide) | Overview of prompt engineering concepts and techniques |
+
+## Courses and Learning Resources
+
+| Resource | Provider | Notes |
+|----------|----------|-------|
+| [Prompt Engineering Courses](https://www.edx.org/search?q=Prompt%20Engineering) | edX | University-backed courses on prompt engineering |
+| [Prompt Engineering Courses](https://www.coursera.org/search?query=prompt%20engineering) | Coursera | Courses from industry and academic partners |
+| [Prompting Guide](https://www.promptingguide.ai/) | DAIR.AI | Open-source guide covering techniques, applications, and research |
+
+## Academic Papers by Technique
+
+### Zero-Shot Prompting
+
+- Brown et al. 2020 — *Language Models are Few-Shot Learners* — [arxiv.org/abs/2005.14165](https://arxiv.org/abs/2005.14165) — The GPT-3 paper that established the zero-shot paradigm, demonstrating that large language models can perform tasks from instructions alone
+- Kojima et al. 2022 — *Large Language Models are Zero-Shot Reasoners* — [arxiv.org/abs/2205.11916](https://arxiv.org/abs/2205.11916) — Showed that adding "Let's think step by step" enables zero-shot chain-of-thought reasoning
+
+### Few-Shot Learning
+
+- Brown et al. 2020 — *Language Models are Few-Shot Learners* — [arxiv.org/abs/2005.14165](https://arxiv.org/abs/2005.14165) — Seminal paper demonstrating few-shot learning via text demonstrations
+- Dong et al. 2022 — *A Survey on In-context Learning* — [arxiv.org/abs/2301.00234](https://arxiv.org/abs/2301.00234) — Comprehensive survey on why few-shot demonstrations work and how models learn in context
+
+### Chain-of-Thought
+
+- Wei et al. 2022 — *Chain-of-Thought Prompting Elicits Reasoning in Large Language Models* — [arxiv.org/abs/2201.11903](https://arxiv.org/abs/2201.11903) — The seminal chain-of-thought paper showing step-by-step reasoning improves performance on math, logic, and commonsense tasks
+- Kojima et al. 2022 — *Large Language Models are Zero-Shot Reasoners* — [arxiv.org/abs/2205.11916](https://arxiv.org/abs/2205.11916) — Zero-shot CoT: "Let's think step by step"
+- Yao et al. 2023 — *Tree of Thoughts: Deliberate Problem Solving with Large Language Models* — [arxiv.org/abs/2305.10601](https://arxiv.org/abs/2305.10601) — Generalizes chain-of-thought into tree-structured reasoning with backtracking
+
+### Direct Instruction
+
+- Wei et al. 2021 — *Finetuned Language Models Are Zero-Shot Learners (FLAN)* — [arxiv.org/abs/2109.01652](https://arxiv.org/abs/2109.01652) — Foundation paper on instruction tuning
+- Ouyang et al. 2022 — *Training Language Models to Follow Instructions with Human Feedback* — [arxiv.org/abs/2203.02155](https://arxiv.org/abs/2203.02155) — InstructGPT paper establishing RLHF for instruction following
+- Zhang et al. 2023 — *Instruction Tuning for Large Language Models: A Survey* — [arxiv.org/abs/2308.10792](https://arxiv.org/abs/2308.10792) — Survey covering instruction tuning methods and their impact
+
+### Contextual Prompting
+
+- Dong et al. 2022 — *A Survey on In-context Learning* — [arxiv.org/abs/2301.00234](https://arxiv.org/abs/2301.00234) — Defines the in-context learning paradigm
+- Lewis et al. 2020 — *Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks* — [arxiv.org/abs/2005.11401](https://arxiv.org/abs/2005.11401) — RAG framework for augmenting prompts with retrieved context
+
+### Role Prompting
+
+- Kong et al. 2023 — *Better Zero-Shot Reasoning with Role-Play Prompting* — [arxiv.org/abs/2308.07702](https://arxiv.org/abs/2308.07702) — Role-play improved ChatGPT accuracy on AQuA from 53.5% to 63.8%
+- Zheng et al. 2023 — *When "A Helpful Assistant" Is Not Really Helpful* — [arxiv.org/abs/2311.10054](https://arxiv.org/abs/2311.10054) — Important counterpoint: persona prompts don't reliably improve performance across all tasks
+
+### Output Formatting
+
+- Tam et al. 2024 — *Let Me Speak Freely? A Study on the Impact of Format Restrictions on Performance* — [arxiv.org/abs/2408.02442](https://arxiv.org/abs/2408.02442) — Shows format restrictions can degrade reasoning performance
+- Liu et al. 2024 — *"We Need Structured Output": Towards User-centered Constraints on LLM Output* — [arxiv.org/abs/2404.07362](https://arxiv.org/abs/2404.07362) — User-centered perspective on structured output constraints
+
+### Multi-Turn Conversation
+
+- Yi et al. 2024 — *A Survey on Recent Advances in LLM-Based Multi-turn Dialogue Systems* — [arxiv.org/abs/2402.18013](https://arxiv.org/abs/2402.18013) — Survey covering dialogue management, context tracking, and coherence
+- Zheng et al. 2025 — *LLMs Get Lost In Multi-Turn Conversation* — [arxiv.org/abs/2505.06120](https://arxiv.org/abs/2505.06120) — Documents a 39% average performance drop in multi-turn vs. single-turn interactions
+
+### Self-Consistency and Reflection
+
+- Wang et al. 2022 — *Self-Consistency Improves Chain of Thought Reasoning in Language Models* — [arxiv.org/abs/2203.11171](https://arxiv.org/abs/2203.11171) — Sampling diverse reasoning paths and selecting the most consistent answer
+- Shinn et al. 2023 — *Reflexion: Language Agents with Verbal Reinforcement Learning* — [arxiv.org/abs/2303.11366](https://arxiv.org/abs/2303.11366) — Verbal self-reflection for iterative improvement
+- Madaan et al. 2023 — *Self-Refine: Iterative Refinement with Self-Feedback* — [arxiv.org/abs/2303.17651](https://arxiv.org/abs/2303.17651) — Generate-critique-refine loop without external feedback
+
+### Emotional Prompting
+
+- Li et al. 2023 — *EmotionPrompt: Leveraging Psychology for Large Language Models Enhancement via Emotional Stimulus* — [arxiv.org/abs/2307.11760](https://arxiv.org/abs/2307.11760) — Showed 10%+ improvement on benchmarks using emotional stimuli, though effects vary by model and task
+
+### Reframing Prompts
+
+- Ma et al. 2023 — *Query Rewriting for Retrieval-Augmented Large Language Models* — [arxiv.org/abs/2305.14283](https://arxiv.org/abs/2305.14283) — Rewrite-Retrieve-Read framework for query reformulation
+
+### Style Unbundling
+
+- Lenny Rachitsky — *Five proven prompt engineering techniques* — [lennysnewsletter.com](https://www.lennysnewsletter.com/p/five-proven-prompt-engineering-techniques) — Practitioner origin of the style unbundling technique
+- Liu et al. 2023 — *Learning to Generate Text in Arbitrary Writing Styles* — [arxiv.org/abs/2312.17242](https://arxiv.org/abs/2312.17242) — Academic research on style decomposition and reproduction
+
+### Summarization and Distillation
+
+- Adams et al. 2023 — *From Sparse to Dense: GPT-4 Summarization with Chain of Density Prompting* — [arxiv.org/abs/2309.04269](https://arxiv.org/abs/2309.04269) — Iterative increasing-density summarization technique
+- Jin et al. 2024 — *A Comprehensive Survey on Process-Oriented Automatic Text Summarization* — [arxiv.org/abs/2403.02901](https://arxiv.org/abs/2403.02901) — Broad survey of summarization approaches
+
+### Real-World Constraints
+
+This is primarily a practitioner pattern. The academic literature on constrained generation focuses on technical format constraints rather than business constraints in prompts. See the platform documentation above for practical guidance.
+
+## General References
+
+These foundational papers cover topics relevant to multiple techniques.
+
+- Schulhoff et al. 2024 — *The Prompt Report: A Systematic Survey of Prompting Techniques* — [arxiv.org/abs/2406.06608](https://arxiv.org/abs/2406.06608) — Comprehensive taxonomy of 58 prompting techniques with a unified terminology
+- Zhou et al. 2022 — *Large Language Models Are Human-Level Prompt Engineers* — [arxiv.org/abs/2211.01910](https://arxiv.org/abs/2211.01910) — Automatic prompt optimization (APE)
+- White et al. 2023 — *A Prompt Pattern Catalog to Enhance Prompt Engineering with ChatGPT* — [arxiv.org/abs/2302.11382](https://arxiv.org/abs/2302.11382) — Pattern-based approach to prompt engineering, similar to software design patterns
+
+## Related
+
+- [Prompt Engineering Overview](index.md)
+- [Prompts Building Block](../index.md)

--- a/docs/agentic-building-blocks/prompts/prompt-engineering/role-prompting.md
+++ b/docs/agentic-building-blocks/prompts/prompt-engineering/role-prompting.md
@@ -1,0 +1,123 @@
+---
+title: Role Prompting
+description: Assign the model a specific identity, expertise, or perspective to shape its vocabulary, reasoning, and level of detail.
+---
+
+# Role Prompting
+
+> **Platforms:** `claude` `openai` `gemini` `m365-copilot`
+
+## What It Is
+
+Role prompting means assigning the model a specific identity, expertise, or perspective to shape its responses. You tell the model who it should "be" — a senior data analyst, a skeptical CFO, a kindergarten teacher — and it adjusts its vocabulary, reasoning approach, and level of detail accordingly. This technique also encompasses **perspective shifts**, where you ask the model to analyze a topic from multiple viewpoints in a single prompt.
+
+## Why It Works
+
+Role assignments activate relevant knowledge clusters in the model's training data. When you say "You are a senior tax attorney," the model (a large language model, or LLM) draws more heavily on legal reasoning patterns and tax-specific knowledge. However, research is mixed — Kong et al. (2023) showed role-play improved ChatGPT's accuracy on math reasoning from 53.5% to 63.8%, but Zheng et al. (2023) found persona prompts don't reliably improve performance across all tasks. The technique works best when the role provides genuine expertise framing, not just a label.
+
+## When to Use It
+
+- Tasks requiring domain-specific knowledge or vocabulary
+- When you need output tailored to a specific audience
+- Exploring a problem from multiple perspectives (perspective shifts)
+- When the default "helpful assistant" tone isn't appropriate
+- Advisory or consulting scenarios where depth and skepticism matter
+
+## The Pattern
+
+```text
+You are a {role/title} with {relevant experience}. Your audience is {who will read this}.
+
+{Task description}
+```
+
+Multi-perspective variation:
+
+```text
+Analyze {topic/decision} from the following perspectives:
+1. {Perspective 1}: focus on {their concerns}
+2. {Perspective 2}: focus on {their concerns}
+3. {Perspective 3}: focus on {their concerns}
+
+For each perspective, identify: key concerns, recommended action, and potential blind spots.
+```
+
+**Filled-in example:**
+
+```text
+You are a senior DevOps engineer with 12 years of experience managing cloud infrastructure
+at scale. Your audience is a startup CTO evaluating hosting options.
+
+Compare AWS, GCP, and Azure for a startup expecting to scale from 1,000 to 100,000 users
+in the next 18 months. Focus on cost efficiency, developer experience, and scaling pain points.
+```
+
+## Examples in Practice
+
+### Example 1 — Expert advice
+
+**Context:** A team is debating an architecture change, and you want a seasoned perspective.
+
+```text
+You are a senior backend engineer with 15 years of experience in distributed systems.
+A junior developer on your team is proposing to move from a monolithic architecture to
+microservices for an app with 500 daily active users. Provide your honest assessment,
+including risks they might not be considering.
+```
+
+**Why this works:** The seniority and domain expertise shape the depth and skepticism of the response — the model will raise concerns a junior engineer might not think of.
+
+### Example 2 — Audience-appropriate explanation
+
+**Context:** A business owner needs accounting concepts explained without jargon.
+
+```text
+You are a financial advisor explaining to a small business owner with no accounting
+background. Explain the difference between cash-basis and accrual accounting. Use
+everyday analogies, avoid jargon, and explain why they should care.
+```
+
+**Why this works:** The role + audience pairing determines both content depth and register — the model will simplify concepts and use relatable comparisons.
+
+### Example 3 — Perspective shift
+
+**Context:** A company is weighing a major policy change and needs to anticipate different stakeholder reactions.
+
+```text
+A mid-size company is considering implementing a 4-day work week. Analyze this from
+three perspectives:
+1. The CEO concerned about productivity and client expectations
+2. An HR director focused on retention and employee wellbeing
+3. A frontline manager worried about scheduling and workload
+
+For each, identify their top concern, likely position, and what data they'd want to see.
+```
+
+**Why this works:** Each perspective surfaces different priorities and blind spots, giving a more complete picture than any single viewpoint.
+
+## Common Pitfalls
+
+!!! warning "Superficial roles"
+    **Problem:** "You are an expert" adds nothing meaningful to the prompt.
+    **Fix:** Specify the *type* of expertise, years of experience, and relevant context. "You are a pediatric nurse with 10 years of emergency room experience" is far more effective than "You are a medical expert."
+
+!!! warning "Role-task mismatch"
+    **Problem:** Asking a "marketing expert" to debug code — the role doesn't bring relevant expertise to the task.
+    **Fix:** Match the role to the task. The role should bring knowledge and judgment that genuinely helps with what you're asking.
+
+!!! warning "Overreliance on roles for accuracy"
+    **Problem:** Assuming that assigning a role (e.g., "You are a fact-checker") makes the model's factual claims more reliable.
+    **Fix:** Roles shape framing, vocabulary, and depth — not factual accuracy. Always verify critical facts independently, regardless of the assigned role.
+
+## Related Techniques
+
+- [Contextual Prompting](contextual-prompting.md) — provide background information alongside your prompt
+- [Emotional Prompting](emotional-prompting.md) — add stakes and motivation to encourage thoroughness
+- [Reframing Prompts](reframing-prompts.md) — restructure a problem to get a better response
+- [Prompt Engineering Overview](index.md)
+- [Ideation and Strategy use case](../../../use-cases/ideation-and-strategy.md) — role prompting is especially effective for strategic analysis
+
+## Further Reading
+
+- Kong et al. 2023 — *Better Zero-Shot Reasoning with Role-Play Prompting* — [arxiv.org/abs/2308.07702](https://arxiv.org/abs/2308.07702)
+- Zheng et al. 2023 — *When "A Helpful Assistant" Is Not Really Helpful* — [arxiv.org/abs/2311.10054](https://arxiv.org/abs/2311.10054)

--- a/docs/agentic-building-blocks/prompts/prompt-engineering/self-consistency-and-reflection.md
+++ b/docs/agentic-building-blocks/prompts/prompt-engineering/self-consistency-and-reflection.md
@@ -1,0 +1,155 @@
+---
+title: Self-Consistency and Reflection
+description: Ask the model to evaluate, critique, and improve its own output or approach a problem from multiple angles to increase reliability.
+---
+
+# Self-Consistency and Reflection
+
+> **Platforms:** `claude` `openai` `gemini` `m365-copilot`
+
+## What It Is
+
+Self-consistency and reflection are two related techniques for improving the reliability of LLM (large language model) output. **Self-reflection** asks the model to critique and revise its own work — essentially adding a review step. **Self-consistency** generates multiple independent reasoning paths and compares them, using agreement as a confidence signal. Both techniques help catch errors that the model might make on a first pass.
+
+## Why It Works
+
+LLMs can often identify errors in text more easily than they can avoid making them in the first place. By adding an explicit review step, you leverage this asymmetry. Self-reflection (Shinn et al. 2023, Madaan et al. 2023) asks the model to critique and revise its own output in an iterative loop. Self-consistency (Wang et al. 2022) takes a different approach: it generates multiple independent answers and uses agreement as a confidence signal.
+
+!!! info "Self-consistency vs. self-reflection — an important distinction"
+    These are related but different techniques. **Self-consistency** (Wang et al. 2022) involves sampling multiple reasoning paths — typically using temperature > 0 to get genuine variation — and taking the majority answer. It is about *diversity of reasoning*. **Self-reflection** is about *iterative improvement* — generating one output, critiquing it, then revising. Both are valuable, but they work through different mechanisms.
+
+## When to Use It
+
+- High-stakes outputs where errors have real consequences
+- Complex analysis where the first attempt may miss something
+- When you need confidence in the answer (especially for quantitative problems)
+- Fact-checking or reviewing model-generated content
+- Code review and debugging
+- Any task where "close enough" isn't good enough
+
+## The Pattern
+
+Self-reflection:
+
+```text
+{Generate initial output}
+
+Now review your response:
+1. Identify any errors, gaps, or weak points
+2. Rate your confidence (high/medium/low) in each section
+3. Provide a revised version addressing the issues you found
+```
+
+Self-consistency:
+
+```text
+{Problem statement}
+
+Approach this problem three different ways:
+1. {Approach A}
+2. {Approach B}
+3. {Approach C}
+
+Compare the results. Where do they agree? Where do they disagree?
+What is your final answer based on the consensus?
+```
+
+**Filled-in example (self-reflection):**
+
+```text
+Write a Python function that validates email addresses using regex. Include edge cases.
+
+Now review your function:
+1. Test it mentally against these inputs: "user@example.com", "user@.com",
+   "user+tag@example.co.uk", "@example.com", "user@example"
+2. Identify any edge cases your regex misses
+3. Provide a revised version that handles the issues you found
+```
+
+## Examples in Practice
+
+### Example 1 — Content review
+
+**Context:** You're drafting a product announcement and want to ensure quality before sending.
+
+```text
+Write a product launch announcement email for our new API analytics dashboard.
+Target audience: CTOs at mid-size companies. Key features: real-time monitoring,
+custom alerts, cost tracking.
+
+Now review your draft. Check for:
+1. Clarity of the value proposition — would a busy CTO understand the benefit in
+   the first two sentences?
+2. Appropriate tone — professional but not stiff
+3. A clear call to action
+
+Revise to address any issues you find.
+```
+
+**Why this works:** The critique dimensions are specific and relevant to the audience, so the review step produces targeted improvements rather than vague "this looks good" feedback.
+
+### Example 2 — Analysis validation
+
+**Context:** You want a recommendation but also want to understand its limitations.
+
+```text
+Recommend the top 3 programming languages for data science in 2025, with reasoning
+for each choice.
+
+Now critique your own recommendations:
+- What biases might affect your ranking?
+- What use cases would change the ranking?
+- What did you leave out that a practitioner might consider important?
+
+Provide a revised recommendation with appropriate caveats.
+```
+
+**Why this works:** The self-critique surfaces assumptions (e.g., bias toward popular languages, not considering niche domains) that the initial response glosses over.
+
+### Example 3 — Multi-path reasoning
+
+**Context:** You need to verify a calculation and want confidence in the result.
+
+```text
+Calculate the break-even point for this business:
+- Fixed costs: $10,000/month
+- Variable cost per unit: $15
+- Selling price per unit: $45
+
+Solve this three different ways:
+1. The algebraic break-even formula
+2. A contribution margin approach
+3. By building a simple unit-by-unit model
+
+Do all three approaches give the same answer? If not, explain the discrepancy.
+```
+
+**Why this works:** Mathematical consistency across three approaches validates correctness — if all three agree, confidence is high; if they disagree, the discrepancy reveals an error.
+
+## Common Pitfalls
+
+!!! warning "Shallow self-critique"
+    **Problem:** The model says "my response looks good" or makes only cosmetic changes without meaningful critique.
+    **Fix:** Give specific dimensions to evaluate: "Check for factual accuracy, completeness, logical consistency, and potential bias." The more specific your critique criteria, the more substantive the review.
+
+!!! warning "Infinite revision loops"
+    **Problem:** Each revision introduces new issues or changes things that were already correct, creating an endless cycle.
+    **Fix:** Limit to one revision cycle, or specify exactly what to focus on: "Only fix factual errors; don't change the structure or tone." Constrained revision prevents scope creep.
+
+!!! warning "False confidence from self-review"
+    **Problem:** The model can confidently confirm its own errors — self-review is not the same as independent verification.
+    **Fix:** For critical decisions, don't rely on self-review alone. Verify key facts, calculations, and claims independently. Self-review catches many errors but not all of them.
+
+## Related Techniques
+
+- [Chain-of-Thought](chain-of-thought.md) — explicit reasoning that pairs well with self-consistency
+- [Multi-Turn Conversation](multi-turn-conversation.md) — use follow-up turns for human-guided reflection
+- [Reframing Prompts](reframing-prompts.md) — restructure the problem to get a different angle
+- [Prompt Engineering Overview](index.md)
+- [Research use case](../../../use-cases/research.md) — self-consistency is especially valuable for research tasks where accuracy matters
+
+## Further Reading
+
+- Wang et al. 2022 — *Self-Consistency Improves Chain of Thought Reasoning in Language Models* — [arxiv.org/abs/2203.11171](https://arxiv.org/abs/2203.11171)
+- Shinn et al. 2023 — *Reflexion: Language Agents with Verbal Reinforcement Learning* — [arxiv.org/abs/2303.11366](https://arxiv.org/abs/2303.11366)
+- Madaan et al. 2023 — *Self-Refine: Iterative Refinement with Self-Feedback* — [arxiv.org/abs/2303.17651](https://arxiv.org/abs/2303.17651)

--- a/docs/agentic-building-blocks/prompts/prompt-engineering/style-unbundling.md
+++ b/docs/agentic-building-blocks/prompts/prompt-engineering/style-unbundling.md
@@ -1,0 +1,134 @@
+---
+title: Style Unbundling
+description: Break down a writing style into individual components like tone, sentence length, and vocabulary to reproduce it precisely.
+---
+
+# Style Unbundling
+
+> **Platforms:** `claude` `openai` `gemini` `m365-copilot`
+
+## What It Is
+
+Breaking down a writing style into its individual components — sentence length, vocabulary level, tone, use of metaphor, paragraph structure, and more — so you can describe and reproduce it precisely. Instead of saying "write like Steve Jobs," you identify *what makes* that style distinctive and instruct the model on each dimension.
+
+Style unbundling treats voice and tone as a set of independent dials you can tune, rather than a single vague label.
+
+## Why It Works
+
+"Write like [person]" is ambiguous — the model may focus on the wrong stylistic elements, and its impression of that person's style may not match yours. Unbundling forces precision. When you specify "short declarative sentences, technical concepts explained through everyday analogies, building to a dramatic reveal," the model has concrete, actionable targets instead of a vague imitation task. Each attribute becomes an independent constraint that the large language model (LLM) can optimize for.
+
+## When to Use It
+
+- Matching a specific brand voice or editorial style
+- Reproducing the tone of a reference document
+- Creating consistent content across multiple pieces
+- When "write like X" isn't producing the right result
+
+## The Pattern
+
+```text
+Write about {topic} using these style attributes:
+- Sentence structure: {short/long/varied, simple/complex}
+- Vocabulary: {technical/accessible/colloquial, reading level}
+- Tone: {formal/casual/authoritative/conversational}
+- Rhetoric: {use of analogies, questions, data, stories}
+- Pacing: {paragraph length, builds tension, front-loads conclusions}
+- Audience: {who you're writing for}
+```
+
+Here is a filled-in example:
+
+```text
+Write about the future of remote work using these style attributes:
+- Sentence structure: Mix of short punchy (5-8 words) and medium (15-20 words). No sentence over 25 words.
+- Vocabulary: Accessible to non-technical readers. No jargon without definition.
+- Tone: Conversational and optimistic but grounded — avoid hype.
+- Rhetoric: Open with a surprising statistic, use one everyday analogy, end with a forward-looking question.
+- Pacing: Short paragraphs (2-3 sentences max). Build momentum toward the closing question.
+- Audience: General business readers, not HR specialists.
+```
+
+## Examples in Practice
+
+### Example 1: Newsletter Style
+
+**Context:** You need a 300-word newsletter intro about AI in healthcare that feels approachable, not academic.
+
+```text
+Write a 300-word newsletter intro about AI in healthcare.
+Style attributes:
+- Sentence structure: Mix of short punchy sentences (5-8 words) and
+  medium sentences (15-20 words). No sentences over 25 words.
+- Vocabulary: Accessible to non-technical readers. Define any medical
+  or AI terms.
+- Tone: Conversational and optimistic but grounded — avoid hype.
+- Rhetoric: Open with a surprising statistic, use one everyday
+  analogy, end with a forward-looking question.
+- Pacing: Short paragraphs (2-3 sentences max).
+```
+
+**Why this works:** Each style dimension is independently specified, so the model knows exactly what "newsletter voice" means in this context rather than guessing.
+
+### Example 2: Executive Brief
+
+**Context:** You need a project status update for engineering leadership that is direct and confident.
+
+```text
+Write a project status update for the VP of Engineering.
+Style attributes:
+- Sentence structure: Declarative, no hedging language.
+- Vocabulary: Technical terms are fine (audience is engineering
+  leadership).
+- Tone: Direct and confident — state conclusions, not possibilities.
+- Rhetoric: Lead with the bottom line, then supporting evidence.
+- Pacing: Bullet points for data, short paragraphs for narrative.
+```
+
+**Why this works:** It defines the register and information hierarchy — the model knows to front-load conclusions and avoid phrases like "it might be worth considering."
+
+### Example 3: Brand Voice Consistency
+
+**Context:** You have existing marketing copy and need new content that matches the same voice.
+
+```text
+Here's a paragraph from our existing marketing copy:
+
+[paste sample paragraph]
+
+Analyze this text and identify the style attributes: sentence length,
+vocabulary level, tone, use of punctuation, rhetoric devices.
+Then write a new paragraph about our enterprise security features
+using the same style attributes.
+```
+
+**Why this works:** It reverse-engineers the style before reproducing it, making the implicit explicit so the model can replicate it consistently.
+
+## Common Pitfalls
+
+!!! warning "Too many style constraints"
+    **Problem:** Specifying 10+ style attributes overwhelms the model, leading to stilted, unnatural output.
+
+    **Fix:** Focus on 4-6 attributes that matter most. The model handles nuance better when not micromanaged on every dimension.
+
+!!! warning "Contradictory attributes"
+    **Problem:** Requesting "casual and authoritative" or "brief and comprehensive" without acknowledging the tension.
+
+    **Fix:** When attributes conflict, prioritize explicitly — "Lean casual, but shift to authoritative when citing data."
+
+!!! warning "Style over substance"
+    **Problem:** Spending all your prompt budget on style, leaving the actual content underspecified.
+
+    **Fix:** Define what you want to say first, then add style constraints. A beautifully styled paragraph that says the wrong thing is still wrong.
+
+## Related Techniques
+
+- [Output Formatting](output-formatting.md) — structure and layout complement style
+- [Role Prompting](role-prompting.md) — roles implicitly bundle style attributes; unbundling makes them explicit
+- [Few-Shot Learning](few-shot-learning.md) — show the desired style by example instead of describing it
+- [Prompt Engineering Overview](index.md)
+- [Content Creation use case](../../../use-cases/content-creation.md) — style unbundling is essential for professional content workflows
+
+## Further Reading
+
+- Lenny Rachitsky — *Five proven prompt engineering techniques* — [https://www.lennysnewsletter.com/p/five-proven-prompt-engineering-techniques](https://www.lennysnewsletter.com/p/five-proven-prompt-engineering-techniques)
+- Liu et al. 2023 — *Learning to Generate Text in Arbitrary Writing Styles* — [https://arxiv.org/abs/2312.17242](https://arxiv.org/abs/2312.17242)

--- a/docs/agentic-building-blocks/prompts/prompt-engineering/summarization-and-distillation.md
+++ b/docs/agentic-building-blocks/prompts/prompt-engineering/summarization-and-distillation.md
@@ -1,0 +1,142 @@
+---
+title: Summarization and Distillation
+description: Techniques for compressing, restructuring, or extracting essential information from longer content using AI prompts.
+---
+
+# Summarization and Distillation
+
+> **Platforms:** `claude` `openai` `gemini` `m365-copilot`
+
+## What It Is
+
+Techniques for compressing, restructuring, or extracting the essential information from longer content. Summarization condenses while preserving meaning; distillation extracts the core principles or key takeaways, often transforming the format — for example, turning a report into action items or a research paper into a one-page brief.
+
+The distinction matters: summarization is *compression* (same content, fewer words), while distillation is *transformation* (different format, different emphasis, tailored for a specific audience or purpose).
+
+## Why It Works
+
+Large language models (LLMs) excel at identifying important information and restructuring it because they have been trained on vast amounts of human-written summaries, abstracts, and briefs. The key is giving them clear criteria for what "important" means in your context — otherwise they will make assumptions about what to keep and what to cut, and those assumptions may not match your needs.
+
+## When to Use It
+
+- Condensing long documents, reports, or meeting transcripts
+- Extracting action items or key decisions from text
+- Creating executive summaries from detailed analyses
+- Transforming content for a different audience or format
+- Research synthesis across multiple sources
+
+## The Pattern
+
+### Standard summarization
+
+```text
+Summarize the following {content type} in {length constraint}.
+Focus on: {what to prioritize}
+Exclude: {what to omit}
+Format: {desired output structure}
+Audience: {who will read the summary}
+
+{Content to summarize}
+```
+
+### Chain of Density variation
+
+Based on Adams et al. 2023, this technique progressively increases information density while holding length constant:
+
+```text
+Summarize the following article in 3-5 sentences.
+Then make the summary denser: rewrite it to include more key details
+from the article while keeping the same length.
+Repeat once more, making it even denser.
+Provide all three versions.
+```
+
+Here is a filled-in standard example:
+
+```text
+Summarize this quarterly earnings call transcript in 200 words.
+Focus on: revenue figures, guidance changes, and strategic shifts.
+Exclude: analyst questions, boilerplate legal disclaimers.
+Format: three bullet sections — Results, Guidance, Strategy.
+Audience: portfolio manager reviewing 15 earnings calls today.
+
+[transcript text]
+```
+
+## Examples in Practice
+
+### Example 1: Meeting Summary
+
+**Context:** You have a 45-minute meeting transcript and need to extract what matters for the people who weren't in the room.
+
+```text
+Summarize this meeting transcript.
+Focus on: (1) decisions made, (2) action items with owners and
+deadlines, (3) open questions.
+Exclude: pleasantries, off-topic discussions, and repeated points.
+Format: three sections with bullet points under each.
+Keep it under 300 words.
+```
+
+**Why this works:** The criteria for inclusion and exclusion are explicit, so the model knows exactly what to keep and what to drop.
+
+### Example 2: Research Distillation
+
+**Context:** A 20-page research report needs to reach C-suite executives who have five minutes to read it.
+
+```text
+Distill the key findings from this 20-page research report into a
+one-page executive brief.
+Audience: non-technical C-suite.
+For each finding: state it in one sentence, explain why it matters
+to the business, and note any caveats.
+Include a "So What?" section at the end with recommended actions.
+```
+
+**Why this works:** It defines a *transformation*, not just compression — each finding must be repackaged with business relevance and caveats, producing output structured for decision-making.
+
+### Example 3: Progressive Summarization
+
+**Context:** Different stakeholders need the same article at different levels of detail.
+
+```text
+Give me three versions of a summary for this article:
+
+(1) A 3-sentence TL;DR
+(2) A 5-bullet executive summary with key data points
+(3) A 200-word narrative summary suitable for a newsletter
+
+Label each version clearly.
+```
+
+**Why this works:** Different stakeholders need different summary depths — requesting all three in one prompt ensures consistency across versions.
+
+## Common Pitfalls
+
+!!! warning "Undefined 'important'"
+    **Problem:** "Summarize this article" without specifying what's important. The model chooses for you, and may focus on the wrong elements.
+
+    **Fix:** Always specify what to prioritize — decisions? data points? recommendations? risks? The focus criteria are as important as the length constraint.
+
+!!! warning "Lossy compression"
+    **Problem:** Critical details get dropped when the length constraint is too tight for the content density.
+
+    **Fix:** After summarizing, ask "What important information was excluded from this summary?" to audit what was lost. Adjust the length constraint or split into multiple summaries if needed.
+
+!!! warning "Summary vs. analysis"
+    **Problem:** Asking for a summary when you actually need analysis or recommendations. These are different tasks.
+
+    **Fix:** Be clear about the task — "Summarize what happened" describes events, while "Analyze what happened and recommend what to do next" requires evaluation and judgment. Use the right verb.
+
+## Related Techniques
+
+- [Output Formatting](output-formatting.md) — structure summaries for readability
+- [Direct Instruction](direct-instruction.md) — clear instructions improve summary quality
+- [Chain-of-Thought](chain-of-thought.md) — reasoning through what matters before summarizing
+- [Prompt Engineering Overview](index.md)
+- [Research use case](../../../use-cases/research.md) — summarization is a core research workflow
+
+## Further Reading
+
+- Adams et al. 2023 — *From Sparse to Dense: GPT-4 Summarization with Chain of Density Prompting* — [https://arxiv.org/abs/2309.04269](https://arxiv.org/abs/2309.04269)
+- Jin et al. 2024 — *A Comprehensive Survey on Process-Oriented Automatic Text Summarization* — [https://arxiv.org/abs/2403.02901](https://arxiv.org/abs/2403.02901)

--- a/docs/agentic-building-blocks/prompts/prompt-engineering/zero-shot-prompting.md
+++ b/docs/agentic-building-blocks/prompts/prompt-engineering/zero-shot-prompting.md
@@ -1,0 +1,121 @@
+---
+title: Zero-Shot Prompting
+description: How to instruct an LLM with no examples, relying on its training to interpret and complete your task.
+---
+
+# Zero-Shot Prompting
+
+> **Platforms:** `claude` `openai` `gemini` `m365-copilot`
+
+## What It Is
+
+Zero-shot prompting means giving the model a task with no examples — just an instruction. It is the simplest form of prompting. The model relies entirely on its training data and instruction-tuning to interpret what you want and produce an appropriate response.
+
+## Why It Works
+
+Modern LLMs (large language models) are trained on massive datasets and fine-tuned to follow instructions through a process called RLHF (Reinforcement Learning from Human Feedback). They already know how to perform thousands of tasks — summarization, translation, classification, and more. You just need to describe what you want clearly enough for the model to match your request to patterns it has already learned.
+
+## When to Use It
+
+- Simple, well-understood tasks (summarize, translate, classify)
+- When you don't have examples handy
+- Quick exploration before investing in more complex prompts
+- Tasks where the standard format is acceptable
+
+## The Pattern
+
+```text
+{Task description}. {Optional constraints or specifications}.
+```
+
+**Filled-in example:**
+
+```text
+Summarize the following article in 3 bullet points, focusing on the key findings.
+```
+
+## Examples in Practice
+
+### Translation
+
+**Context:** You need a formal French translation of an English paragraph.
+
+```text
+Translate the following English text to French, maintaining a formal tone:
+
+"We are pleased to announce that our quarterly results exceeded expectations,
+driven by strong performance in the European market."
+```
+
+**Why this works:** Translation is a well-defined task the model has seen extensively in training, and specifying "formal tone" constrains the register.
+
+### Classification
+
+**Context:** You need to categorize incoming customer reviews for a dashboard.
+
+```text
+Classify the following customer review as positive, negative, or neutral.
+
+Review: "The product arrived on time but the packaging was damaged."
+
+Classification:
+```
+
+**Why this works:** The instruction is specific and the output space is constrained to three clear options, leaving no room for ambiguity.
+
+### Content generation
+
+**Context:** You need a quick out-of-office reply before heading on vacation.
+
+```text
+Write a professional out-of-office email reply. I'll be away from Feb 15-22
+and Jane Smith (jane@company.com) will handle urgent requests.
+```
+
+**Why this works:** Out-of-office emails have a well-known format, so the model can produce a polished result without any examples.
+
+## Zero-Shot Chain-of-Thought
+
+A powerful variation of zero-shot prompting is **Zero-Shot CoT** (Chain-of-Thought). Simply appending "Let's think step by step" to a zero-shot prompt can dramatically improve performance on reasoning tasks (Kojima et al. 2022). This bridges zero-shot prompting and [Chain-of-Thought](chain-of-thought.md) prompting without requiring any examples.
+
+```text
+A store has 45 apples. They sell 60% in the morning and half of the remainder
+in the afternoon. How many are left? Let's think step by step.
+```
+
+!!! tip "Platform tip"
+
+    Claude's extended thinking mode essentially automates Zero-Shot CoT reasoning — the model reasons internally before responding. On OpenAI, the o1/o3 model family does this natively. Enable these features when tackling complex reasoning tasks where zero-shot alone falls short.
+
+## Common Pitfalls
+
+!!! warning "Too vague"
+
+    **Problem:** "Write something about marketing." gives the model too much freedom, producing generic, unfocused output.
+
+    **Fix:** Be specific — "Write a 200-word LinkedIn post about email marketing best practices for small businesses."
+
+!!! warning "Assuming model knowledge"
+
+    **Problem:** Asking about your specific product, internal processes, or proprietary data without providing details. The model has no access to information it hasn't been trained on.
+
+    **Fix:** Include necessary context directly in the prompt, or switch to [Contextual Prompting](contextual-prompting.md) for tasks that require background information.
+
+!!! warning "Complex tasks without structure"
+
+    **Problem:** Asking for multi-part analysis in a single sentence leads to incomplete or disorganized output.
+
+    **Fix:** Break the task into explicit steps or switch to [Chain-of-Thought](chain-of-thought.md) prompting for problems that require multi-step reasoning.
+
+## Related Techniques
+
+- [Few-Shot Learning](few-shot-learning.md) — add examples when zero-shot isn't producing the right format or quality
+- [Direct Instruction](direct-instruction.md) — make your zero-shot prompts more explicit with imperative commands
+- [Chain-of-Thought](chain-of-thought.md) — add step-by-step reasoning for complex problems
+- [Prompt Engineering Overview](index.md)
+- [Content Creation use case](../../../use-cases/content-creation.md)
+
+## Further Reading
+
+- Kojima et al. 2022 — *Large Language Models are Zero-Shot Reasoners* — [arxiv.org/abs/2205.11916](https://arxiv.org/abs/2205.11916)
+- Brown et al. 2020 — *Language Models are Few-Shot Learners* — [arxiv.org/abs/2005.14165](https://arxiv.org/abs/2005.14165)

--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -29,7 +29,7 @@ Reusable patterns and best practices for AI/ML development.
 
 ### Prompting Patterns
 
-Patterns for structuring and optimizing prompts.
+Patterns for structuring and optimizing prompts. See the [Prompt Engineering](../agentic-building-blocks/prompts/prompt-engineering/index.md) section for 14 detailed technique guides covering zero-shot, few-shot, chain-of-thought, and more.
 
 ### Agent Patterns
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -182,6 +182,20 @@ nav:
       - Overview: agentic-building-blocks/prompts/index.md
       - Prompt Engineering:
         - Overview: agentic-building-blocks/prompts/prompt-engineering/index.md
+        - Zero-Shot Prompting: agentic-building-blocks/prompts/prompt-engineering/zero-shot-prompting.md
+        - Few-Shot Learning: agentic-building-blocks/prompts/prompt-engineering/few-shot-learning.md
+        - Chain-of-Thought: agentic-building-blocks/prompts/prompt-engineering/chain-of-thought.md
+        - Direct Instruction: agentic-building-blocks/prompts/prompt-engineering/direct-instruction.md
+        - Contextual Prompting: agentic-building-blocks/prompts/prompt-engineering/contextual-prompting.md
+        - Role Prompting: agentic-building-blocks/prompts/prompt-engineering/role-prompting.md
+        - Output Formatting: agentic-building-blocks/prompts/prompt-engineering/output-formatting.md
+        - Multi-Turn Conversation: agentic-building-blocks/prompts/prompt-engineering/multi-turn-conversation.md
+        - Self-Consistency and Reflection: agentic-building-blocks/prompts/prompt-engineering/self-consistency-and-reflection.md
+        - Emotional Prompting: agentic-building-blocks/prompts/prompt-engineering/emotional-prompting.md
+        - Reframing Prompts: agentic-building-blocks/prompts/prompt-engineering/reframing-prompts.md
+        - Style Unbundling: agentic-building-blocks/prompts/prompt-engineering/style-unbundling.md
+        - Summarization and Distillation: agentic-building-blocks/prompts/prompt-engineering/summarization-and-distillation.md
+        - Real-World Constraints: agentic-building-blocks/prompts/prompt-engineering/real-world-constraints.md
         - Resources: agentic-building-blocks/prompts/prompt-engineering/resources.md
       - Questions:
         - What is a system prompt?: agentic-building-blocks/prompts/questions/what-is-a-system-prompt.md


### PR DESCRIPTION
## Summary

- Adds 14 new prompt engineering technique pages under `docs/agentic-building-blocks/prompts/prompt-engineering/`, covering zero-shot, few-shot, chain-of-thought, direct instruction, contextual prompting, role prompting, output formatting, multi-turn conversation, self-consistency and reflection, emotional prompting, reframing, style unbundling, summarization and distillation, and real-world constraints
- Rewrites the hub page (`index.md`) from placeholder to a rich overview with 8 core principles and a categorized technique catalog
- Populates `resources.md` with platform documentation, courses (edX, Coursera, DAIR.AI), and 25+ academic papers organized by technique
- Updates `mkdocs.yml` nav and `patterns/index.md` cross-link

## Test plan

- [ ] `mkdocs build` succeeds (non-strict — pre-existing warnings in strict mode are unrelated)
- [ ] `mkdocs serve` renders all 14 pages with correct nav ordering
- [ ] Each page has: frontmatter, platform banner, all template sections, 2-3 examples, 2-3 pitfall admonitions, working cross-links, Further Reading references
- [ ] Hub page tables link correctly to each pattern page
- [ ] Resources page links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)