### PR TITLE
Add resource pages for remaining 5 use cases

### DIFF
--- a/docs/use-cases/automation-resources.md
+++ b/docs/use-cases/automation-resources.md
@@ -1,0 +1,11 @@
+---
+title: "Automation Resources"
+description: Curated resources for AI-assisted automation — reports, guides, and references
+---
+
+# Automation Resources
+
+Curated external resources for the [Automation](automation.md) use case.
+
+| Resource | Source | Notes |
+|----------|--------|-------|

--- a/docs/use-cases/automation.md
+++ b/docs/use-cases/automation.md
@@ -99,3 +99,4 @@ Automation delivers the largest time savings because it eliminates recurring man
 - [Skills](../agentic-building-blocks/skills/index.md) — reusable routines that agents invoke during automation
 - [Scheduling Subagents](../platforms/claude/subagents/scheduling-subagents.md) — how to schedule automated agents on Claude
 - [Build Workflows](../business-first-ai-framework/build/index.md) — worked examples including autonomous agent workflows
+- [Automation Resources](automation-resources.md) — curated reports, guides, and references

--- a/docs/use-cases/content-creation-resources.md
+++ b/docs/use-cases/content-creation-resources.md
@@ -1,0 +1,11 @@
+---
+title: "Content Creation Resources"
+description: Curated resources for AI-assisted content creation — reports, guides, and references
+---
+
+# Content Creation Resources
+
+Curated external resources for the [Content Creation](content-creation.md) use case.
+
+| Resource | Source | Notes |
+|----------|--------|-------|

--- a/docs/use-cases/content-creation.md
+++ b/docs/use-cases/content-creation.md
@@ -98,3 +98,4 @@ Content creation use cases scale from simple (rewriting an email for a different
 - [Context](../agentic-building-blocks/context/index.md) — providing brand voice, style guides, and examples
 - [Skills](../agentic-building-blocks/skills/index.md) — packaging content creation workflows for reuse
 - [Projects](../agentic-building-blocks/projects/index.md) — persistent workspaces for recurring content workflows
+- [Content Creation Resources](content-creation-resources.md) — curated reports, guides, and references

--- a/docs/use-cases/data-analysis-resources.md
+++ b/docs/use-cases/data-analysis-resources.md
@@ -1,0 +1,11 @@
+---
+title: "Data Analysis Resources"
+description: Curated resources for AI-assisted data analysis — reports, guides, and references
+---
+
+# Data Analysis Resources
+
+Curated external resources for the [Data Analysis](data-analysis.md) use case.
+
+| Resource | Source | Notes |
+|----------|--------|-------|

--- a/docs/use-cases/data-analysis.md
+++ b/docs/use-cases/data-analysis.md
@@ -98,3 +98,4 @@ Data analysis is often the highest-value primitive for teams that have data but 
 - [Skills](../agentic-building-blocks/skills/index.md) — packaging analysis workflows for repeatable use
 - [Coding](coding.md) — when the goal is the analysis tool itself, not the insight
 - [Automation](automation.md) — running analysis workflows on a schedule
+- [Data Analysis Resources](data-analysis-resources.md) — curated reports, guides, and references

--- a/docs/use-cases/ideation-and-strategy-resources.md
+++ b/docs/use-cases/ideation-and-strategy-resources.md
@@ -1,0 +1,11 @@
+---
+title: "Ideation & Strategy Resources"
+description: Curated resources for AI-assisted ideation and strategy — reports, guides, and references
+---
+
+# Ideation & Strategy Resources
+
+Curated external resources for the [Ideation & Strategy](ideation-and-strategy.md) use case.
+
+| Resource | Source | Notes |
+|----------|--------|-------|

--- a/docs/use-cases/ideation-and-strategy.md
+++ b/docs/use-cases/ideation-and-strategy.md
@@ -98,3 +98,4 @@ Unlike the other primitives where AI executes work, ideation and strategy is abo
 - [Context](../agentic-building-blocks/context/index.md) — providing goals, constraints, and history
 - [Prompts](../agentic-building-blocks/prompts/index.md) — crafting effective brainstorming and evaluation prompts
 - [Discover Workflows](../business-first-ai-framework/discover.md) — using ideation to find AI opportunities
+- [Ideation & Strategy Resources](ideation-and-strategy-resources.md) — curated reports, guides, and references

--- a/docs/use-cases/research-resources.md
+++ b/docs/use-cases/research-resources.md
@@ -1,0 +1,11 @@
+---
+title: "Research Resources"
+description: Curated resources for AI-assisted research — reports, guides, and references
+---
+
+# Research Resources
+
+Curated external resources for the [Research](research.md) use case.
+
+| Resource | Source | Notes |
+|----------|--------|-------|

--- a/docs/use-cases/research.md
+++ b/docs/use-cases/research.md
@@ -98,3 +98,4 @@ Research becomes particularly powerful when paired with MCP connections to your 
 - [MCP](../agentic-building-blocks/mcp/index.md) — connecting AI to external data sources for live research
 - [Context](../agentic-building-blocks/context/index.md) — providing source documents and background knowledge
 - [Automation](automation.md) — running research workflows on a schedule
+- [Research Resources](research-resources.md) — curated reports, guides, and references

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -220,12 +220,17 @@ nav:
   - Use Cases:
     - Overview: use-cases/index.md
     - Content Creation: use-cases/content-creation.md
+    - Content Creation Resources: use-cases/content-creation-resources.md
     - Research: use-cases/research.md
+    - Research Resources: use-cases/research-resources.md
     - Coding: use-cases/coding.md
     - Coding Resources: use-cases/coding-resources.md
     - Data Analysis: use-cases/data-analysis.md
+    - Data Analysis Resources: use-cases/data-analysis-resources.md
     - Ideation & Strategy: use-cases/ideation-and-strategy.md
+    - Ideation & Strategy Resources: use-cases/ideation-and-strategy-resources.md
     - Automation: use-cases/automation.md
+    - Automation Resources: use-cases/automation-resources.md
   - Platforms:
     - Overview: platforms/index.md
     - Claude:


### PR DESCRIPTION
## Summary
- Creates dedicated resource pages for Content Creation, Research, Data Analysis, Ideation & Strategy, and Automation
- Each use case page now links to its resource page from the Related section
- All 6 resource pages added to mkdocs.yml nav (paired with their use case)
- Resource tables are empty and ready to be populated with curated links

## Test plan
- [x] `mkdocs build --strict` passes (no new warnings beyond expected git-revision for new files)
- [ ] Verify all 5 new pages render correctly on deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)