### PR TITLE
Generate syllabus pages before building MCP content index

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+
+      - name: Generate syllabus pages
+        run: python scripts/generate_syllabi.py
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

- Adds Python setup and `generate_syllabi.py` step to the `deploy-mcp` job
- Ensures gitignored syllabus and lesson pages are included in the content index
- Fixes page count from 144 → ~250

## Test plan

- [ ] Verify deploy-mcp job generates syllabi before building the index
- [ ] Verify page count increases after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)