### PR TITLE
Add workflow architecture patterns

### DIFF
--- a/docs/agentic-building-blocks/agents/index.md
+++ b/docs/agentic-building-blocks/agents/index.md
@@ -38,4 +38,5 @@ For guidance on deciding *whether* your workflow needs an agent, see [Build Work
 - [Agentic Building Blocks](../index.md)
 - [AI Use Cases](../../use-cases/index.md) — what teams build with agents, organized by six primitives
 - [Automation Use Cases](../../use-cases/automation.md) — the highest-autonomy use cases powered by agents
+- [Workflow Architecture Patterns](../../patterns/workflow-architecture/index.md) — seven patterns from augmented LLMs to autonomous agents
 - [Patterns](../../patterns/index.md)

--- a/docs/business-first-ai-framework/build/design.md
+++ b/docs/business-first-ai-framework/build/design.md
@@ -53,6 +53,9 @@ Work through these five questions in order. The first "yes" tells you the minimu
 
 Most workflows start as Prompt or Skill-Powered Prompt and evolve toward agents as you add automation. Start simple, upgrade when you hit limits.
 
+!!! info "Deeper architectural patterns"
+    For detailed implementation blueprints (prompt chaining, routing, parallelization, orchestrator-workers, evaluator-optimizer, and autonomous agents), see [Workflow Architecture Patterns](../../patterns/workflow-architecture/index.md).
+
 ## Autonomy Classification
 
 For each step in your Workflow Definition, classify it on the autonomy spectrum:

--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -1,29 +1,17 @@
 ---
 title: AI Patterns and Best Practices
-description: Reusable patterns for prompting, agents, integrations, and error handling in AI systems
+description: Reusable patterns for workflow architecture, prompting, agents, integrations, and error handling in AI systems
 ---
 
 # Patterns
 
-Reusable patterns and best practices for AI/ML development.
+Reusable patterns and best practices for designing and building AI-powered systems.
 
-## Patterns
+## Workflow Architecture Patterns
 
-*Patterns will be listed here as they are added.*
+Seven architectural patterns for AI workflows, ranging from simple augmented LLMs to fully autonomous agents. Use these patterns to choose the right level of complexity for your workflow.
 
-<!-- Example format:
-### Prompting Patterns
-- [System Prompt Structure](./system-prompt-structure.md)
-- [Few-Shot Template](./few-shot-template.md)
-
-### Agent Patterns
-- [ReAct Loop](./react-loop.md)
-- [Tool Error Recovery](./tool-error-recovery.md)
-
-### Integration Patterns
-- [Retry with Backoff](./retry-with-backoff.md)
-- [Streaming Handler](./streaming-handler.md)
--->
+[Explore Workflow Architecture Patterns :material-arrow-right:](workflow-architecture/index.md){ .md-button }
 
 ## Categories
 
@@ -33,7 +21,7 @@ Patterns for structuring and optimizing prompts. See the [Prompt Engineering](..
 
 ### Agent Patterns
 
-Patterns for building reliable AI agents.
+Patterns for building reliable AI agents. See [Agent Capability Patterns](../agentic-building-blocks/agents/capability-patterns/index.md) for seven patterns that make agents effective.
 
 ### Integration Patterns
 

--- a/docs/patterns/workflow-architecture/augmented-llm.md
+++ b/docs/patterns/workflow-architecture/augmented-llm.md
@@ -1,0 +1,58 @@
+---
+title: Augmented LLM
+description: The foundational AI workflow pattern — an LLM enhanced with retrieval, tools, and memory to overcome its inherent limitations
+---
+
+# Augmented LLM
+
+An **Augmented LLM** combines the reasoning and generative abilities of an LLM with external tools, data, or systems to overcome its inherent limitations. It is the foundational building block for all other workflow architecture patterns.
+
+Think of it as an intelligent assistant that can access databases, search the web, run calculations, or interact with APIs — providing answers that go beyond what the model knows from training alone.
+
+## Why It Matters
+
+- **Enhanced capabilities** — Augmentation lets the model fetch real-time information, query databases, or use tools for accurate, up-to-date, and customized responses
+- **Task specialization** — Augmented LLMs excel at domain-specific tasks (financial analysis, customer service, medical diagnostics) because they pull in relevant data
+- **Adaptability** — They integrate into existing workflows and leverage specialized tools, making them flexible across business applications
+
+## Key Components
+
+| Component | Purpose | Example |
+|-----------|---------|---------|
+| **LLM Core** | Understands input, generates responses, decides which tasks require augmentation | User asks "What were our sales figures last month?" — the model recognizes it needs to retrieve this data |
+| **External Data Source** | Provides relevant, up-to-date, or domain-specific information (APIs, databases, cloud storage) | Sales data in a company database queried for the latest figures |
+| **Tools (Plugins)** | Specialized tools for calculations, data processing, or third-party interactions | A spreadsheet plugin calculates revenue growth from retrieved data |
+| **Orchestrator** | Oversees the process, ensuring seamless interaction between the LLM and external components | Routes the query to the database and sends results back to the LLM |
+| **User Input/Output** | The user's request in, and the enriched response out | Input: "What were last month's sales?" → Output: "Sales were $500,000, a 10% increase from the previous month." |
+
+## When to Use It
+
+- **Real-time information needs** — generating reports from live data, stock prices, or current metrics
+- **Complex tasks requiring multiple tools** — financial analysis that involves querying a database, running calculations, and formatting results
+- **Domain-specific expertise** — a healthcare LLM augmented with medical databases and imaging tools
+
+## Example: Customer Support Chatbot
+
+A company uses an AI-powered chatbot augmented with external systems:
+
+1. The LLM understands the customer's issue
+2. It queries the company's knowledge base or CRM for specific information (e.g., order status)
+3. If needed, it uses tools like a refund calculator to generate a solution
+4. The response — enriched with real-time data — is delivered to the customer
+
+This pattern enables accurate, context-aware responses without requiring the model to have all information in its training data.
+
+## How to Implement
+
+1. **Define the goal** — What task does the augmented LLM need to perform? Real-time data retrieval, calculations, or insight generation?
+2. **Integrate external data and tools** — Connect the LLM to relevant APIs, databases, or plugins. Ensure the orchestrator routes tasks properly.
+3. **Test iteratively** — Validate with different inputs to ensure seamless, accurate responses
+
+*Based on [Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) by Anthropic.*
+
+## Related
+
+- [Workflow Architecture Patterns Overview](index.md)
+- [Prompt Chaining](prompt-chaining.md) — the next step up in complexity
+- [MCP (Model Context Protocol)](../../agentic-building-blocks/mcp/index.md) — the connector layer for giving models access to external tools
+- [Build > Design Your AI Workflow](../../business-first-ai-framework/build/design.md)

--- a/docs/patterns/workflow-architecture/autonomous-agents.md
+++ b/docs/patterns/workflow-architecture/autonomous-agents.md
@@ -1,0 +1,78 @@
+---
+title: Autonomous Agents
+description: LLMs with tools, memory, and planning that independently execute multi-step tasks through a think-act-observe loop
+---
+
+# Autonomous Agents
+
+An **autonomous agent** is an LLM equipped with tools, memory, and planning logic that can interpret a high-level goal, break it into steps, execute actions in an external environment, evaluate feedback, and iterate until it finishes or hits a stop condition.
+
+Unlike the other workflow patterns where steps are predefined, agents decide **in real time** which tools to call and how many iterations they need. This gives them flexibility for open-ended, non-deterministic tasks.
+
+## Why It Matters
+
+| Benefit | Impact |
+|---------|--------|
+| **Flexibility** | Handles tasks where steps can't be pre-coded — multistep research, dynamic troubleshooting |
+| **Ground-truth feedback** | Uses real tool outputs or API responses to self-correct, reducing hallucinations |
+| **Human-like autonomy** | Mirrors expert work patterns (plan, do, check) and scales them across domains |
+| **Rapid iteration** | Adds, repeats, or skips steps until quality criteria or iteration/time limits are hit |
+
+## Key Components: The Agent Loop
+
+| Element | Purpose | Example |
+|---------|---------|---------|
+| **Human** | Issues the initial goal or provides feedback | "Draft a competitive analysis of ACME vs. BetaCo." |
+| **LLM Call (Brain)** | Parses the goal, reasons, and chooses the next action | *Thought:* "I should collect market-share data." |
+| **Action** | Invokes one or more tools (API, code, web search) | Calls a market data API for ACME and BetaCo |
+| **Environment** | The external system the action touches | Market-data service returns JSON |
+| **Feedback** | The result sent back to the LLM for reflection | *Observation:* "ACME 42%, BetaCo 35%." |
+| **Stop** | Task complete or iteration/time cap reached | "Report ready — exit loop." |
+
+The agent cycles through **think → act → observe** until the task is complete or a stop condition is met.
+
+## When to Use It
+
+| Use an Agent When... | Use a Workflow When... |
+|---------------------|----------------------|
+| Steps are unknown until runtime (open-ended research, debugging) | Steps are fixed and predictable (ETL, translation) |
+| Tool selection depends on intermediate results | A single LLM call plus retrieval suffices |
+| Human oversight is only needed at checkpoints | Tight latency or cost constraints dominate |
+
+## Example: Autonomous Customer Support Agent
+
+A SaaS company wants an agent that triages inquiries, pulls user data, suggests answers, and closes tickets automatically when confident:
+
+| Loop Phase | What Happens |
+|-----------|-------------|
+| **Goal** | "Resolve Tier-1 tickets under 3 min average." |
+| **Think** | Parse ticket, decide next action |
+| **Act** | CRM API → fetch account history. KB search → retrieve relevant article. |
+| **Observe** | CRM returns premium plan; KB returns refund policy article |
+| **Think** | Compose personalized answer; confidence 0.92 |
+| **Act** | Send reply + mark ticket solved |
+| **Stop** | Confidence above 0.9 OR max 5 iterations |
+
+**Results:**
+
+- **Quality** — Accurate, personalized resolutions
+- **Efficiency** — 60% of Tier-1 tickets auto-closed, cutting average handle time by 65%
+- **Scalability** — Agent retrains on new KB content nightly, staying up-to-date
+
+## How to Implement
+
+1. **Define clear success criteria** — Accuracy, format, KPIs that tell the agent when it's done
+2. **Expose the right tools** — Provide tools with explicit documentation and guardrails
+3. **Set iteration/time caps** — Prevent runaway loops with maximum iteration counts or time limits
+4. **Test in a sandbox** — Measure cost vs. quality, then graduate to production
+
+*Based on [Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) by Anthropic.*
+
+## Related
+
+- [Workflow Architecture Patterns Overview](index.md)
+- [Orchestrator-Workers](orchestrator-workers.md) — dynamic task delegation without the autonomous loop
+- [Evaluator-Optimizer](evaluator-optimizer.md) — iterative refinement with structured feedback
+- [Agents](../../agentic-building-blocks/agents/index.md) — concepts for building AI agents
+- [Agent Capability Patterns](../../agentic-building-blocks/agents/capability-patterns/index.md) — behavioral patterns (reflection, tool use, planning, etc.)
+- [Build > Design Your AI Workflow](../../business-first-ai-framework/build/design.md)

--- a/docs/patterns/workflow-architecture/evaluator-optimizer.md
+++ b/docs/patterns/workflow-architecture/evaluator-optimizer.md
@@ -1,0 +1,63 @@
+---
+title: Evaluator-Optimizer
+description: Generate output, evaluate it against criteria, and refine iteratively through a feedback loop until quality standards are met
+---
+
+# Evaluator-Optimizer
+
+The **evaluator-optimizer** pattern uses iterative refinement through two components: a **generator** that produces output and an **evaluator** that assesses it against predefined criteria. The workflow cycles between generation and evaluation until the output meets quality standards.
+
+This mirrors how humans refine their work — drafting, reviewing, and editing — to achieve optimal outcomes.
+
+## Why It Matters
+
+- **High-quality outputs** — The evaluator catches and refines suboptimal results before delivery
+- **Adaptable to complex tasks** — Ideal for nuanced or multi-faceted outputs that benefit from incremental improvement
+- **Human-like iteration** — Mimics the draft-review-revise cycle that produces polished work
+- **Dynamic feedback** — The evaluator can provide domain-specific feedback or adapt criteria, making it versatile across use cases
+
+## Key Components
+
+| Component | Purpose | Example |
+|-----------|---------|---------|
+| **Generator (LLM Call)** | Produces an initial solution or response | Drafts a marketing tagline for a product |
+| **Evaluator (LLM Call)** | Reviews output against evaluation criteria and provides actionable feedback | Assesses whether the tagline aligns with brand voice and audience preferences |
+| **Feedback Loop** | Iteratively refines output until it meets criteria | If the tagline misses brand guidelines, the evaluator provides specific improvement guidance |
+| **Accepted Output** | Delivers the finalized result once criteria are satisfied | A polished tagline ready for the campaign |
+
+## When to Use It
+
+- **Nuanced tasks** — When outputs require multiple layers of refinement (creative content, technical documentation)
+- **High-stakes outputs** — When accuracy and quality are critical (legal documents, strategic reports)
+- **Clear evaluation criteria** — When you can define measurable standards for what "good" looks like
+
+## Example: Refining a Marketing Campaign
+
+A company needs compelling marketing content (taglines, ad copy, social posts) that must reflect brand tone, resonate with the audience, and meet platform guidelines:
+
+1. **Generator** — Produces initial drafts of taglines, ad copy, and social media posts
+2. **Evaluator** — Reviews drafts against brand tone, audience fit, and platform requirements; provides actionable feedback ("Make the tagline more emotionally engaging for the target audience")
+3. **Feedback Loop** — Refines outputs iteratively until all criteria are met
+4. **Accepted Output** — Polished, ready-to-use marketing content aligned with campaign goals
+
+**Results:**
+
+- **Quality** — High-quality outputs aligned with brand and audience
+- **Efficiency** — Reduces manual editing, saving time and resources
+- **Consistency** — Uniform tone and style across campaign elements
+
+## How to Implement
+
+1. **Define evaluation criteria** — Establish clear, measurable standards (quality, alignment, tone)
+2. **Set up the feedback loop** — Ensure seamless communication between generator and evaluator for iterative refinement
+3. **Set iteration limits** — Prevent infinite loops by capping the number of refinement cycles
+4. **Test the workflow** — Validate that evaluator feedback effectively guides the generator toward desired outcomes
+
+*Based on [Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) by Anthropic.*
+
+## Related
+
+- [Workflow Architecture Patterns Overview](index.md)
+- [Prompt Chaining](prompt-chaining.md) — sequential steps with gates (but not iterative)
+- [Autonomous Agents](autonomous-agents.md) — agents with built-in evaluation through the think-act-observe loop
+- [Build > Design Your AI Workflow](../../business-first-ai-framework/build/design.md)

--- a/docs/patterns/workflow-architecture/index.md
+++ b/docs/patterns/workflow-architecture/index.md
@@ -1,0 +1,102 @@
+---
+title: Workflow Architecture Patterns
+description: Seven architectural patterns for AI workflows — from augmented LLMs to autonomous agents — with a selection framework for choosing the right pattern
+---
+
+# Workflow Architecture Patterns
+
+Every AI workflow falls somewhere on an autonomy spectrum. These seven patterns — drawn from Anthropic's research — provide a common vocabulary for describing how AI systems are structured, from simple tool-augmented models to fully autonomous agents.
+
+The right pattern depends on what your workflow actually needs, not on how sophisticated you want it to be. Start simple, upgrade when you hit limits.
+
+## The Autonomy Spectrum
+
+The patterns are organized into three tiers of increasing autonomy:
+
+### Foundation
+
+| Pattern | Description |
+|---------|-------------|
+| [Augmented LLM](augmented-llm.md) | An LLM enhanced with retrieval, tools, and memory — the building block for all other patterns |
+
+### Structured Workflows
+
+| Pattern | Description |
+|---------|-------------|
+| [Prompt Chaining](prompt-chaining.md) | Break a task into sequential steps, with validation gates between each step |
+| [Routing](routing.md) | Classify input and direct it to a specialized follow-up process |
+| [Parallelization](parallelization.md) | Run subtasks simultaneously and aggregate the results |
+| [Orchestrator-Workers](orchestrator-workers.md) | A central orchestrator dynamically breaks down tasks and delegates to specialized workers |
+| [Evaluator-Optimizer](evaluator-optimizer.md) | Generate output, evaluate it against criteria, and refine iteratively until it meets quality standards |
+
+### Autonomous
+
+| Pattern | Description |
+|---------|-------------|
+| [Autonomous Agents](autonomous-agents.md) | An LLM with tools, memory, and planning that independently executes multi-step tasks through a think-act-observe loop |
+
+## Pattern Selection Framework
+
+Use these three questions to identify which pattern your workflow needs:
+
+**1. Is the task predictable or open-ended?**
+
+- **Predictable** (you can define the steps in advance) → Use a structured workflow pattern
+- **Open-ended** (steps depend on what the AI discovers) → Consider an autonomous agent
+
+**2. How many steps are involved?**
+
+- **Single step** → Augmented LLM
+- **Sequential steps** → Prompt Chaining
+- **Branching paths** → Routing
+- **Independent parallel steps** → Parallelization
+- **Dynamic subtasks** → Orchestrator-Workers
+
+**3. Does the output need iterative refinement?**
+
+- **Yes, with clear quality criteria** → Evaluator-Optimizer
+- **Yes, with open-ended exploration** → Autonomous Agent
+
+### Decision Flow
+
+```
+Start here: Can you define all the steps in advance?
+│
+├── YES → How many steps?
+│   ├── One step → Augmented LLM
+│   ├── Sequential steps with validation → Prompt Chaining
+│   ├── Input determines the path → Routing
+│   ├── Independent steps that can run simultaneously → Parallelization
+│   └── Steps need dynamic decomposition → Orchestrator-Workers
+│
+├── PARTIALLY → Does output need iterative refinement?
+│   └── YES → Evaluator-Optimizer
+│
+└── NO → Steps are unknown until runtime
+    └── Autonomous Agent
+```
+
+!!! tip "Start simple, upgrade when needed"
+    Most workflows start as a single Augmented LLM or Prompt Chain. Only add complexity when you hit a concrete limitation — not because the problem *seems* complex.
+
+## How These Patterns Relate to the Framework
+
+The [Build > Design](../../business-first-ai-framework/build/design.md) phase of the Business-First AI Framework uses an Execution Pattern Spectrum (Prompt → Skill-Powered Prompt → Single Agent → Multi-Agent) to classify workflows at a higher level. These seven architecture patterns provide the detailed implementation blueprints within that spectrum:
+
+| Framework Execution Pattern | Architecture Patterns |
+|---------------------------|----------------------|
+| Prompt | Augmented LLM |
+| Skill-Powered Prompt | Prompt Chaining, Routing |
+| Single Agent | Parallelization, Orchestrator-Workers, Evaluator-Optimizer |
+| Multi-Agent | Orchestrator-Workers (multi-agent), Autonomous Agents |
+
+## Credit
+
+*Based on [Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) by Anthropic.*
+
+## Related
+
+- [Build > Design Your AI Workflow](../../business-first-ai-framework/build/design.md) — choose an execution pattern for your workflow
+- [Agents](../../agentic-building-blocks/agents/index.md) — concepts for building AI agents
+- [Agent Capability Patterns](../../agentic-building-blocks/agents/capability-patterns/index.md) — behavioral patterns (reflection, tool use, planning, etc.)
+- [Patterns Overview](../index.md)

--- a/docs/patterns/workflow-architecture/orchestrator-workers.md
+++ b/docs/patterns/workflow-architecture/orchestrator-workers.md
@@ -1,0 +1,79 @@
+---
+title: Orchestrator-Workers
+description: A central orchestrator dynamically breaks down tasks and delegates to specialized workers for flexible handling of complex, unpredictable problems
+---
+
+# Orchestrator-Workers
+
+The **orchestrator-workers** pattern handles complex tasks where subtasks can't be defined in advance. A central orchestrator dynamically breaks down a task, delegates subtasks to specialized workers, and synthesizes their outputs into a final result.
+
+This pattern differs from [parallelization](parallelization.md) because it emphasizes **flexibility and adaptability** — the orchestrator determines what needs to be done at runtime rather than following a predefined plan.
+
+## Why It Matters
+
+- **Flexibility for unknowns** — Adapts dynamically to varying task requirements, ideal for unstructured or evolving problems
+- **Specialization** — The orchestrator ensures each subtask goes to the most suitable worker
+- **Efficiency in complexity** — Complex tasks are broken into manageable components and results are synthesized
+- **Scalability** — Dynamic task assignment allows systems to scale for diverse and large workloads
+
+## Key Components
+
+| Component | Purpose | Example |
+|-----------|---------|---------|
+| **Orchestrator** | Analyzes input, determines required subtasks, assigns them to appropriate workers | Divides a customer query into legal, financial, and technical subtasks |
+| **Workers (LLM Calls)** | Specialized models or systems that process each subtask | Worker 1: legal analysis, Worker 2: financial evaluation, Worker 3: technical feasibility |
+| **Synthesizer** | Combines worker outputs into a coherent final result | Merges legal, financial, and technical findings into actionable recommendations |
+| **Input/Output** | The original task in, the synthesized result out | Input: multi-faceted customer request → Output: structured report addressing all aspects |
+
+## Predefined vs. Dynamic Workers
+
+The orchestrator can work with both:
+
+- **Predefined workers** — Specialized for known task types (e.g., financial analysis, image recognition). The orchestrator routes to the right one.
+- **Dynamic workers** — For tasks with unknown subtasks, the orchestrator creates workers on the fly:
+    1. **Dynamic configuration** — Tailors a general-purpose LLM with specific prompts to temporarily specialize it
+    2. **Tool integration** — Activates external tools or APIs to augment the worker's capabilities
+    3. **On-the-fly instantiation** — In advanced systems, generates new worker instances adapted to the task
+
+Dynamic worker creation ensures the system handles unexpected inputs without needing pre-configured workflows for every scenario.
+
+## When to Use It
+
+- **Unstructured tasks** — When subtasks can't be predicted or defined in advance
+- **Multi-domain expertise** — When the task spans areas requiring different specialized knowledge
+- **Dynamic workloads** — When new subtask types may emerge that weren't anticipated
+
+## Example: Comprehensive Market Research
+
+A company entering a new market needs analysis across competitor strategy, customer segmentation, and regulatory compliance:
+
+1. **Orchestrator** breaks the task into three subtasks and assigns workers
+2. **Worker 1** — Scans competitor pricing, products, and strategies
+3. **Worker 2** — Processes demographic and survey data to generate customer segments
+4. **Worker 3** — Reviews regulatory documents and flags compliance risks
+5. **Synthesizer** — Combines outputs into a unified market research report
+
+If a new subtask emerges (e.g., evaluating environmental impact), the orchestrator dynamically assigns or creates a new worker.
+
+**Results:**
+
+- **Speed** — All subtasks processed simultaneously
+- **Specialization** — Each domain handled by a focused worker
+- **Flexibility** — New subtasks addressed without restructuring the workflow
+
+## How to Implement
+
+1. **Design the orchestrator** — Build the logic that analyzes inputs and determines subtask breakdown
+2. **Define worker capabilities** — Establish predefined workers for known task types and rules for dynamic creation
+3. **Build the synthesizer** — Define how worker outputs combine into a coherent final result
+4. **Test with varied inputs** — Ensure the orchestrator correctly identifies subtasks and routes to appropriate workers
+
+*Based on [Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) by Anthropic.*
+
+## Related
+
+- [Workflow Architecture Patterns Overview](index.md)
+- [Parallelization](parallelization.md) — similar structure but with predefined subtasks
+- [Autonomous Agents](autonomous-agents.md) — the next step in autonomy
+- [Agents](../../agentic-building-blocks/agents/index.md) — concepts for building AI agents
+- [Build > Design Your AI Workflow](../../business-first-ai-framework/build/design.md)

--- a/docs/patterns/workflow-architecture/parallelization.md
+++ b/docs/patterns/workflow-architecture/parallelization.md
@@ -1,0 +1,72 @@
+---
+title: Parallelization
+description: Run subtasks simultaneously and aggregate results for faster, more reliable AI workflows
+---
+
+# Parallelization
+
+**Parallelization** divides subtasks of a larger problem and processes them simultaneously through separate LLM calls. The outputs are then aggregated to produce the final result.
+
+This pattern has two primary variations:
+
+- **Sectioning** — Breaking a task into independent subtasks, each processed in parallel
+- **Voting** — Running the same task multiple times to generate diverse perspectives, then aggregating for higher confidence
+
+## Why It Matters
+
+- **Increased speed** — Parallel processing reduces latency by distributing workloads, ideal for time-sensitive tasks
+- **Enhanced reliability** — Multiple evaluations or diverse subtasks processed in parallel produce higher-confidence results
+- **Focused task management** — Specialized LLM calls handle each subtask, improving accuracy through focused attention
+- **Scalability** — Larger datasets or more complex workflows are handled without bottlenecking a single model
+
+## Key Components
+
+| Component | Purpose | Example |
+|-----------|---------|---------|
+| **Parallel LLM Calls** | Each handles a different subtask (sectioning) or repeats the same task (voting) | One call evaluates content for tone, another for factual accuracy, another for compliance |
+| **Aggregator** | Combines parallel outputs into a unified result (consolidating, voting on best, or integrating insights) | Merges flagged issues from parallel code reviews into a comprehensive report |
+| **Input/Output** | Input initiates all parallel processes; output delivers aggregated results | Input: a large dataset → Output: a combined analysis report |
+
+## When to Use It
+
+- **Speed-intensive tasks** — Time-sensitive workflows requiring simultaneous processing
+- **Tasks with multiple dimensions** — Multiple independent considerations that can be evaluated separately
+- **Higher confidence needs** — Outputs requiring validation through multiple attempts or perspectives
+
+## Example: Market Research Analysis
+
+A company needs comprehensive market analysis for a product launch covering competitor analysis, consumer trends, and regional insights:
+
+**Sectioning approach:**
+
+1. **Parallel Call 1** — Evaluates competitors' pricing and positioning
+2. **Parallel Call 2** — Analyzes customer preferences and behaviors
+3. **Parallel Call 3** — Studies market potential across regions
+4. **Aggregator** — Combines all findings into one comprehensive report
+
+**Voting approach (for uncertain predictions):**
+
+1. Multiple models independently predict regional sales figures
+2. The aggregator evaluates and combines predictions for a well-rounded decision
+
+**Results:**
+
+- **Speed** — All parts complete simultaneously instead of sequentially
+- **Focus** — Each call specializes in its area, improving depth and quality
+- **Confidence** — Voting reflects multiple viewpoints, reducing bias
+
+## How to Implement
+
+1. **Identify subtasks** — Break the problem into components that can be processed independently
+2. **Determine parallelization type** — Sectioning (dividing tasks) or voting (repeating with different approaches)
+3. **Set up aggregation rules** — Define how outputs combine (consensus, averaging, concatenating)
+4. **Test and optimize** — Ensure efficient operation and consistent, high-quality outputs
+
+*Based on [Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) by Anthropic.*
+
+## Related
+
+- [Workflow Architecture Patterns Overview](index.md)
+- [Routing](routing.md) — directs to one specialized path; parallelization runs multiple paths simultaneously
+- [Orchestrator-Workers](orchestrator-workers.md) — similar structure but with dynamic task decomposition
+- [Build > Design Your AI Workflow](../../business-first-ai-framework/build/design.md)

--- a/docs/patterns/workflow-architecture/prompt-chaining.md
+++ b/docs/patterns/workflow-architecture/prompt-chaining.md
@@ -1,0 +1,62 @@
+---
+title: Prompt Chaining
+description: Break complex tasks into sequential steps with validation gates between each step for structured, reliable AI workflows
+---
+
+# Prompt Chaining
+
+**Prompt chaining** breaks a complex task into a sequence of smaller steps. Each step (LLM call) builds on the output of the previous one, with intermediate **gates** that validate quality before proceeding. If an output fails validation, the process can exit early to prevent error propagation.
+
+Think of it as an assembly line where each station contributes a specific part to the final product.
+
+## Why It Matters
+
+- **Increased accuracy** — Each LLM call focuses on a specific goal, reducing errors and improving overall quality
+- **Modularity** — You can inspect and debug intermediate steps, making the workflow easier to adapt and refine
+- **Enhanced reliability** — Programmatic gates catch errors early, increasing confidence in the final output
+- **Efficiency trade-off** — This workflow trades some latency (multiple steps) for more robust, higher-quality outputs
+
+## Key Components
+
+| Component | Purpose | Example |
+|-----------|---------|---------|
+| **LLM Call 1** | Handles the initial step and produces the first output | Generate a document outline based on user input |
+| **Gate** | Validates the output of the previous call; continues or exits | Check if the outline contains all necessary sections |
+| **LLM Call 2** | Processes the validated output from the previous step | Expand the approved outline into a detailed draft |
+| **LLM Call 3** | Finalizes the task by refining or transforming the output | Translate the draft or format it for publication |
+| **Exit** | Ends the workflow early if validation fails | Stop if the outline doesn't meet quality standards |
+| **Output** | Delivers the final product after all steps complete successfully | A polished, translated document ready for publication |
+
+## When to Use It
+
+- **Multi-step processes** — Tasks that naturally decompose into sequential steps (generate, validate, refine)
+- **Tasks requiring validation** — When intermediate outputs need quality checks before proceeding
+- **Complex workflows** — When different steps benefit from different prompts, models, or configurations
+
+## Example: Generating Marketing Materials
+
+A company needs product launch copy translated into multiple languages with consistent tone:
+
+1. **LLM Call 1** — Generate initial marketing copy from product details and target audience
+2. **Gate** — Validate against tone guide and campaign goals
+3. **LLM Call 2** — Translate the validated copy into multiple languages
+4. **Gate** — Ensure translations retain tone and key messages
+5. **LLM Call 3** — Format translated copy for each platform (email, social media, website)
+6. **Output** — Finalized, multilingual marketing materials ready for deployment
+
+## How to Implement
+
+1. **Decompose the task** — Identify the logical subtasks that make up the overall goal
+2. **Define validation criteria** — Establish clear checkpoints (gates) to evaluate outputs after each step
+3. **Connect steps programmatically** — Design the workflow so outputs from one step feed into the next
+4. **Test and refine** — Ensure each step performs as intended and adjust based on intermediate results
+
+*Based on [Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) by Anthropic.*
+
+## Related
+
+- [Workflow Architecture Patterns Overview](index.md)
+- [Augmented LLM](augmented-llm.md) — the foundation this pattern builds on
+- [Routing](routing.md) — another structured workflow for branching paths
+- [Evaluator-Optimizer](evaluator-optimizer.md) — iterative refinement with feedback loops
+- [Build > Design Your AI Workflow](../../business-first-ai-framework/build/design.md)

--- a/docs/patterns/workflow-architecture/routing.md
+++ b/docs/patterns/workflow-architecture/routing.md
@@ -1,0 +1,62 @@
+---
+title: Routing
+description: Classify input and direct it to specialized follow-up processes for optimized handling of diverse task types
+---
+
+# Routing
+
+The **routing** pattern classifies input and directs it to a specialized follow-up task. By separating tasks into distinct categories and routing them to appropriate processes, this pattern enables **separation of concerns** and highly optimized handling for each input type.
+
+Without routing, optimizing a system for one type of input (e.g., simple queries) can degrade performance for other types (e.g., complex or edge-case queries).
+
+## Why It Matters
+
+- **Specialization improves performance** — Each task type is handled by a tailored process, ensuring higher accuracy
+- **Efficiency** — Tasks go to the most appropriate system, optimizing resource use and reducing computational costs
+- **Scalability** — Varied input types are handled effectively by directing them to the right models or systems
+- **Reduced bottlenecks** — No single model becomes overwhelmed by diverse inputs it isn't optimized for
+
+## Key Components
+
+| Component | Purpose | Example |
+|-----------|---------|---------|
+| **Router (LLM Call)** | Classifies incoming tasks and directs them to the appropriate follow-up | Determines if a customer query is general, refund-related, or technical |
+| **Specialized Process 1** | Handles one specific task category | Responds to general inquiries (store hours, product info) |
+| **Specialized Process 2** | Handles a different task category | Processes refund requests (checking order history, issuing refunds) |
+| **Specialized Process 3** | Handles complex or specialized tasks | Resolves technical support issues with troubleshooting steps |
+| **Output** | Consolidates results into the final response | Delivers the resolved answer to the customer |
+
+## When to Use It
+
+- **Diverse input types** — When the system handles inputs that differ in complexity or nature
+- **High-performance requirements** — When optimizing for one input type risks degrading performance for others
+- **Resource optimization** — When simple tasks can use smaller models while reserving powerful models for complex cases
+
+## Example: Customer Service Automation
+
+A company automates customer service across varied query types:
+
+1. **Router** classifies each query:
+    - General questions ("What are your store hours?")
+    - Refund requests ("I want a refund for my last order.")
+    - Technical issues ("My device isn't turning on.")
+2. **Process 1** handles general inquiries with predefined responses
+3. **Process 2** processes refunds by accessing order history, validating claims, and initiating refunds
+4. **Process 3** resolves technical issues with product-specific troubleshooting
+5. **Output** delivers the final response to the customer
+
+## How to Implement
+
+1. **Define categories** — Identify the distinct task or input types your system will handle
+2. **Train or configure the router** — Implement a classification mechanism (LLM or traditional classifier) to route inputs correctly
+3. **Develop specialized workflows** — Create tailored workflows or prompts for each category
+4. **Test and refine** — Evaluate routing accuracy and each specialized workflow's effectiveness
+
+*Based on [Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) by Anthropic.*
+
+## Related
+
+- [Workflow Architecture Patterns Overview](index.md)
+- [Prompt Chaining](prompt-chaining.md) — sequential processing within a single path
+- [Parallelization](parallelization.md) — running multiple paths simultaneously
+- [Build > Design Your AI Workflow](../../business-first-ai-framework/build/design.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -300,7 +300,17 @@ nav:
     - "Step 5 — AI Coding CLIs": builder-setup/claude-code-install.md
     - "Step 6 — AI Registry": builder-setup/notion-registry-setup.md
     - "Step 7 — Voice to Text": builder-setup/voice-to-text-setup.md
-  - Patterns: patterns/index.md
+  - Patterns:
+    - Overview: patterns/index.md
+    - Workflow Architecture Patterns:
+        - Overview: patterns/workflow-architecture/index.md
+        - Augmented LLM: patterns/workflow-architecture/augmented-llm.md
+        - Prompt Chaining: patterns/workflow-architecture/prompt-chaining.md
+        - Routing: patterns/workflow-architecture/routing.md
+        - Parallelization: patterns/workflow-architecture/parallelization.md
+        - Orchestrator-Workers: patterns/workflow-architecture/orchestrator-workers.md
+        - Evaluator-Optimizer: patterns/workflow-architecture/evaluator-optimizer.md
+        - Autonomous Agents: patterns/workflow-architecture/autonomous-agents.md
   - Courses:
     - Overview: courses/index.md
     - Agentic AI for Leaders:


### PR DESCRIPTION
## Summary

- Adds 7 workflow architecture pattern pages to `docs/patterns/workflow-architecture/` based on Anthropic's "Building Effective Agents" research
- Patterns cover the full autonomy spectrum: Augmented LLM, Prompt Chaining, Routing, Parallelization, Orchestrator-Workers, Evaluator-Optimizer, Autonomous Agents
- Includes an overview page with a pattern selection framework (decision tree) and mapping to the Business-First AI Framework execution patterns

## Test plan

- [ ] `mkdocs build` passes (no new warnings from pattern pages)
- [ ] Nav expands correctly under Patterns with all 8 pages
- [ ] Cross-links work from Build > Design and Agents building block
- [ ] Anthropic credit links resolve correctly
- [ ] Pattern selection framework decision flow renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)