### PR TITLE
Add MCP server usage analytics with Cloudflare D1

### DIFF
--- a/docs/use-the-cookbook/ask/index.md
+++ b/docs/use-the-cookbook/ask/index.md
@@ -108,3 +108,16 @@ Once connected, try asking your AI assistant:
 - "Show me the automation use case"
 
 The AI will use the cookbook MCP tools to pull relevant content and answer with cookbook knowledge.
+
+## Analytics & Privacy
+
+!!! info "No personally identifiable information is collected"
+    This MCP server **does not collect personally identifiable information**. There are no user accounts, no IP addresses, no cookies, no tracking identifiers, and no conversation content stored — ever. We cannot identify who you are or what you asked your AI assistant.
+
+    **What is logged:** Each MCP tool call records the tool name, search keywords or page path requested, a timestamp, approximate country (from Cloudflare's network), client type (User-Agent header), and response time. Only tool calls and resource reads are logged — protocol handshake messages are not.
+
+    **Why:** We use this aggregate data to understand which topics people search for most and where content gaps exist, so we can create new pages and improve existing ones. The goal is to make the cookbook more useful for everyone.
+
+    **Retention:** Analytics data is retained for 12 months, then deleted.
+
+    **Storage:** Data is stored in a private database accessible only to the cookbook maintainer. It is never shared, sold, or used for advertising.

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -1,0 +1,4 @@
+# Required for scripts/analytics-query.ts
+CLOUDFLARE_API_TOKEN=your-api-token
+CLOUDFLARE_ACCOUNT_ID=your-account-id
+CLOUDFLARE_D1_DATABASE_ID=your-d1-database-id

--- a/mcp-server/migrations/0001_create_analytics.sql
+++ b/mcp-server/migrations/0001_create_analytics.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS mcp_events (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  timestamp   TEXT    NOT NULL DEFAULT (datetime('now')),
+  method      TEXT    NOT NULL,
+  tool_name   TEXT,
+  params      TEXT,
+  result_size INTEGER,
+  is_error    INTEGER NOT NULL DEFAULT 0,
+  error_msg   TEXT,
+  duration_ms REAL,
+  user_agent  TEXT,
+  cf_country  TEXT
+);
+
+CREATE INDEX idx_events_timestamp ON mcp_events(timestamp);
+CREATE INDEX idx_events_method ON mcp_events(method);
+CREATE INDEX idx_events_tool_name ON mcp_events(tool_name);
+CREATE INDEX idx_events_tool_timestamp ON mcp_events(tool_name, timestamp);

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -7,7 +7,8 @@
     "build:index": "tsx scripts/build-index.ts",
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "build": "wrangler deploy --dry-run --outdir=dist"
+    "build": "wrangler deploy --dry-run --outdir=dist",
+    "analytics": "tsx scripts/analytics-query.ts"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250214.0",

--- a/mcp-server/scripts/analytics-query.ts
+++ b/mcp-server/scripts/analytics-query.ts
@@ -1,0 +1,241 @@
+#!/usr/bin/env tsx
+/**
+ * CLI for querying MCP analytics via the Cloudflare D1 REST API.
+ *
+ * Usage:  npx tsx scripts/analytics-query.ts <command> [options]
+ *
+ * Requires env vars: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_D1_DATABASE_ID
+ */
+
+const COMMANDS: Record<string, string> = {
+  "top-queries":  "Most frequent search queries",
+  "tool-usage":   "Tool call breakdown",
+  "daily-volume": "Events per day",
+  "top-pages":    "Most requested pages (get_page)",
+  "errors":       "Error rate by day",
+  "zero-results": "Searches that returned no results",
+  "clients":      "User-agent breakdown",
+  "raw-sql":      "Run arbitrary SQL",
+};
+
+function env(key: string): string {
+  const val = process.env[key];
+  if (!val) {
+    console.error(`Missing env var: ${key}`);
+    process.exit(1);
+  }
+  return val;
+}
+
+function parseDays(args: string[]): number {
+  const flag = args.find((a) => a.startsWith("--days="));
+  if (!flag) return 30;
+  const value = parseInt(flag.split("=")[1], 10);
+  if (isNaN(value) || value <= 0) {
+    console.error(`Invalid --days value: "${flag.split("=")[1]}". Must be a positive integer.`);
+    process.exit(1);
+  }
+  return value;
+}
+
+async function queryD1(sql: string, params: unknown[] = []): Promise<unknown[]> {
+  const accountId = env("CLOUDFLARE_ACCOUNT_ID");
+  const dbId = env("CLOUDFLARE_D1_DATABASE_ID");
+  const token = env("CLOUDFLARE_API_TOKEN");
+
+  const res = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/d1/database/${dbId}/query`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sql, params }),
+    }
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error(`Cloudflare API error (${res.status}):`, text);
+    process.exit(1);
+  }
+
+  const data = (await res.json()) as {
+    result: { results: unknown[] }[];
+    success: boolean;
+    errors: unknown[];
+  };
+
+  if (!data.success) {
+    console.error("D1 query failed:", JSON.stringify(data.errors, null, 2));
+    process.exit(1);
+  }
+
+  if (!Array.isArray(data.result) || data.result.length === 0 || !data.result[0].results) {
+    console.error("Unexpected D1 API response shape:", JSON.stringify(data, null, 2));
+    process.exit(1);
+  }
+
+  return data.result[0].results;
+}
+
+function printTable(rows: unknown[]) {
+  if (rows.length === 0) {
+    console.log("(no results)");
+    return;
+  }
+  console.table(rows);
+}
+
+const QUERIES: Record<string, (args: string[]) => Promise<void>> = {
+  "top-queries": async (args) => {
+    const days = parseDays(args);
+    const rows = await queryD1(
+      `SELECT json_extract(params, '$.query') AS query, COUNT(*) AS count
+       FROM mcp_events
+       WHERE tool_name = 'search_cookbook'
+         AND params IS NOT NULL
+         AND timestamp >= datetime('now', ?)
+       GROUP BY query
+       ORDER BY count DESC
+       LIMIT 25`,
+      [`-${days} days`]
+    );
+    console.log(`\nTop search queries (last ${days} days):\n`);
+    printTable(rows);
+  },
+
+  "tool-usage": async (args) => {
+    const days = parseDays(args);
+    const rows = await queryD1(
+      `SELECT tool_name, COUNT(*) AS count,
+              ROUND(AVG(duration_ms), 1) AS avg_ms,
+              SUM(is_error) AS errors
+       FROM mcp_events
+       WHERE method = 'tools/call'
+         AND timestamp >= datetime('now', ?)
+       GROUP BY tool_name
+       ORDER BY count DESC`,
+      [`-${days} days`]
+    );
+    console.log(`\nTool usage (last ${days} days):\n`);
+    printTable(rows);
+  },
+
+  "daily-volume": async (args) => {
+    const days = parseDays(args);
+    const rows = await queryD1(
+      `SELECT date(timestamp) AS day, COUNT(*) AS events,
+              SUM(CASE WHEN method = 'tools/call' THEN 1 ELSE 0 END) AS tool_calls
+       FROM mcp_events
+       WHERE timestamp >= datetime('now', ?)
+       GROUP BY day
+       ORDER BY day DESC`,
+      [`-${days} days`]
+    );
+    console.log(`\nDaily volume (last ${days} days):\n`);
+    printTable(rows);
+  },
+
+  "top-pages": async (args) => {
+    const days = parseDays(args);
+    const rows = await queryD1(
+      `SELECT json_extract(params, '$.path') AS page, COUNT(*) AS count
+       FROM mcp_events
+       WHERE tool_name = 'get_page'
+         AND params IS NOT NULL
+         AND timestamp >= datetime('now', ?)
+       GROUP BY page
+       ORDER BY count DESC
+       LIMIT 25`,
+      [`-${days} days`]
+    );
+    console.log(`\nTop pages (last ${days} days):\n`);
+    printTable(rows);
+  },
+
+  errors: async (args) => {
+    const days = parseDays(args);
+    const rows = await queryD1(
+      `SELECT date(timestamp) AS day,
+              COUNT(*) AS total,
+              SUM(is_error) AS errors,
+              ROUND(100.0 * SUM(is_error) / COUNT(*), 1) AS error_pct
+       FROM mcp_events
+       WHERE timestamp >= datetime('now', ?)
+       GROUP BY day
+       ORDER BY day DESC`,
+      [`-${days} days`]
+    );
+    console.log(`\nError rate by day (last ${days} days):\n`);
+    printTable(rows);
+  },
+
+  "zero-results": async (args) => {
+    const days = parseDays(args);
+    const rows = await queryD1(
+      `SELECT json_extract(params, '$.query') AS query, COUNT(*) AS count
+       FROM mcp_events
+       WHERE tool_name = 'search_cookbook'
+         AND params IS NOT NULL
+         AND result_size IS NOT NULL
+         AND result_size < 100
+         AND timestamp >= datetime('now', ?)
+       GROUP BY query
+       ORDER BY count DESC
+       LIMIT 25`,
+      [`-${days} days`]
+    );
+    console.log(`\nZero/low-result searches — content gaps (last ${days} days):\n`);
+    printTable(rows);
+  },
+
+  clients: async (args) => {
+    const days = parseDays(args);
+    const rows = await queryD1(
+      `SELECT user_agent, COUNT(*) AS count
+       FROM mcp_events
+       WHERE timestamp >= datetime('now', ?)
+       GROUP BY user_agent
+       ORDER BY count DESC
+       LIMIT 20`,
+      [`-${days} days`]
+    );
+    console.log(`\nClients (last ${days} days):\n`);
+    printTable(rows);
+  },
+
+  "raw-sql": async (args) => {
+    const sql = args.find((a) => !a.startsWith("--"));
+    if (!sql) {
+      console.error("Usage: raw-sql <query>");
+      process.exit(1);
+    }
+    if (!/^\s*SELECT\b/i.test(sql)) {
+      console.error("raw-sql only supports SELECT queries. Use `wrangler d1 execute` for mutations.");
+      process.exit(1);
+    }
+    const rows = await queryD1(sql);
+    printTable(rows);
+  },
+};
+
+// --- main ---
+const [command, ...rest] = process.argv.slice(2);
+
+if (!command || !COMMANDS[command]) {
+  console.log("Usage: npx tsx scripts/analytics-query.ts <command> [options]\n");
+  console.log("Commands:");
+  for (const [cmd, desc] of Object.entries(COMMANDS)) {
+    console.log(`  ${cmd.padEnd(16)} ${desc}`);
+  }
+  console.log("\nOptions:");
+  console.log("  --days=N       Look-back window (default: 30)");
+  process.exit(0);
+}
+
+QUERIES[command](rest).catch((err) => {
+  console.error("Command failed:", err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/mcp-server/src/analytics.ts
+++ b/mcp-server/src/analytics.ts
@@ -1,0 +1,95 @@
+/**
+ * Analytics — non-blocking D1 event logging for MCP requests.
+ *
+ * Every function is wrapped in try/catch so a DB failure
+ * never breaks an MCP response.
+ */
+
+export interface AnalyticsEvent {
+  method: string;
+  toolName: string | null;
+  params: string | null;
+  resultSize: number | null;
+  isError: boolean;
+  errorMsg: string | null;
+  durationMs: number;
+  userAgent: string | null;
+  cfCountry: string | null;
+}
+
+/** Extract only the small, useful bits from tool arguments. */
+export function sanitizeParams(
+  method: string,
+  params: Record<string, unknown> | undefined
+): string | null {
+  if (!params) return null;
+
+  if (method === "tools/call") {
+    const args = params.arguments;
+    if (!args || typeof args !== "object" || Array.isArray(args)) return null;
+    // Keep only short string values (query, path, section, slug, etc.)
+    const safe: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(args as Record<string, unknown>)) {
+      if (typeof v === "string" && v.length <= 200) {
+        safe[k] = v;
+      } else if (typeof v === "number" || typeof v === "boolean") {
+        safe[k] = v;
+      }
+    }
+    return Object.keys(safe).length > 0 ? JSON.stringify(safe) : null;
+  }
+
+  if (method === "resources/read" && typeof params.uri === "string") {
+    return JSON.stringify({ uri: params.uri });
+  }
+
+  return null;
+}
+
+/** Character count of the JSON-RPC result text content. */
+export function getResultSize(responseBody: unknown): number | null {
+  try {
+    const body = responseBody as { result?: unknown };
+    if (!body?.result) return null;
+    return JSON.stringify(body.result).length;
+  } catch (err) {
+    console.error("[analytics] Failed to compute result size:", err);
+    return null;
+  }
+}
+
+/** INSERT one row into mcp_events. Never throws. */
+export async function logEvent(
+  db: D1Database,
+  event: AnalyticsEvent
+): Promise<void> {
+  try {
+    await db
+      .prepare(
+        `INSERT INTO mcp_events
+           (method, tool_name, params, result_size, is_error, error_msg, duration_ms, user_agent, cf_country)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        event.method,
+        event.toolName,
+        event.params,
+        event.resultSize,
+        event.isError ? 1 : 0,
+        event.errorMsg,
+        event.durationMs,
+        event.userAgent,
+        event.cfCountry
+      )
+      .run();
+  } catch (err) {
+    console.error(JSON.stringify({
+      level: "error",
+      component: "analytics",
+      operation: "logEvent",
+      method: event.method,
+      toolName: event.toolName,
+      error: err instanceof Error ? err.message : String(err),
+    }));
+  }
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -1,3 +1,7 @@
+export interface Env {
+  DB: D1Database;
+}
+
 export interface Page {
   path: string;
   title: string;

--- a/mcp-server/wrangler.toml
+++ b/mcp-server/wrangler.toml
@@ -4,3 +4,9 @@ compatibility_date = "2025-01-01"
 
 [observability]
 enabled = true
+
+[[d1_databases]]
+binding = "DB"
+database_name = "handsonai-mcp-analytics"
+database_id = "504a3253-1e9c-47c6-9eb4-900fb40e619c"
+migrations_dir = "migrations"


### PR DESCRIPTION
## Summary

- **D1 instrumentation**: Non-blocking analytics logging via `ctx.waitUntil()` — tracks tool calls and resource reads only (not protocol handshakes). Captures tool name, sanitized params, result size, error status, duration, User-Agent, and country.
- **CLI query tool**: `npm run analytics <command>` for querying D1 via Cloudflare REST API — top queries, tool usage, daily volume, top pages, errors, zero-result searches, and client breakdown.
- **Privacy disclosure**: Added "Analytics & Privacy" section to MCP server docs page — no PII collected, 12-month retention, data never shared/sold.

## Post-merge steps

1. Apply migration: `wrangler d1 migrations apply handsonai-mcp-analytics --remote`
2. Deploy: `wrangler deploy`
3. Verify: `wrangler d1 execute handsonai-mcp-analytics --remote --command "SELECT COUNT(*) FROM mcp_events"`

## Test plan

- [x] TypeScript compiles (`wrangler deploy --dry-run`)
- [x] Happy path: `search_cookbook` and `get_page` log correctly to local D1
- [x] Method filtering: `initialize` and `tools/list` are NOT logged
- [x] Error capture: nonexistent tool call logs `is_error = 1`
- [x] DB failure resilience: MCP responses return normally when D1 binding is removed
- [x] MkDocs build passes without new warnings
- [x] Code review: SQL injection guard on `raw-sql`, input validation, structured error logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)