### PR TITLE
Add dedicated Coding Resources page

### DIFF
--- a/docs/use-cases/coding-resources.md
+++ b/docs/use-cases/coding-resources.md
@@ -1,0 +1,12 @@
+---
+title: "Coding Resources"
+description: Curated resources for AI-assisted coding — reports, guides, and references
+---
+
+# Coding Resources
+
+Curated external resources for the [Coding](coding.md) use case.
+
+| Resource | Source | Notes |
+|----------|--------|-------|
+| [2026 Agentic Coding Trends Report](https://resources.anthropic.com/hubfs/2026%20Agentic%20Coding%20Trends%20Report.pdf?hsLang=en) | Anthropic | Industry trends and data on AI-assisted coding |

--- a/docs/use-cases/coding.md
+++ b/docs/use-cases/coding.md
@@ -98,3 +98,4 @@ Coding is the primitive where AI agents are most mature. Modern AI coding agents
 - [Context](../agentic-building-blocks/context/index.md) — providing codebases, documentation, and examples
 - [Data Analysis](data-analysis.md) — when the insight is the goal, not the code
 - [Automation](automation.md) — when code runs as part of an unattended pipeline
+- [Coding Resources](coding-resources.md) — curated reports, guides, and references

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -222,6 +222,7 @@ nav:
     - Content Creation: use-cases/content-creation.md
     - Research: use-cases/research.md
     - Coding: use-cases/coding.md
+    - Coding Resources: use-cases/coding-resources.md
     - Data Analysis: use-cases/data-analysis.md
     - Ideation & Strategy: use-cases/ideation-and-strategy.md
     - Automation: use-cases/automation.md


### PR DESCRIPTION
## Summary
- Creates `docs/use-cases/coding-resources.md` as a dedicated resource page for the Coding use case
- Adds the Anthropic 2026 Agentic Coding Trends Report as the first entry
- Links the new page from the Coding use case Related section and the mkdocs nav
- Establishes a pattern for adding resource pages to other use cases

## Test plan
- [x] `mkdocs build --strict` passes (no new warnings)
- [ ] Verify page renders correctly on deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)