### PR TITLE
Add Model as the 7th agentic building block

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Thank you for contributing to Hands-On AI! This guide explains how to add new co
 
 | Section | Location | Purpose |
 |---------|----------|---------|
-| Agentic Building Blocks | `agentic-building-blocks/` | The six AI building blocks (Prompts, Context, Projects, Skills, Agents, MCP) |
+| Agentic Building Blocks | `agentic-building-blocks/` | The seven AI building blocks (Model, Prompts, Context, Projects, Skills, Agents, MCP) |
 | Business-First AI Framework | `business-first-ai-framework/` | Three-phase methodology (Discover, Deconstruct, Build) |
 | Use Cases | `use-cases/` | Six use case primitives (Content Creation, Research, Coding, Data Analysis, Ideation & Strategy, Automation) |
 | Platforms | `platforms/` | Platform-specific content (Claude, OpenAI, Gemini, M365 Copilot) |

--- a/docs/agentic-building-blocks/context/context-graphs.md
+++ b/docs/agentic-building-blocks/context/context-graphs.md
@@ -117,7 +117,7 @@ Context graphs intersect with every other building block:
 
 - [Context Engineering](../../ai-engineering/context-engineering.md) — the broader discipline; context graphs are an advanced technique within it
 - [Context](index.md) — the Context building block overview
-- [Agentic Building Blocks](../index.md) — Context Graphs in the context of all six building blocks
+- [Agentic Building Blocks](../index.md) — Context Graphs in the context of all seven building blocks
 - [AI Use Cases](../../use-cases/index.md) — what teams build with context, organized by six primitives
 - [Agents](../agents/index.md) — autonomous workflows that benefit most from structured context
 - [MCP](../mcp/index.md) — the protocol for connecting agents to external context sources

--- a/docs/agentic-building-blocks/context/index.md
+++ b/docs/agentic-building-blocks/context/index.md
@@ -72,7 +72,7 @@ Context makes prompts smarter. Projects organize context persistently so you don
 ## Related
 
 - [Context Graphs](context-graphs.md) — structured decision and reasoning graphs for agentic AI
-- [Agentic Building Blocks](../index.md) — Context in the context of all six building blocks
+- [Agentic Building Blocks](../index.md) — Context in the context of all seven building blocks
 - [AI Use Cases](../../use-cases/index.md) — what teams build with context, organized by six primitives
 - [Prompts](../prompts/index.md) — the instructions that context enhances
 - [Projects](../projects/index.md) — where context becomes persistent and organized

--- a/docs/agentic-building-blocks/index.md
+++ b/docs/agentic-building-blocks/index.md
@@ -1,6 +1,6 @@
 ---
 title: Agentic AI Building Blocks
-description: The six components of agentic AI workflows — Prompt, Context, Project, Skill, Agent, and MCP
+description: The seven components of agentic AI workflows — Model, Prompt, Context, Project, Skill, Agent, and MCP
 ---
 
 # Agentic AI Building Blocks
@@ -9,23 +9,24 @@ description: The six components of agentic AI workflows — Prompt, Context, Pro
 
 ## Overview
 
-The six AI building blocks are a shared vocabulary for describing the components of any AI workflow. Whether you're writing a single prompt or orchestrating a multi-agent pipeline, every AI workflow is assembled from some combination of these six pieces.
+The seven AI building blocks are a shared vocabulary for describing the components of any AI workflow. Whether you're writing a single prompt or orchestrating a multi-agent pipeline, every AI workflow is assembled from some combination of these seven pieces.
 
 The blocks progress from simple to complex:
 
-**Prompt** → **Context** → **Project** → **Skill** → **Agent** → **MCP**
+**Model** → **Prompt** → **Context** → **Project** → **Skill** → **Agent** → **MCP**
 
-These are platform-agnostic concepts. Every major AI platform implements them, though the names and interfaces differ. Understanding the blocks gives you a mental model that transfers across tools — you can evaluate any platform by asking "how does it handle prompts, context, projects, skills, agents, and external connections?"
+These are platform-agnostic concepts. Every major AI platform implements them, though the names and interfaces differ. Understanding the blocks gives you a mental model that transfers across tools — you can evaluate any platform by asking "how does it handle models, prompts, context, projects, skills, agents, and external connections?"
 
 !!! tip "Using building blocks for workflow analysis"
-    The [Business-First AI Framework](../business-first-ai-framework/index.md) uses these six blocks as the analysis tool in [Design Your AI Workflow](../business-first-ai-framework/build/design.md), where each step of a workflow gets mapped to the building blocks it needs.
+    The [Business-First AI Framework](../business-first-ai-framework/index.md) uses these seven blocks as the analysis tool in [Design Your AI Workflow](../business-first-ai-framework/build/design.md), where each step of a workflow gets mapped to the building blocks it needs.
 
-![Agentic AI Building Blocks — the six components from Prompt through MCP](../assets/images/agentic-building-blocks.png)
+![Agentic AI Building Blocks — the seven components from Model through MCP](../assets/images/agentic-building-blocks.png)
 
 ## Summary
 
 | Block | What It Is | Persistence | Complexity |
 |-------|-----------|-------------|------------|
+| **Model** | The AI engine that processes inputs and generates outputs | Persistent (platform-managed) | Foundation |
 | **Prompt** | A well-crafted instruction that tells the model what to do | Single use | Low |
 | **Context** | Background information, reference docs, or examples the model needs | Per conversation or persistent | Low |
 | **Project** | A persistent workspace grouping prompts, context, skills, and agents | Persistent | Medium |
@@ -33,7 +34,34 @@ These are platform-agnostic concepts. Every major AI platform implements them, t
 | **Agent** | An autonomous AI that plans, uses tools, and executes multi-step work | Session-based or persistent | High |
 | **MCP** | A connector that lets AI access external tools, services, or databases | Persistent | High |
 
-## The Six Building Blocks
+## The Seven Building Blocks
+
+### Model
+
+The AI engine that processes inputs and generates outputs. Models are trained on data and come in different capability tiers — from fast, lightweight models for simple tasks to deep reasoning models for complex analysis.
+
+**Key characteristics:**
+
+- The foundation all other blocks operate on — every AI interaction requires a model
+- Come in capability tiers: fast models for speed, reasoning models for depth
+- Have defined context windows and vary by modality (text, code, vision, audio)
+
+**When to use it:** Every AI interaction uses a model. The key decision is choosing the *right* model — matching model capabilities to your task requirements.
+
+**Example:** Using a fast model for high-volume email classification, and a reasoning model for complex strategy analysis that requires nuanced judgment.
+
+**Cross-platform implementations:**
+
+| Platform | How It Works |
+|----------|-------------|
+| Claude | Multiple model tiers (fast, balanced, reasoning); select via model picker or API |
+| OpenAI (ChatGPT) | Multiple model tiers (fast, balanced, reasoning); select via model picker or API |
+| Gemini | Multiple model tiers (fast, balanced); select via model picker or API |
+| M365 Copilot | Models managed by Microsoft; limited user selection |
+
+**Relationship to other blocks:** Model is the engine — prompts steer it, context informs it, skills package routines for it, agents orchestrate it, and MCP connects it to external systems.
+
+---
 
 ### Prompt
 
@@ -205,12 +233,13 @@ An open standard for connecting AI assistants to external systems where data liv
 
 The building blocks build on each other. Here's how a workflow grows as you adopt more blocks:
 
-1. **Start with a Prompt** — Write clear instructions for what you want done
-2. **Add Context** — Attach reference materials so the model has what it needs
-3. **Organize in a Project** — Group your prompt and context so they persist across conversations
-4. **Package as a Skill** — Turn the prompt + context into a reusable routine you can invoke with different inputs
-5. **Connect with MCP** — Give the skill access to external data and tools
-6. **Orchestrate with an Agent** — Let an autonomous AI run the skill, use MCP connections, and handle multi-step workflows
+1. **Choose a Model** — Select the right AI engine for your task (speed vs. depth, modality, cost)
+2. **Start with a Prompt** — Write clear instructions for what you want done
+3. **Add Context** — Attach reference materials so the model has what it needs
+4. **Organize in a Project** — Group your prompt and context so they persist across conversations
+5. **Package as a Skill** — Turn the prompt + context into a reusable routine you can invoke with different inputs
+6. **Connect with MCP** — Give the skill access to external data and tools
+7. **Orchestrate with an Agent** — Let an autonomous AI run the skill, use MCP connections, and handle multi-step workflows
 
 ### Worked example: Weekly Client Status Report
 
@@ -227,10 +256,11 @@ The building blocks build on each other. Here's how a workflow grows as you adop
 
 ## Platform Comparison
 
-All six building blocks across all four platforms in one view:
+All seven building blocks across all four platforms in one view:
 
 | Building Block | Claude | OpenAI (ChatGPT) | Gemini | M365 Copilot |
 |---------------|--------|-------------------|--------|--------------|
+| **Model** | Multiple tiers (fast, balanced, reasoning) | Multiple tiers (fast, balanced, reasoning) | Multiple tiers (fast, balanced) | Microsoft-managed |
 | **Prompt** | Conversation messages, system prompts | Conversation messages, system prompts | Conversation messages | Chat messages |
 | **Context** | File attachments, project knowledge | File uploads, GPT knowledge files | File uploads, Drive, NotebookLM | Microsoft Graph, documents |
 | **Project** | Claude Projects | Custom GPTs, ChatGPT Projects | Gems | Copilot agents |
@@ -243,7 +273,7 @@ All six building blocks across all four platforms in one view:
 **"Skills and agents are the same thing."**
 Skills are routines — they do one specific thing when invoked. Agents are autonomous — they decide what to do, plan steps, and invoke skills (among other tools) to accomplish goals. A skill is a tool; an agent is the one using the toolbox.
 
-**"You need all six blocks for every workflow."**
+**"You need all seven blocks for every workflow."**
 Most workflows need two or three blocks. A well-written prompt with good context handles many tasks. Only add blocks when the workflow genuinely requires them.
 
 **"MCP is a Claude-only technology."**
@@ -263,6 +293,7 @@ A project is an active workspace — it provides standing instructions, persiste
 
 **Fundamentals deep-dives:**
 
+- [Model](models/index.md) — the AI engine that powers everything
 - [Prompts](prompts/index.md) — the Prompt building block, with prompt engineering techniques
 - [Context](context/index.md) — background information and reference materials
 - [Projects](projects/index.md) — project workspaces with memory, knowledge bases, and custom instructions

--- a/docs/agentic-building-blocks/mcp/index.md
+++ b/docs/agentic-building-blocks/mcp/index.md
@@ -60,7 +60,7 @@ MCP extends what agents and skills can do by connecting them to external systems
 
 ## Related
 
-- [Agentic Building Blocks](../index.md) — MCP in the context of all six building blocks
+- [Agentic Building Blocks](../index.md) — MCP in the context of all seven building blocks
 - [AI Use Cases](../../use-cases/index.md) — what teams build with MCP, organized by six primitives
 - [Automation Use Cases](../../use-cases/automation.md) — MCP enables the data connections that power automated workflows
 - [Agents](../agents/index.md) — autonomous systems that use MCP to interact with external tools

--- a/docs/agentic-building-blocks/models/index.md
+++ b/docs/agentic-building-blocks/models/index.md
@@ -1,0 +1,109 @@
+---
+title: Model
+description: The Model building block — the AI engine that processes inputs and generates outputs, powering everything the other building blocks do
+---
+
+# Model
+
+> **Platforms:** `claude` `openai` `gemini` `m365-copilot`
+
+## What a Model Is
+
+A **model** is the AI engine that powers everything. It's a system trained on data that takes input and produces output through learned patterns — generating text, writing code, analyzing images, or reasoning through complex problems.
+
+Every other building block depends on a model. Prompts steer it. Context informs it. Projects organize work for it. Skills package routines for it. Agents orchestrate it. MCP connects it to external systems. Without a model, the other blocks have nothing to run on.
+
+## Key Characteristics
+
+- **Trained on data** — a model's knowledge comes from its training data, with a cutoff date after which it has no information
+- **Come in capability tiers** — from fast, lightweight models for simple tasks to deep reasoning models for complex analysis
+- **Have defined context windows** — how much information (measured in tokens) a model can process at once
+- **Vary by modality** — some handle only text, others work with code, vision, audio, or multiple modalities together
+
+## Model Capabilities
+
+Different models excel at different things. Here are the key capability dimensions to consider:
+
+| Capability | What It Means | Example Tasks |
+|-----------|---------------|---------------|
+| **Reasoning** | Complex analysis, multi-step logic, nuanced judgment | Strategy analysis, research synthesis, debugging complex systems |
+| **Code generation** | Writing, debugging, and explaining code | Building features, fixing bugs, code review |
+| **Multimodal** | Processing or generating images, audio, or video | Analyzing charts, describing photos, transcribing audio |
+| **Speed** | Fast response for simple, high-volume tasks | Summarization, formatting, classification, triage |
+| **Context window** | How much input the model can handle at once | Processing long documents, large codebases, multi-file analysis |
+| **Tool use** | Calling functions, APIs, and external tools | Running code, searching the web, querying databases |
+
+## When to Use It (Model Selection Guidance)
+
+Choosing the right model for the task is one of the highest-leverage decisions you can make:
+
+| Task Type | Recommended Model Tier | Why |
+|-----------|----------------------|-----|
+| Simple tasks (summarization, formatting, classification) | Fast, lightweight models | Speed and cost matter more than depth |
+| Complex analysis (research, strategy, multi-step reasoning) | Reasoning-capable models | Accuracy and depth matter more than speed |
+| Visual tasks (image analysis, diagram interpretation) | Multimodal models | The task requires understanding non-text inputs |
+| Code-heavy work (building features, debugging, refactoring) | Code-optimized models | Specialized training produces better code output |
+| High-volume automation (batch processing, triage) | Fast models with tool use | Throughput and cost-efficiency are priorities |
+
+!!! tip "Cost-quality tradeoff"
+    Not every task needs the most powerful model. Using a fast model for simple tasks and reserving reasoning models for complex ones saves cost without sacrificing quality. Many platforms let you route different tasks to different models within the same workflow.
+
+## Foundational Concepts
+
+These concepts help you understand what a model is and how it works:
+
+**Parameters** — The internal weights that define a model's learned patterns. More parameters generally means more capability, but also more computational cost. You don't set parameters — they're determined during training.
+
+**Tokens** — How models measure input and output. A token is roughly 3-4 characters of English text. Models have limits on how many tokens they can process (input) and generate (output) per request.
+
+**Context window** — The total number of tokens a model can handle in a single interaction, including both the input you provide and the output it generates. Larger context windows let you work with longer documents and more complex inputs.
+
+**Temperature** — A setting that controls randomness in outputs. Low temperature (0.0) produces more deterministic, focused responses. High temperature (1.0+) produces more creative, varied responses. Most platforms default to a balanced setting.
+
+**Training data and knowledge cutoff** — Models learn from data up to a specific date. They don't know about events, products, or information published after their cutoff. This is why context (providing current information) is essential for tasks involving recent data.
+
+**Fine-tuning** — Customizing a pre-trained model on your specific data to improve performance for your domain. Most users don't need to fine-tune — prompt engineering and context are usually sufficient — but it's available for specialized use cases.
+
+## Where to Find Models
+
+| Source | What's Available | Best For |
+|--------|-----------------|----------|
+| **Anthropic (Claude)** | Claude model family across capability tiers | Reasoning, code, analysis, long context |
+| **OpenAI** | GPT and reasoning model families | General purpose, reasoning, multimodal |
+| **Google** | Gemini model family | Multimodal, Google ecosystem integration |
+| **Open-source hubs (Hugging Face)** | Thousands of community and enterprise models | Custom deployment, fine-tuning, specialized tasks |
+
+!!! info "Open-source vs. proprietary"
+    Proprietary models (Claude, GPT, Gemini) are accessed via APIs and platforms — you don't host them yourself. Open-source models (Llama, Mistral, and others on Hugging Face) can be downloaded and run on your own infrastructure, offering more control but requiring more technical setup.
+
+## Platform Implementations
+
+| Platform | How It Works |
+|----------|-------------|
+| **Claude** | Multiple model tiers (fast, balanced, reasoning); select via model picker in conversation or API parameter |
+| **OpenAI (ChatGPT)** | Multiple model tiers (fast, balanced, reasoning); select via model picker in conversation or API parameter |
+| **Gemini** | Multiple model tiers (fast, balanced); select via model picker in conversation or API parameter |
+| **M365 Copilot** | Models managed by Microsoft; limited user selection based on Copilot context |
+
+## Relationship to Other Blocks
+
+Model is the foundation — the engine everything else runs on:
+
+- **Prompts** steer the model — telling it what to do
+- **Context** informs the model — giving it knowledge it wasn't trained on
+- **Projects** organize work for the model — grouping instructions and context
+- **Skills** package routines for the model — reusable workflows it executes
+- **Agents** orchestrate the model — directing it through multi-step tasks
+- **MCP** connects the model — giving it access to external tools and data
+
+## Related
+
+- [Agentic Building Blocks](../index.md) — Model in the context of all seven building blocks
+- [AI Use Cases](../../use-cases/index.md) — what teams build with these blocks, organized by six primitives
+- [Prompts](../prompts/index.md) — the instructions that steer the model
+- [Context](../context/index.md) — the knowledge that informs the model
+- [Projects](../projects/index.md) — workspaces that organize work for the model
+- [Skills](../skills/index.md) — reusable routines the model executes
+- [Agents](../agents/index.md) — autonomous systems that orchestrate the model
+- [MCP](../mcp/index.md) — connectors that extend the model's reach
+- [Platforms](../../platforms/index.md) — platform-specific model guides

--- a/docs/agentic-building-blocks/projects/index.md
+++ b/docs/agentic-building-blocks/projects/index.md
@@ -77,7 +77,7 @@ Good projects have:
 
 ## Related
 
-- [Agentic Building Blocks](../index.md) — Projects in the context of all six building blocks
+- [Agentic Building Blocks](../index.md) — Projects in the context of all seven building blocks
 - [AI Use Cases](../../use-cases/index.md) — what teams build with projects, organized by six primitives
 - [Prompts](../prompts/index.md) — techniques for the prompts that go inside projects
 - [Business-First AI Framework](../../business-first-ai-framework/index.md) — uses projects as a building block in workflow analysis

--- a/docs/agentic-building-blocks/prompts/index.md
+++ b/docs/agentic-building-blocks/prompts/index.md
@@ -73,7 +73,7 @@ Not every prompt needs all four elements. A simple question needs only the task.
 ## Related
 
 - [Context Engineering](../../ai-engineering/context-engineering.md) — the broader discipline that prompt engineering is part of
-- [Agentic Building Blocks](../index.md) — Prompts in the context of all six building blocks
+- [Agentic Building Blocks](../index.md) — Prompts in the context of all seven building blocks
 - [AI Use Cases](../../use-cases/index.md) — see how prompts are used across content creation, research, coding, data analysis, ideation, and automation
 - [Projects](../projects/index.md) — where prompts become persistent custom instructions
 - [Patterns](../../patterns/index.md) — reusable prompt structures

--- a/docs/agentic-building-blocks/prompts/questions/what-is-a-system-prompt.md
+++ b/docs/agentic-building-blocks/prompts/questions/what-is-a-system-prompt.md
@@ -59,4 +59,4 @@ print(response.choices[0].message.content)
 
 - [Prompts](../index.md) — the Prompt building block overview
 - [Prompt Engineering](../prompt-engineering/index.md) — core prompting techniques
-- [Agentic Building Blocks](../../index.md) — all six building blocks
+- [Agentic Building Blocks](../../index.md) — all seven building blocks

--- a/docs/agentic-building-blocks/skills/index.md
+++ b/docs/agentic-building-blocks/skills/index.md
@@ -74,7 +74,7 @@ The `SKILL.md` file contains the instructions. The `references/` folder holds an
 
 ## Related
 
-- [Agentic Building Blocks](../index.md) — Skills in the context of all six building blocks
+- [Agentic Building Blocks](../index.md) — Skills in the context of all seven building blocks
 - [AI Use Cases](../../use-cases/index.md) — what teams build with skills, organized by six primitives
 - [Prompts](../prompts/index.md) — the foundation that skills build on
 - [Agents](../agents/index.md) — autonomous systems that invoke skills as part of multi-step workflows

--- a/docs/ai-engineering/context-engineering.md
+++ b/docs/ai-engineering/context-engineering.md
@@ -107,7 +107,7 @@ Think of it this way: context engineering is the practice; context graphs are on
 ## Related
 
 - [AI Engineering](index.md) — the parent discipline
-- [Agentic Building Blocks](../agentic-building-blocks/index.md) — the six components context engineering operates on
+- [Agentic Building Blocks](../agentic-building-blocks/index.md) — the seven components context engineering operates on
 - [Prompts](../agentic-building-blocks/prompts/index.md) — the most fundamental building block, and a key component of context engineering
 - [Context](../agentic-building-blocks/context/index.md) — the data and knowledge component
 - [Context Graphs](../agentic-building-blocks/context/context-graphs.md) — structured reasoning graphs, an advanced technique within context engineering

--- a/docs/ai-engineering/index.md
+++ b/docs/ai-engineering/index.md
@@ -29,6 +29,6 @@ A useful analogy: the building blocks are like construction materials (wood, ste
 
 ## Related
 
-- [Agentic Building Blocks](../agentic-building-blocks/index.md) — the six components that AI engineering practices operate on
+- [Agentic Building Blocks](../agentic-building-blocks/index.md) — the seven components that AI engineering practices operate on
 - [Patterns](../patterns/index.md) — reusable approaches across building blocks
 - [AI Use Cases](../use-cases/index.md) — what teams build with these practices, organized by six primitives

--- a/docs/blog/posts/2026-02-10-introducing-the-cookbook.md
+++ b/docs/blog/posts/2026-02-10-introducing-the-cookbook.md
@@ -49,8 +49,9 @@ The cookbook includes [six use case primitives](../../use-cases/index.md) — [C
 
 ### Layer 3: The Building Blocks
 
-Every AI workflow — from a single prompt to a multi-agent pipeline — is assembled from six building blocks:
+Every AI workflow — from a single prompt to a multi-agent pipeline — is assembled from seven building blocks:
 
+- **[Model](../../agentic-building-blocks/models/index.md)** — The AI engine that powers everything
 - **[Prompt](../../agentic-building-blocks/prompts/index.md)** — Instructions you give the AI
 - **[Context](../../agentic-building-blocks/context/index.md)** — Background knowledge the AI needs (your data, your docs, your domain)
 - **[Project](../../agentic-building-blocks/projects/index.md)** — A persistent workspace that holds everything together
@@ -58,7 +59,7 @@ Every AI workflow — from a single prompt to a multi-agent pipeline — is asse
 - **[Agent](../../agentic-building-blocks/agents/index.md)** — An autonomous AI that plans and executes multi-step work
 - **[MCP](../../agentic-building-blocks/mcp/index.md)** — A connector that lets AI access external tools and data
 
-These are platform-agnostic concepts. The cookbook maps each block across Claude, ChatGPT, Gemini, and M365 Copilot in a single [comparison table](../../agentic-building-blocks/index.md). So instead of learning four different systems, you learn the six blocks once and apply them everywhere.
+These are platform-agnostic concepts. The cookbook maps each block across Claude, ChatGPT, Gemini, and M365 Copilot in a single [comparison table](../../agentic-building-blocks/index.md). So instead of learning four different systems, you learn the seven blocks once and apply them everywhere.
 
 This is the vocabulary that makes AI adoption repeatable. Once you understand building blocks, you can look at any workflow and say: "This needs a skill with context and an MCP connection" — regardless of which platform you're using.
 

--- a/docs/builder-setup/index.md
+++ b/docs/builder-setup/index.md
@@ -178,7 +178,7 @@ With your builder stack in place, you're ready to start building with AI.
 
     ---
 
-    Understand the six components of every AI workflow — prompts, context, projects, skills, agents, and MCP (connections to external tools).
+    Understand the seven components of every AI workflow — models, prompts, context, projects, skills, agents, and MCP (connections to external tools).
 
     [:octicons-arrow-right-24: Agentic Building Blocks](../agentic-building-blocks/index.md)
 

--- a/docs/business-first-ai-framework/build/design.md
+++ b/docs/business-first-ai-framework/build/design.md
@@ -7,7 +7,7 @@ description: Choose an execution pattern, classify steps on the autonomy spectru
 
 > **Part of:** [Build Workflows](index.md)
 
-!!! tip "New to the six building blocks?"
+!!! tip "New to the seven building blocks?"
     See the [Agentic Building Blocks](../../agentic-building-blocks/index.md) reference for definitions, examples, and cross-platform comparisons.
 
 ## What This Is
@@ -69,10 +69,11 @@ For each step in your Workflow Definition, classify it on the autonomy spectrum:
 
 ## Building Block Mapping
 
-Map each AI-assisted step to one or more of the six building blocks:
+Map each AI-assisted step to one or more of the seven building blocks:
 
 | Block | What It Is | When to Use It |
 |-------|-----------|----------------|
+| **Model** | The AI engine that processes inputs and generates outputs | When the task requires specific capabilities (reasoning, multimodal, speed) that influence model choice |
 | **Prompt** | A well-crafted instruction that tells the model what to do for this step | Every AI step needs at least a prompt |
 | **Context** | Background information, reference documents, examples, or data the model needs | When the step requires domain-specific knowledge not in the model's training |
 | **Skill** | A reusable routine — give it inputs, it follows a defined process, it produces consistent outputs | When a step has complex logic that recurs across workflows |
@@ -213,7 +214,8 @@ For each refined step from the Workflow Definition, determine:
    - **AI step (semi-autonomous)** — AI handles most of the work but needs human review at key checkpoints
    - **AI step (fully autonomous / agentic)** — AI executes end-to-end, including decisions and tool use, with no human in the loop
 
-2. **AI building block** — Map each AI-assisted step to one or more of these six building blocks:
+2. **AI building block** — Map each AI-assisted step to one or more of these seven building blocks:
+   - **Model** — The AI engine for this step; choose based on the step's requirements (speed, reasoning depth, multimodal)
    - **Prompt** — A well-crafted instruction that tells the model what to do for this step
    - **Context** — Background information, reference documents, examples, or data the model needs to perform the step well
    - **Skill** — A reusable routine the model can invoke — give it inputs, it follows a defined process, it produces consistent outputs (on Claude, this is a Claude Code Skill; on other platforms, this maps to custom instructions, GPTs, or Gems)

--- a/docs/business-first-ai-framework/deconstruct/index.md
+++ b/docs/business-first-ai-framework/deconstruct/index.md
@@ -27,7 +27,7 @@ This prompt walks you through that deconstruction interactively. You provide the
 
 The context needs and failure modes captured here directly inform design decisions in the next step — they tell you what context to create, what tools to connect, and where human review gates are needed.
 
-This builds directly on the concepts of workflow deconstruction. If terms like the "5-question framework" or "six building blocks" are new to you, review the [Key Concepts section of the Business-First AI Framework](../index.md#key-concepts) for quick definitions before starting.
+This builds directly on the concepts of workflow deconstruction. If terms like the "5-question framework" or "seven building blocks" are new to you, review the [Key Concepts section of the Business-First AI Framework](../index.md#key-concepts) for quick definitions before starting.
 
 ## How to Use This
 

--- a/docs/business-first-ai-framework/framework-coach.md
+++ b/docs/business-first-ai-framework/framework-coach.md
@@ -130,10 +130,11 @@ Build has three parts: **3.1 Design**, **3.2 Construct**, and **3.3 Run**.
 | **Semi-Autonomous** | AI does most of the work; human reviews at key checkpoints |
 | **Autonomous** | AI executes end-to-end, including decisions and tool use |
 
-**Six AI Building Blocks:**
+**Seven AI Building Blocks:**
 
 | Block | What It Is |
 |-------|-----------|
+| **Model** | The AI engine that processes inputs and generates outputs |
 | **Prompt** | A well-crafted instruction that tells the model what to do |
 | **Context** | Background information, reference docs, or examples the model needs |
 | **Skill** | A reusable routine — give it inputs, it follows a defined process, produces consistent outputs |
@@ -255,6 +256,6 @@ When the user needs more depth on a specific topic, fetch the raw Markdown from 
 
 | Topic | Description | Raw Markdown URL |
 |-------|-------------|-----------------|
-| Agentic Building Blocks | Definitions and cross-platform details for all six blocks | `https://raw.githubusercontent.com/jamesgray-ai/handsonai/main/docs/agentic-building-blocks/index.md` |
+| Agentic Building Blocks | Definitions and cross-platform details for all seven blocks | `https://raw.githubusercontent.com/jamesgray-ai/handsonai/main/docs/agentic-building-blocks/index.md` |
 | AI Use Cases | Six use case primitives with examples | `https://raw.githubusercontent.com/jamesgray-ai/handsonai/main/docs/use-cases/index.md` |
 | Agents by platform | Platform-specific agent building guides | `https://raw.githubusercontent.com/jamesgray-ai/handsonai/main/docs/agentic-building-blocks/agents/index.md` |

--- a/docs/business-first-ai-framework/index.md
+++ b/docs/business-first-ai-framework/index.md
@@ -100,10 +100,11 @@ Used to decompose each workflow step:
 4. **Context needs** — What documents, files, or reference materials are required?
 5. **Failure modes** — What happens when this step fails?
 
-### Six AI Building Blocks
+### Seven AI Building Blocks
 
 | Block | What It Is |
 |-------|-----------|
+| **Model** | The AI engine that processes inputs and generates outputs |
 | **Prompt** | A well-crafted instruction that tells the model what to do |
 | **Context** | Background information, reference docs, or examples the model needs |
 | **Skill** | A reusable routine the model can invoke — give it inputs, it follows a defined process, it produces consistent outputs |

--- a/docs/business-first-ai-framework/questions/how-do-i-identify-the-right-ai-tools-for-a-workflow.md
+++ b/docs/business-first-ai-framework/questions/how-do-i-identify-the-right-ai-tools-for-a-workflow.md
@@ -19,10 +19,11 @@ Most people jump straight to tool selection — "Should I use an agent? Do I nee
 
 The right approach is to **deconstruct first, then map**. Start by breaking your workflow into discrete steps using the 5-question framework: What are the individual steps? Where are the decision points? What data flows in and out? What context does each step need? What happens when this step fails? That last question surfaces the exception paths where the most important logic often lives.
 
-Once you have the refined step-by-step breakdown, map each step to one of six AI building blocks:
+Once you have the refined step-by-step breakdown, map each step to one or more of the seven AI building blocks:
 
 | Building Block | What It Is | When to Use It |
 |---------------|------------|----------------|
+| **Model** | The AI engine that processes inputs and generates outputs | When the task requires specific capabilities (reasoning, multimodal, speed) |
 | **Prompt** | A well-crafted instruction that tells the model what to do | Single-step tasks with clear inputs and outputs |
 | **Context** | Background information, reference docs, or examples | Steps that need domain knowledge or specific data |
 | **Skill** | A reusable routine — give it inputs, it follows a defined process, it produces consistent outputs | Repeatable tasks you'll run many times |
@@ -48,7 +49,7 @@ Use the [Deconstruct Workflows](../deconstruct/index.md) to run through this pro
 
 - Deconstruct the workflow before choosing tools — you can't pick the right AI building blocks for a process you don't fully understand
 - Use the 5-question framework: discrete steps, decision points, data flows, context needs, and failure modes
-- Map each step to one of six building blocks: Prompt, Context, Skill, Agent, MCP, or Project
+- Map each step to one or more of the seven building blocks: Model, Prompt, Context, Skill, Agent, MCP, or Project
 - Not every step needs AI — the autonomy classification helps you see which steps are candidates and which should stay manual
 - Use the [Deconstruct Workflows](../deconstruct/index.md) to run through this process interactively
 

--- a/docs/courses/leaders/index.md
+++ b/docs/courses/leaders/index.md
@@ -26,7 +26,7 @@ From AI user to AI builder in 30 days. This cohort-based course goes beyond Chat
 ## What You'll Learn
 
 - Systematize AI-powered workflows with version-controlled asset libraries and opportunity catalogs
-- Master agentic frameworks including the autonomy spectrum, six building blocks, and twelve architecture patterns
+- Master agentic frameworks including the autonomy spectrum, seven building blocks, and twelve architecture patterns
 - Build prompt workflows and project workspaces with memory systems and custom instructions across platforms
 - Develop agent skills that package your expertise for reusable task execution
 - Create browser automation workflows that execute multi-step web tasks hands-free

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ Master AI. Master yourself. Build what matters. That's what [Graymatter](https:/
 
     ---
 
-    The six components of every AI workflow — prompts, context, projects, skills, agents, and MCP
+    The seven components of every AI workflow — models, prompts, context, projects, skills, agents, and MCP
 
     [:octicons-arrow-right-24: Building blocks](agentic-building-blocks/)
 
@@ -92,7 +92,7 @@ See [What People Built](what-people-built.md) with the cookbook.
 | Understand system prompts | [What is a system prompt?](agentic-building-blocks/prompts/questions/what-is-a-system-prompt.md) |
 | Schedule AI agents | [Scheduling Subagents](platforms/claude/subagents/scheduling-subagents.md) |
 | Set up Git and GitHub | [Git Installation](builder-setup/git-install.md) |
-| Learn the six AI building blocks | [Agentic Building Blocks](agentic-building-blocks/) |
+| Learn the seven AI building blocks | [Agentic Building Blocks](agentic-building-blocks/) |
 | Explore AI use cases by type | [Use Case Primitives](use-cases/) |
 | Install Claude Code plugins | [Plugin Marketplace](plugins/) |
 | Take a structured course | [Courses](courses/) |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -62,7 +62,7 @@
 
 ### Overview
 - URL: https://handsonai.info/agentic-building-blocks/
-- Summary: The six building blocks for AI-powered workflows, arranged along an autonomy spectrum from simple to complex: Prompts, Context, Projects, Skills, Agents, and MCP (Model Context Protocol).
+- Summary: The seven building blocks for AI-powered workflows, arranged along an autonomy spectrum from simple to complex: Model, Prompts, Context, Projects, Skills, Agents, and MCP (Model Context Protocol).
 
 ### Prompts
 - URL: https://handsonai.info/agentic-building-blocks/prompts/

--- a/docs/use-cases/index.md
+++ b/docs/use-cases/index.md
@@ -112,6 +112,6 @@ Primitives help you browse use cases by category. Building blocks help you assem
 
 - [Business-First AI Framework](../business-first-ai-framework/index.md) — find and prioritize AI opportunities
 - [Discover Workflows](../business-first-ai-framework/discover.md) — structured audit to surface workflow candidates
-- [Agentic Building Blocks](../agentic-building-blocks/index.md) — the six components for implementing AI workflows
+- [Agentic Building Blocks](../agentic-building-blocks/index.md) — the seven components for implementing AI workflows
 - [Build Workflows](../business-first-ai-framework/build/index.md) — worked examples across the autonomy spectrum
 - [Plugin Marketplace](../plugins/index.md) — pre-built agents and skills you can install

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -178,6 +178,7 @@ nav:
       - Identify the right AI tools for a workflow: business-first-ai-framework/questions/how-do-i-identify-the-right-ai-tools-for-a-workflow.md
   - Agentic Building Blocks:
     - Overview: agentic-building-blocks/index.md
+    - Model: agentic-building-blocks/models/index.md
     - Prompts:
       - Overview: agentic-building-blocks/prompts/index.md
       - Prompt Engineering:


### PR DESCRIPTION
## Summary

- Adds **Model** as the 7th agentic building block, positioned first in the progression (Model → Prompt → Context → Project → Skill → Agent → MCP)
- New page at `docs/agentic-building-blocks/models/index.md` covering model capabilities, selection guidance, foundational concepts (tokens, context windows, temperature), and platform implementations
- Updates all "six building blocks" references to "seven" across 23 files (overview, framework, use cases, blog, courses, etc.)
- Uses generic model tier descriptions (fast, balanced, reasoning) instead of specific model names for maintainability

## Test plan

- [x] `mkdocs build --strict` passes (all warnings are pre-existing)
- [x] Grep confirms no remaining "six building blocks" references in tracked docs (only auto-generated Notion files remain)
- [ ] Visual check: Model appears first in Agentic Building Blocks nav
- [ ] Visual check: Summary and Platform Comparison tables show 7 rows
- [ ] Visual check: "How the Blocks Fit Together" starts with "Choose a Model"

🤖 Generated with [Claude Code](https://claude.com/claude-code)