### PR TITLE
Add agent capability patterns pages

### DIFF
--- a/docs/agentic-building-blocks/agents/capability-patterns/guardrails.md
+++ b/docs/agentic-building-blocks/agents/capability-patterns/guardrails.md
@@ -1,0 +1,103 @@
+---
+title: Guardrails
+description: How automated rules and constraints keep AI agents safe, on-topic, and within policy — without requiring human intervention at every step.
+---
+
+# Guardrails
+
+## What It Is
+
+Guardrails are automated rules and constraints that govern what an agent can and cannot do. They operate continuously during agent execution, checking inputs, outputs, and actions against defined policies — and blocking or modifying anything that violates those policies.
+
+Unlike [human-in-the-loop](human-in-the-loop.md) controls, guardrails are automated. They don't require a human to review every action — they enforce rules programmatically, allowing the agent to operate autonomously within defined boundaries.
+
+## Why It Matters
+
+As agents gain more autonomy — making decisions, calling tools, taking actions — the potential for harm increases. An agent without guardrails can hallucinate confidently, leak sensitive data, make unauthorized purchases, or provide advice it shouldn't.
+
+Guardrails are the difference between a useful autonomous system and a liability. They let you grant agents more autonomy (which makes them more useful) while maintaining safety (which makes them trustworthy). Production agent systems always need guardrails — the question is not *whether* to add them, but *which ones* and *where*.
+
+## How It Works
+
+Guardrails can be applied at multiple points in the agent pipeline:
+
+```text
+┌────────┐   ┌──────────┐   ┌────────┐   ┌──────────┐   ┌────────┐
+│ Input  │──▸│  Input    │──▸│ Agent  │──▸│  Output   │──▸│ Output │
+│        │   │  Guards   │   │ (LLM)  │   │  Guards   │   │        │
+└────────┘   └──────────┘   └────────┘   └──────────┘   └────────┘
+```
+
+### Types of guardrails
+
+**Input guardrails** — Filter or reject problematic inputs before they reach the agent:
+
+- Block prompt injection attempts
+- Reject off-topic requests ("I can help with order management, but I can't help with medical advice")
+- Sanitize sensitive data (redact credit card numbers before processing)
+
+**Output guardrails** — Check agent responses before they reach the user:
+
+- Block responses containing personally identifiable information (PII)
+- Ensure responses stay within the agent's approved topic area
+- Verify factual claims against a knowledge base
+- Enforce tone and brand voice guidelines
+
+**Action guardrails** — Restrict what tools the agent can call and with what parameters:
+
+- Limit refund amounts ("agent can issue refunds up to $100; anything higher requires approval")
+- Restrict database access to read-only queries
+- Block destructive operations (delete, overwrite)
+- Enforce rate limits on API calls
+
+**Constitutional guardrails** — Baked into the model's behavior through system prompts or fine-tuning:
+
+- Anthropic's Constitutional AI trains models to follow a set of principles
+- System prompts that define the agent's role and boundaries
+- Instructions like "Never provide medical, legal, or financial advice"
+
+## Example
+
+### Customer exchange scenario
+
+An exchange-processing agent has these guardrails:
+
+| Guardrail | Type | Rule |
+|-----------|------|------|
+| Refund cap | Action | Cannot issue refunds over $200 without escalation |
+| Final sale block | Action | Cannot process returns on items marked "final sale" |
+| PII filter | Output | Redacts credit card numbers and SSNs from responses |
+| Scope limit | Input | Rejects requests unrelated to order management |
+| Policy compliance | Output | Verifies that the response cites the correct return policy |
+
+A customer asks: "Can I return this final-sale item?" The action guardrail blocks the return process, and the agent responds: "I'm sorry, final-sale items are not eligible for return or exchange per our policy. I can help you find an alternative product if you'd like."
+
+### Code generation agent
+
+A coding agent has guardrails to prevent generating insecure code:
+
+- **Block** — SQL queries built with string concatenation (SQL injection risk)
+- **Warn** — API keys or secrets hardcoded in source code
+- **Enforce** — All file writes must go through a sandbox directory
+
+## When to Use It
+
+- Any production agent system — guardrails are not optional for deployed agents
+- Agents with access to tools that can take real-world actions (payments, emails, database writes)
+- Customer-facing agents where brand safety matters
+- Regulated industries (healthcare, finance, legal) with compliance requirements
+- Multi-agent systems where individual agents need scoped permissions
+
+## Related Patterns
+
+- [Human-in-the-Loop](human-in-the-loop.md) — Guardrails handle routine constraints automatically; HITL handles exceptions and edge cases
+- [Tool Use](tool-use.md) — Action guardrails govern which tools the agent can access
+- [Reflection](reflection.md) — Self-reflection is a soft guardrail; automated guardrails are hard constraints
+- [Agent Capability Patterns](index.md)
+
+## Further Reading
+
+- Anthropic — *Constitutional AI: Harmlessness from AI Feedback* — [anthropic.com/research/constitutional-ai-harmlessness-from-ai-feedback](https://www.anthropic.com/research/constitutional-ai-harmlessness-from-ai-feedback)
+- Anthropic — *Building Effective Agents* — [anthropic.com/research/building-effective-agents](https://www.anthropic.com/research/building-effective-agents)
+- OWASP — *LLM AI Security & Governance Checklist* — [owasp.org/www-project-top-10-for-large-language-model-applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
+- Guardrails AI — *Open-source framework for adding guardrails to LLM applications* — [guardrailsai.com](https://www.guardrailsai.com/)

--- a/docs/agentic-building-blocks/agents/capability-patterns/human-in-the-loop.md
+++ b/docs/agentic-building-blocks/agents/capability-patterns/human-in-the-loop.md
@@ -1,0 +1,104 @@
+---
+title: Human-in-the-Loop
+description: How human checkpoints at key decision points keep AI agents aligned, accountable, and safe for high-stakes tasks.
+---
+
+# Human-in-the-Loop
+
+## What It Is
+
+Human-in-the-loop (HITL) is a pattern where an agent pauses at defined checkpoints to get human approval, input, or correction before proceeding. Instead of running fully autonomously, the agent escalates decisions that are high-stakes, ambiguous, or outside its confidence threshold to a human operator.
+
+HITL is not the opposite of automation — it's the safety net that makes deeper automation possible. By building in human checkpoints at the right moments, you can grant agents more autonomy for the routine work while keeping humans in control of the decisions that matter.
+
+## Why It Matters
+
+Fully autonomous agents are powerful but risky. They can make mistakes that are expensive, embarrassing, or irreversible — sending the wrong email to a customer, approving a refund that violates policy, or making a decision based on hallucinated data.
+
+HITL addresses the trust gap: users may not trust an agent to handle everything autonomously, but they also don't want to supervise every step. The solution is selective human involvement — the agent handles the routine 90% automatically and escalates the exceptional 10% to a human.
+
+The key design question is: *"Would I be comfortable if the agent did this without asking me?"* If the answer is no, that's where you add a checkpoint.
+
+## How It Works
+
+Three common HITL architectures:
+
+### Approval gate
+
+The agent completes a unit of work and pauses for human approval before taking the next action.
+
+```text
+┌────────┐     ┌──────────┐     ┌────────────┐     ┌──────────┐
+│ Agent   │────▸│ Proposed  │────▸│ Human      │────▸│ Execute  │
+│ works   │     │ Action    │     │ Approves/  │     │ or       │
+│         │     │ (paused)  │     │ Modifies   │     │ Revise   │
+└────────┘     └──────────┘     └────────────┘     └──────────┘
+```
+
+**Example:** An agent drafts a customer email, then waits for human approval before sending it.
+
+### Escalation trigger
+
+The agent operates autonomously by default but escalates when it hits a defined threshold — low confidence, policy edge case, high-value action.
+
+```text
+┌────────┐     ┌──────────────┐
+│ Agent   │────▸│ Confidence   │──── High ───▸ Proceed automatically
+│ works   │     │ Check        │
+│         │     │              │──── Low ────▸ Escalate to human
+└────────┘     └──────────────┘
+```
+
+**Example:** An agent processes routine exchanges automatically but escalates to a supervisor when the refund amount exceeds $500 or the return window has expired.
+
+### Collaborative workspace
+
+The agent and human work in parallel on a shared artifact — the agent drafts, the human edits, the agent refines based on the edits.
+
+**Example:** An agent writes a report in a shared document. The human adds comments and corrections in real-time. The agent incorporates the feedback into subsequent sections.
+
+## Example
+
+### Customer exchange scenario
+
+A customer wants to exchange an item that's past the return window:
+
+1. **Agent** — Looks up the order, determines the return window expired 3 days ago.
+2. **Agent** — Checks guardrails: "Expired return window" triggers escalation rule.
+3. **Agent** → **Human** — "Customer Jane Smith (VIP, 4-year account) is requesting an exchange for Order #ORD-5678. The return window expired 3 days ago. Recommended action: approve as a courtesy given VIP status. Approve / Deny / Modify?"
+4. **Human** — Approves the courtesy exchange.
+5. **Agent** — Processes the exchange, sends confirmation to the customer.
+
+Without HITL, the agent would either rigidly deny the exchange (frustrating a loyal customer) or blindly approve it (creating a policy loophole). HITL lets the agent handle the workflow while the human makes the judgment call.
+
+### Code deployment
+
+A CI/CD agent with HITL checkpoints:
+
+1. **Autonomous:** Run tests, generate build, scan for vulnerabilities
+2. **Checkpoint:** "All tests pass. Deploy to staging?" → Human approves
+3. **Autonomous:** Deploy to staging, run integration tests
+4. **Checkpoint:** "Staging tests pass. Deploy to production?" → Human approves
+5. **Autonomous:** Deploy to production, monitor health metrics
+
+## When to Use It
+
+- High-stakes decisions with real-world consequences (financial transactions, customer communications, production deployments)
+- Edge cases that fall outside the agent's training or policy coverage
+- Compliance-sensitive workflows where an audit trail of human approvals is required
+- Early-stage deployments where you're still building trust in the agent's capabilities
+- Any action that would be difficult or expensive to reverse
+
+## Related Patterns
+
+- [Guardrails](guardrails.md) — Guardrails handle routine constraints automatically; HITL handles exceptions that require judgment
+- [Planning](planning.md) — Humans can review and approve the agent's plan before execution begins
+- [Reflection](reflection.md) — The agent's self-assessment can determine when to escalate to a human
+- [Agent Capability Patterns](index.md)
+
+## Further Reading
+
+- Anthropic — *Building Effective Agents* — [anthropic.com/research/building-effective-agents](https://www.anthropic.com/research/building-effective-agents)
+- Permit.io — *Human-in-the-Loop for AI Agents: Best Practices* — [permit.io/blog/human-in-the-loop-for-ai-agents-best-practices-frameworks-use-cases-and-demo](https://www.permit.io/blog/human-in-the-loop-for-ai-agents-best-practices-frameworks-use-cases-and-demo)
+- Zapier — *Human-in-the-Loop in AI Workflows: Meaning and Patterns* — [zapier.com/blog/human-in-the-loop](https://zapier.com/blog/human-in-the-loop/)
+- UiPath — *10 Best Practices for Building Reliable AI Agents* — [uipath.com/blog/ai/agent-builder-best-practices](https://www.uipath.com/blog/ai/agent-builder-best-practices)

--- a/docs/agentic-building-blocks/agents/capability-patterns/index.md
+++ b/docs/agentic-building-blocks/agents/capability-patterns/index.md
@@ -1,0 +1,62 @@
+---
+title: Agent Capability Patterns
+description: Seven architectural patterns that make AI agents effective — from self-reflection to multi-agent collaboration, plus safety and control mechanisms
+---
+
+# Agent Capability Patterns
+
+Capability patterns are the architectural building blocks that make AI agents powerful. While a basic LLM generates text in a single pass, an *agentic* system combines multiple patterns — reflection, tool use, planning, collaboration, and memory — to tackle complex, multi-step tasks autonomously.
+
+These patterns were popularized by Andrew Ng in his 2024 writing on agentic design patterns (*The Batch*, DeepLearning.AI), building on research from Google, Stanford, Princeton, and others. The patterns are platform-agnostic — they apply whether you're building with Claude, ChatGPT, Gemini, or any other LLM.
+
+## Pattern Catalog
+
+### Capability Patterns
+
+These five patterns define *what agents can do*.
+
+| Pattern | What It Does | Key Benefit |
+|---------|-------------|-------------|
+| [Reflection](reflection.md) | Agent reviews and critiques its own output, then improves it | Higher-quality results through self-correction |
+| [Tool Use](tool-use.md) | Agent calls external tools, APIs, and data sources | Extends capabilities beyond text generation |
+| [Planning](planning.md) | Agent breaks complex goals into a sequence of steps | Handles multi-step tasks that require strategy |
+| [Multi-Agent Collaboration](multi-agent-collaboration.md) | Multiple specialized agents work together on a task | Tackles problems too complex for a single agent |
+| [Memory](memory.md) | Agent stores and retrieves information across interactions | Learns from experience and maintains context |
+
+### Safety & Control
+
+These two patterns define *how agents stay safe and aligned*.
+
+| Pattern | What It Does | Key Benefit |
+|---------|-------------|-------------|
+| [Guardrails](guardrails.md) | Automated rules that constrain agent behavior | Prevents harmful or off-topic outputs without human intervention |
+| [Human-in-the-Loop](human-in-the-loop.md) | Human checkpoints at key decision points | Keeps humans in control of high-stakes actions |
+
+## How Patterns Work Together
+
+Consider a customer exchange request — a customer wants to return a product and exchange it for a different item. A capable agent doesn't just use one pattern; it combines several:
+
+1. **Planning** — The agent breaks the exchange into steps: verify the order, check return eligibility, find the replacement item, process the return, place the new order.
+2. **Tool Use** — At each step, the agent calls the order management API, inventory system, and payment processor.
+3. **Reflection** — Before confirming the exchange, the agent reviews its work: "Did I verify the return window? Is the replacement item in stock? Are the prices correct?"
+4. **Guardrails** — Automated rules prevent the agent from issuing refunds above a threshold or processing exchanges for final-sale items.
+5. **Human-in-the-Loop** — If the exchange involves an exception (expired return window, high-value item), the agent escalates to a human agent for approval.
+6. **Memory** — The agent remembers this customer's preferences and past interactions, personalizing future service.
+
+No single pattern makes this workflow possible. Their combination is what turns a basic chatbot into a capable agent.
+
+## Where to Start
+
+**Understanding agent concepts?** Start with [Reflection](reflection.md) — it's the simplest pattern to grasp and demonstrates the core idea of iterative improvement.
+
+**Building your first agent?** [Tool Use](tool-use.md) is the most immediately practical pattern — it's how agents interact with the real world.
+
+**Designing a production system?** Read [Guardrails](guardrails.md) and [Human-in-the-Loop](human-in-the-loop.md) first — safety and control should be designed in from the start, not bolted on later.
+
+## Related
+
+- [Agents](../index.md) — The Agents building block overview
+- [Agents Resources](../resources.md) — Recommended reading on agents
+- [Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) — Anthropic's guide to agent architecture
+- [Prompt Engineering](../../prompts/prompt-engineering/index.md) — Techniques for the prompts that drive agent behavior
+- [Automation Use Cases](../../../use-cases/automation.md) — Real-world applications of agentic systems

--- a/docs/agentic-building-blocks/agents/capability-patterns/memory.md
+++ b/docs/agentic-building-blocks/agents/capability-patterns/memory.md
@@ -1,0 +1,99 @@
+---
+title: Memory
+description: How AI agents store and retrieve information across interactions, enabling them to learn from experience and maintain context over time.
+---
+
+# Memory
+
+## What It Is
+
+Memory is a pattern where an agent stores information from past interactions and retrieves it when relevant to current tasks. Without memory, every conversation starts from scratch — the agent has no knowledge of previous interactions, decisions, or user preferences. With memory, the agent builds up context over time, becoming more useful and personalized with each interaction.
+
+Memory in AI agents is inspired by human memory systems, but implemented through a combination of databases, embeddings, and retrieval mechanisms rather than biological processes.
+
+## Why It Matters
+
+A stateless agent is like a colleague with amnesia — you have to re-explain everything every time. Memory transforms agents from one-shot tools into persistent collaborators that accumulate knowledge, learn preferences, and build on past work.
+
+The landmark Generative Agents paper (Park et al. 2023) demonstrated that agents with memory could form relationships, remember past conversations, and coordinate activities over time — emergent behaviors that weren't explicitly programmed but arose naturally from the memory architecture.
+
+## How It Works
+
+Agent memory systems typically implement multiple types of memory:
+
+### Short-term memory (working context)
+
+The current conversation history and any documents loaded into the context window. This is what the agent can "see" right now. It's limited by the model's context window size.
+
+### Long-term memory (persistent storage)
+
+Information stored outside the context window in a database or file system, retrieved when relevant. This includes:
+
+- **Episodic memory** — Records of specific past interactions ("Last Tuesday, the user asked about exchange policies and preferred email communication").
+- **Semantic memory** — General knowledge extracted from interactions ("This user prefers concise responses" or "This customer is a VIP account").
+- **Procedural memory** — Learned workflows and procedures ("When processing exchanges for this company, always check the VIP discount table first").
+
+### Retrieval
+
+When the agent starts a new task, it queries long-term memory for relevant context. Common retrieval methods include:
+
+- **Keyword/semantic search** — Finding memories related to the current topic using embeddings
+- **Recency weighting** — Prioritizing recent memories over older ones
+- **Importance scoring** — Surfacing memories that were flagged as significant
+
+```text
+┌─────────────┐     ┌──────────────┐     ┌─────────────┐
+│  Current     │────▸│  Retrieval    │────▸│  Enriched    │
+│  Task        │     │  (search      │     │  Context     │
+│              │     │   memory)     │     │              │
+└─────────────┘     └──────┬───────┘     └─────────────┘
+                           │
+                    ┌──────▼───────┐
+                    │  Long-term    │
+                    │  Memory Store │
+                    └──────────────┘
+```
+
+## Example
+
+### Customer exchange scenario
+
+A customer contacts support about an exchange. The agent retrieves from memory:
+
+- **Episodic:** "This customer contacted us 3 weeks ago about a defective Blue Widget. We sent a replacement. They mentioned they prefer phone updates over email."
+- **Semantic:** "This customer has been with us for 4 years and has a lifetime value of $2,400. They're in the VIP tier."
+- **Procedural:** "VIP customers get free expedited shipping on exchanges and a courtesy discount on the replacement item."
+
+Armed with this context, the agent provides personalized service without the customer having to repeat their history.
+
+### Development workflow
+
+A coding agent with memory:
+
+- Remembers the project's architecture decisions from previous sessions
+- Recalls that the user prefers TypeScript over JavaScript and tabs over spaces
+- Knows which test framework the project uses without being told each time
+- Stores debugging insights ("The authentication module has a known issue with token refresh timing")
+
+Claude Code's `CLAUDE.md` files and memory directory are a practical implementation of this pattern — project context and user preferences persist across sessions.
+
+## When to Use It
+
+- Customer-facing systems where personalization improves the experience
+- Long-running projects where context accumulates over time
+- Agents that need to learn from mistakes (paired with [Reflection](reflection.md))
+- Any workflow where repeating context to the agent is a friction point
+
+## Related Patterns
+
+- [Reflection](reflection.md) — Reflection generates insights that can be stored in memory for future use
+- [Planning](planning.md) — Memory of past plans helps the agent make better plans in the future
+- [Multi-Agent Collaboration](multi-agent-collaboration.md) — Shared memory allows agents to coordinate without direct communication
+- [Agent Capability Patterns](index.md)
+
+## Further Reading
+
+- Park et al. 2023 — *Generative Agents: Interactive Simulacra of Human Behavior* — [arxiv.org/abs/2304.03442](https://arxiv.org/abs/2304.03442)
+- Zhang et al. 2024 — *A Survey on the Memory Mechanism of Large Language Model Based Agents* — [arxiv.org/abs/2404.13501](https://arxiv.org/abs/2404.13501)
+- Andrew Ng — *Agentic Design Patterns Part 6: Memory* — [deeplearning.ai/the-batch](https://www.deeplearning.ai/the-batch/)
+- LangChain — *Memory in LLM Applications* — [python.langchain.com/docs/concepts/memory](https://python.langchain.com/docs/concepts/memory/)

--- a/docs/agentic-building-blocks/agents/capability-patterns/multi-agent-collaboration.md
+++ b/docs/agentic-building-blocks/agents/capability-patterns/multi-agent-collaboration.md
@@ -1,0 +1,94 @@
+---
+title: Multi-Agent Collaboration
+description: How multiple specialized AI agents work together to solve problems that are too complex for a single agent.
+---
+
+# Multi-Agent Collaboration
+
+## What It Is
+
+Multi-agent collaboration is a pattern where multiple AI agents — each with different roles, tools, or expertise — work together to accomplish a task. Instead of one general-purpose agent doing everything, the work is divided among specialists that communicate, delegate, and coordinate.
+
+Think of it like a team at a company: a researcher gathers information, an analyst processes it, a writer drafts the report, and an editor reviews it. Each agent focuses on what it does best, and the combined output is better than any single agent could produce alone.
+
+## Why It Matters
+
+Single agents hit a complexity ceiling. As tasks grow more complex, a single agent's context window fills up, its instructions become contradictory, and its performance degrades. Multi-agent systems solve this by decomposing the problem across agents that each operate with focused context and clear responsibilities.
+
+Multi-agent collaboration also enables **separation of concerns** — a safety-critical agent can enforce policies while a creative agent generates content, without either interfering with the other's role.
+
+## How It Works
+
+```text
+┌──────────────┐
+│  Orchestrator │
+│  (coordinator)│
+└──┬───┬───┬───┘
+   │   │   │
+   ▼   ▼   ▼
+┌────┐┌────┐┌────┐
+│ A1 ││ A2 ││ A3 │
+│    ││    ││    │
+└────┘└────┘└────┘
+Researcher  Analyst  Writer
+```
+
+Common architectures:
+
+- **Orchestrator pattern** — A central agent assigns tasks to specialist agents, collects results, and synthesizes the final output.
+- **Pipeline pattern** — Agents are arranged in a sequence where each agent's output becomes the next agent's input (researcher → analyst → writer).
+- **Debate pattern** — Two or more agents argue different perspectives, and a judge agent selects or synthesizes the best answer.
+- **Peer collaboration** — Agents communicate as equals, each contributing their expertise to a shared workspace.
+
+The key design decisions are:
+
+1. **How many agents?** — Use the minimum number needed. More agents means more coordination overhead.
+2. **How do they communicate?** — Through shared context, message passing, or a shared workspace.
+3. **Who decides what?** — An orchestrator, a round-robin, or autonomous negotiation.
+
+## Example
+
+### Customer exchange scenario
+
+A customer exchange can be handled by a team of agents:
+
+- **Triage Agent** — Reads the customer's request, classifies it as "exchange," and routes it to the right specialist.
+- **Order Agent** — Looks up the order, verifies return eligibility, and handles the logistics.
+- **Inventory Agent** — Checks stock levels and finds the best warehouse to ship from.
+- **Communications Agent** — Drafts the customer-facing email with exchange details and return instructions.
+
+Each agent has access only to the tools it needs — the Communications Agent can't process payments, and the Order Agent can't send emails. This limits the blast radius of any single agent's mistakes.
+
+### Content production
+
+A marketing team's content pipeline as a multi-agent system:
+
+- **Research Agent** — Gathers data, competitor analysis, and market trends
+- **Writer Agent** — Produces a draft based on the research brief
+- **Editor Agent** — Reviews for clarity, accuracy, and brand voice
+- **SEO Agent** — Optimizes headlines, metadata, and keyword placement
+
+The Writer Agent never sees raw data — it receives a structured brief from the Research Agent. The Editor Agent doesn't know about SEO — it focuses purely on quality. This separation produces better results than a single agent trying to juggle all four concerns.
+
+## When to Use It
+
+- Tasks that require multiple distinct skill sets (research + writing + analysis)
+- Workflows where separation of concerns improves quality or safety
+- Problems where debate or multiple perspectives lead to better answers
+- Systems that need to scale — adding a new capability means adding a new agent, not rewriting the existing one
+- Production systems where different agents need different permission levels
+
+## Related Patterns
+
+- [Planning](planning.md) — An orchestrator agent often uses planning to coordinate the team
+- [Tool Use](tool-use.md) — Each agent typically has its own set of tools
+- [Reflection](reflection.md) — A critic agent reviewing another agent's work is multi-agent reflection
+- [Guardrails](guardrails.md) — Each agent can have its own guardrails, limiting what it can do
+- [Agent Capability Patterns](index.md)
+
+## Further Reading
+
+- Wu et al. 2023 — *AutoGen: Enabling Next-Gen LLM Applications via Multi-Agent Conversation* — [arxiv.org/abs/2308.08155](https://arxiv.org/abs/2308.08155)
+- Andrew Ng — *Agentic Design Patterns Part 5: Multi-Agent Collaboration* — [deeplearning.ai/the-batch](https://www.deeplearning.ai/the-batch/agentic-design-patterns-part-5-multi-agent-collaboration/)
+- Anthropic — *Building Effective Agents* — [anthropic.com/research/building-effective-agents](https://www.anthropic.com/research/building-effective-agents)
+- CrewAI — *Multi-Agent Framework Documentation* — [docs.crewai.com](https://docs.crewai.com/)

--- a/docs/agentic-building-blocks/agents/capability-patterns/planning.md
+++ b/docs/agentic-building-blocks/agents/capability-patterns/planning.md
@@ -1,0 +1,96 @@
+---
+title: Planning
+description: How AI agents break complex goals into a sequence of steps, deciding what to do and in what order before taking action.
+---
+
+# Planning
+
+## What It Is
+
+Planning is a pattern where an agent decomposes a complex goal into a sequence of smaller, manageable steps — then executes them in order. Instead of attempting to solve a problem in a single response, the agent first creates a plan, then follows it step by step, adapting as needed based on intermediate results.
+
+This is what separates an agent from a simple chatbot. A chatbot responds to a single prompt. An agent with planning capability can take a high-level objective ("process this customer's exchange") and autonomously determine the sequence of actions required to achieve it.
+
+## Why It Matters
+
+Real-world tasks are rarely single-step. Processing an exchange requires verifying the order, checking return eligibility, confirming inventory, processing payment, and sending confirmation. A planning agent handles this entire workflow without requiring the user to specify each step.
+
+Andrew Ng has noted that planning is the least mature of the four core agentic patterns — it works well for well-defined workflows but remains challenging for open-ended, ambiguous goals. This makes it both the most powerful pattern (when it works) and the one that most benefits from [guardrails](guardrails.md) and [human oversight](human-in-the-loop.md).
+
+## How It Works
+
+```text
+┌──────────┐     ┌──────────────┐     ┌──────────────┐
+│  Goal     │────▸│  Plan         │────▸│  Execute      │
+│  (input)  │     │  (decompose)  │     │  (step by    │
+│           │     │               │     │   step)       │
+└──────────┘     └──────────────┘     └──────┬───────┘
+                                             │
+                                      Replan if needed
+```
+
+1. **Receive goal** — The agent receives a high-level objective.
+2. **Decompose** — The agent breaks the goal into an ordered sequence of sub-tasks.
+3. **Execute** — The agent works through each sub-task, using [tool calls](tool-use.md) and [reflection](reflection.md) as needed.
+4. **Monitor** — After each step, the agent checks whether the result changes the remaining plan.
+5. **Replan** — If a step fails or produces unexpected results, the agent revises the remaining plan rather than blindly continuing.
+
+Advanced planning approaches include:
+
+- **Chain-of-thought planning** — The agent reasons through the plan in natural language before executing.
+- **Tree-of-thought** — The agent explores multiple possible plans and selects the best one (Yao et al. 2023).
+- **Hierarchical planning** — High-level plans are broken into sub-plans, each with their own steps.
+
+## Example
+
+### Customer exchange scenario
+
+**Goal:** "Process customer Jane Smith's exchange — return Blue Widget, ship Red Widget."
+
+**Agent's plan:**
+
+1. Look up Jane Smith's order history → find order #ORD-5678
+2. Verify return eligibility → check if Blue Widget is within the 30-day return window
+3. Check Red Widget inventory → confirm availability in the nearest warehouse
+4. Calculate price difference → Blue Widget was $29.99, Red Widget is $34.99, difference is $5.00
+5. Process return for Blue Widget → generate prepaid return label
+6. Charge $5.00 price difference → process payment
+7. Place order for Red Widget → create new shipment
+8. Send confirmation email → include return label, new order details, and timeline
+
+**Replanning example:** At step 3, the Red Widget is out of stock. The agent replans: offer the customer the Green Widget as an alternative, or place the Red Widget on backorder with an estimated date.
+
+### Research task
+
+**Goal:** "Write a competitive analysis of our top 3 competitors."
+
+**Agent's plan:**
+
+1. Identify the top 3 competitors from the company's CRM data
+2. For each competitor, gather recent news, product launches, and pricing
+3. Analyze strengths and weaknesses relative to our product
+4. Draft a comparison table
+5. Write executive summary with recommendations
+6. Review and refine the full document
+
+## When to Use It
+
+- Multi-step workflows with dependencies between steps (step 3 depends on step 2's output)
+- Tasks where the sequence of actions matters
+- Goals that are too complex to accomplish in a single tool call
+- Workflows where failure at one step should change the approach for subsequent steps
+
+## Related Patterns
+
+- [Tool Use](tool-use.md) — Planning determines which tools to call and in what order
+- [Reflection](reflection.md) — The agent can reflect on its plan before and during execution
+- [Multi-Agent Collaboration](multi-agent-collaboration.md) — A planning agent can delegate sub-tasks to specialized agents
+- [Human-in-the-Loop](human-in-the-loop.md) — Humans can approve the plan before execution begins
+- [Agent Capability Patterns](index.md)
+
+## Further Reading
+
+- Yao et al. 2023 — *Tree of Thoughts: Deliberate Problem Solving with Large Language Models* — [arxiv.org/abs/2305.10601](https://arxiv.org/abs/2305.10601)
+- Huang et al. 2024 — *Understanding the Planning of LLM Agents: A Survey* — [arxiv.org/abs/2402.02716](https://arxiv.org/abs/2402.02716)
+- Andrew Ng — *Agentic Design Patterns Part 4: Planning* — [deeplearning.ai/the-batch](https://www.deeplearning.ai/the-batch/agentic-design-patterns-part-4-planning/)
+- Anthropic — *Building Effective Agents* — [anthropic.com/research/building-effective-agents](https://www.anthropic.com/research/building-effective-agents)

--- a/docs/agentic-building-blocks/agents/capability-patterns/reflection.md
+++ b/docs/agentic-building-blocks/agents/capability-patterns/reflection.md
@@ -1,0 +1,82 @@
+---
+title: Reflection
+description: How AI agents improve their output by reviewing, critiquing, and revising their own work before delivering a final result.
+---
+
+# Reflection
+
+## What It Is
+
+Reflection is a pattern where an agent reviews its own output, identifies flaws or gaps, and revises its work before presenting a final result. Instead of delivering the first response it generates, the agent runs an internal feedback loop — acting as both creator and critic.
+
+In its simplest form, the agent generates an output, then prompts itself (or a second "critic" agent) to evaluate that output against criteria like accuracy, completeness, and tone. The feedback is fed back into the generation step, producing an improved version.
+
+## Why It Matters
+
+LLMs generate text in a single forward pass — essentially thinking the entire answer at once. For simple tasks, this works fine. But for complex tasks (writing, analysis, code generation), the first draft is rarely the best draft. Reflection mimics the human process of drafting, reviewing, and revising — and it significantly improves output quality.
+
+Research shows that self-reflection can improve agent performance by 20–30% on coding benchmarks and knowledge-intensive tasks, without requiring any model fine-tuning (Shinn et al. 2023).
+
+## How It Works
+
+```text
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│  Generator   │────▸│   Critic     │────▸│  Revised     │
+│  (Draft)     │     │  (Evaluate)  │     │  Output      │
+└─────────────┘     └──────┬──────┘     └─────────────┘
+                           │
+                    Feedback loop
+                    (repeat if needed)
+```
+
+1. **Generate** — The agent produces an initial output.
+2. **Evaluate** — The agent (or a separate critic) reviews the output against defined criteria.
+3. **Revise** — The agent incorporates the feedback and produces an improved version.
+4. **Repeat** — Steps 2–3 can loop multiple times until the output meets quality thresholds or a maximum iteration count is reached.
+
+The critic can be the same LLM with a different prompt ("Review this for accuracy and completeness") or a separate agent entirely. Using a separate critic agent often produces more rigorous feedback because it avoids confirmation bias.
+
+## Example
+
+### Customer exchange scenario
+
+An agent is drafting a response to a customer requesting a product exchange:
+
+**First draft:**
+> "Your exchange has been processed. The new item will ship in 3-5 business days."
+
+**Critic feedback:**
+> "The response doesn't confirm which item is being exchanged, doesn't mention the return process for the original item, and doesn't provide a tracking or confirmation number."
+
+**Revised response:**
+> "I've processed your exchange of the Blue Widget (Order #4521) for the Red Widget. Please return the Blue Widget using the prepaid label sent to your email within 14 days. Your Red Widget will ship within 3–5 business days once we receive the return. Your exchange confirmation number is EX-78234."
+
+### Code generation
+
+An agent writes a Python function, then reviews it:
+
+**Critic feedback:**
+> "The function doesn't handle the edge case where the input list is empty. It also uses a variable name `l` which is hard to distinguish from `1`."
+
+The agent revises the function to add an empty-list check and renames the variable to `items`.
+
+## When to Use It
+
+- Writing tasks where quality matters (reports, emails, documentation)
+- Code generation — catching bugs, edge cases, and style issues before delivery
+- Analysis tasks where accuracy is critical
+- Any task where the cost of iteration is lower than the cost of a wrong first answer
+
+## Related Patterns
+
+- [Planning](planning.md) — Reflection can evaluate whether a plan is complete before execution begins
+- [Multi-Agent Collaboration](multi-agent-collaboration.md) — A dedicated critic agent is a form of multi-agent collaboration
+- [Guardrails](guardrails.md) — Guardrails enforce hard constraints; reflection handles softer quality improvements
+- [Agent Capability Patterns](index.md)
+
+## Further Reading
+
+- Shinn et al. 2023 — *Reflexion: Language Agents with Verbal Reinforcement Learning* — [arxiv.org/abs/2303.11366](https://arxiv.org/abs/2303.11366)
+- Madaan et al. 2023 — *Self-Refine: Iterative Refinement with Self-Feedback* — [arxiv.org/abs/2303.17651](https://arxiv.org/abs/2303.17651)
+- Andrew Ng — *Agentic Design Patterns Part 2: Reflection* — [deeplearning.ai/the-batch](https://www.deeplearning.ai/the-batch/agentic-design-patterns-part-2-reflection/)
+- Anthropic — *Building Effective Agents* — [anthropic.com/research/building-effective-agents](https://www.anthropic.com/research/building-effective-agents)

--- a/docs/agentic-building-blocks/agents/capability-patterns/tool-use.md
+++ b/docs/agentic-building-blocks/agents/capability-patterns/tool-use.md
@@ -1,0 +1,78 @@
+---
+title: Tool Use
+description: How AI agents extend their capabilities by calling external tools, APIs, and data sources to interact with the real world.
+---
+
+# Tool Use
+
+## What It Is
+
+Tool use is a pattern where an agent calls external tools — APIs, databases, calculators, code interpreters, web browsers, file systems — to perform actions that go beyond text generation. Instead of relying solely on its training data, the agent selects the right tool, formats the input, executes the call, and interprets the result.
+
+This is arguably the most fundamental capability pattern. Without tool use, an agent is limited to generating text. With tool use, it can check inventory, send emails, query databases, run code, and interact with any system that exposes an API.
+
+## Why It Matters
+
+LLMs have inherent limitations: they can't access real-time data, perform reliable arithmetic, interact with external systems, or take actions in the world. Tool use bridges these gaps by giving the agent access to specialized capabilities on demand.
+
+The MRKL (Modular Reasoning, Knowledge and Language) architecture (Karpas et al. 2022) formalized this idea: combine a language model with a set of expert modules (calculators, search engines, databases) and let the model route queries to the right module. Every major AI platform — Claude, ChatGPT, Gemini, Copilot — now implements some form of this pattern.
+
+## How It Works
+
+```text
+┌──────────┐     ┌──────────────┐     ┌──────────┐
+│  Agent    │────▸│ Tool Router   │────▸│  Tool    │
+│  (LLM)   │◂────│ (select tool) │◂────│  Result  │
+└──────────┘     └──────────────┘     └──────────┘
+```
+
+1. **Observe** — The agent receives a task or question that requires external information or action.
+2. **Select** — The agent decides which tool to call based on the task requirements and available tool descriptions.
+3. **Format** — The agent structures the input according to the tool's expected parameters (function calling).
+4. **Execute** — The tool runs and returns a result.
+5. **Interpret** — The agent incorporates the tool result into its reasoning and either responds or calls another tool.
+
+Modern implementations use **function calling** (also called tool calling) — the model outputs structured JSON specifying which function to call and with what arguments, rather than generating free-form text that needs parsing.
+
+## Example
+
+### Customer exchange scenario
+
+A customer asks to exchange a product. The agent uses multiple tools in sequence:
+
+1. **Order lookup tool** — `get_order(customer_id="C-1234")` → Returns order details, items, and dates
+2. **Policy checker tool** — `check_return_eligibility(order_id="ORD-5678", reason="exchange")` → Returns "eligible, 14-day window"
+3. **Inventory tool** — `check_stock(sku="WIDGET-RED", warehouse="US-EAST")` → Returns "in stock, 47 units"
+4. **Payment tool** — `process_exchange(original_order="ORD-5678", new_sku="WIDGET-RED")` → Returns confirmation number
+
+Without tool use, the agent could only say "I'd be happy to help with your exchange" — it couldn't actually *do* anything.
+
+### Data analysis
+
+A user asks: "What were our top 5 products by revenue last quarter?"
+
+The agent calls a SQL query tool: `execute_query("SELECT product_name, SUM(revenue) as total FROM sales WHERE quarter='Q4-2025' GROUP BY product_name ORDER BY total DESC LIMIT 5")` — then formats the results into a readable table.
+
+## When to Use It
+
+- Any task requiring real-time or external data (current prices, weather, stock levels)
+- Tasks involving calculations or precise data manipulation
+- Workflows that require taking actions (sending emails, updating records, creating files)
+- Integration with existing business systems (CRM, ERP, order management)
+- Code execution and testing
+
+## Related Patterns
+
+- [Planning](planning.md) — Planning determines *which* tools to call and in what order
+- [Reflection](reflection.md) — The agent can reflect on tool results to decide if it needs to call additional tools
+- [Multi-Agent Collaboration](multi-agent-collaboration.md) — Different agents may have access to different tool sets
+- [Guardrails](guardrails.md) — Guardrails can restrict which tools an agent is allowed to call
+- [Agent Capability Patterns](index.md)
+
+## Further Reading
+
+- Karpas et al. 2022 — *MRKL Systems: A modular, neuro-symbolic architecture that combines large language models, external knowledge sources and discrete reasoning* — [arxiv.org/abs/2205.00445](https://arxiv.org/abs/2205.00445)
+- Yao et al. 2022 — *ReAct: Synergizing Reasoning and Acting in Language Models* — [arxiv.org/abs/2210.03629](https://arxiv.org/abs/2210.03629)
+- Anthropic — *Tool Use with Claude* — [docs.anthropic.com/en/docs/build-with-claude/tool-use](https://docs.anthropic.com/en/docs/build-with-claude/tool-use)
+- Andrew Ng — *Agentic Design Patterns Part 3: Tool Use* — [deeplearning.ai/the-batch](https://www.deeplearning.ai/the-batch/agentic-design-patterns-part-3-tool-use/)
+- OpenAI — *Function Calling Guide* — [platform.openai.com/docs/guides/function-calling](https://platform.openai.com/docs/guides/function-calling)

--- a/docs/agentic-building-blocks/agents/index.md
+++ b/docs/agentic-building-blocks/agents/index.md
@@ -9,13 +9,7 @@ Concepts for building AI agents and implementing tool use.
 
 ## Topics
 
-*Topics will be listed here as they are added.*
-
-<!-- Example format:
-- [Function Calling Basics](./function-calling-basics.md)
-- [Agent Architectures](./agent-architectures.md)
-- [Tool Design Patterns](./tool-design-patterns.md)
--->
+- [Agent Capability Patterns](./capability-patterns/index.md) — Seven architectural patterns that make agents effective: Reflection, Tool Use, Planning, Multi-Agent Collaboration, Memory, Guardrails, and Human-in-the-Loop
 
 ## Key Concepts
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -212,6 +212,15 @@ nav:
         - Do plugin skills conflict with custom skills?: agentic-building-blocks/skills/questions/do-plugin-skills-conflict-with-custom-skills.md
     - Agents:
       - Overview: agentic-building-blocks/agents/index.md
+      - Capability Patterns:
+        - Overview: agentic-building-blocks/agents/capability-patterns/index.md
+        - Reflection: agentic-building-blocks/agents/capability-patterns/reflection.md
+        - Tool Use: agentic-building-blocks/agents/capability-patterns/tool-use.md
+        - Planning: agentic-building-blocks/agents/capability-patterns/planning.md
+        - Multi-Agent Collaboration: agentic-building-blocks/agents/capability-patterns/multi-agent-collaboration.md
+        - Memory: agentic-building-blocks/agents/capability-patterns/memory.md
+        - Guardrails: agentic-building-blocks/agents/capability-patterns/guardrails.md
+        - Human-in-the-Loop: agentic-building-blocks/agents/capability-patterns/human-in-the-loop.md
       - Resources: agentic-building-blocks/agents/resources.md
     - MCP: agentic-building-blocks/mcp/index.md
   - AI Engineering:


### PR DESCRIPTION
## Summary

- Add 7 new pages under `docs/agentic-building-blocks/agents/capability-patterns/` covering Andrew Ng's agentic design patterns (Reflection, Tool Use, Planning, Multi-Agent Collaboration, Memory) plus Safety & Control patterns (Guardrails, Human-in-the-Loop)
- Add a hub page (`index.md`) with pattern catalog table, running customer exchange scenario, and where-to-start guidance
- Update `agents/index.md` to link to the new capability patterns hub
- Add nav entries to `mkdocs.yml`

## Test plan

- [ ] `mkdocs build --strict` passes (no new warnings from capability-patterns files)
- [ ] All cross-links between pattern pages resolve correctly
- [ ] Each pattern page has: What It Is, Why It Matters, How It Works, Example, When to Use It, Related Patterns, Further Reading
- [ ] Nav renders correctly in sidebar under Agents > Capability Patterns
- [ ] Visual spot-check on localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)