### PR TITLE
docs: rename Leaders setup checklist to Tools Setup Checklist

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,9 @@ import sitemap from '@astrojs/sitemap';
 export default defineConfig({
   site: 'https://handsonai.info',
   trailingSlash: 'always',
+  redirects: {
+    '/courses/leaders/setup-checklist/': '/courses/tools-setup-checklist/',
+  },
   integrations: [
     starlight({
       title: 'Hands-on AI Playbook',
@@ -452,14 +455,8 @@ export default defineConfig({
           collapsed: true,
           items: [
             { label: 'Overview', link: '/courses/' },
-            {
-              label: 'Agentic AI for Leaders',
-              collapsed: true,
-              items: [
-                { label: 'Overview', link: '/courses/leaders/' },
-                { label: 'Setup Checklist', link: '/courses/leaders/setup-checklist/' },
-              ],
-            },
+            { label: 'Tools Setup Checklist', link: '/courses/tools-setup-checklist/' },
+            { label: 'Agentic AI for Leaders', link: '/courses/leaders/' },
             { label: 'Claude for Builders', link: '/courses/builders/' },
             {
               label: 'Questions',

--- a/scripts/generate-leaders-checklist-pdf.py
+++ b/scripts/generate-leaders-checklist-pdf.py
@@ -185,7 +185,7 @@ def build_pdf():
     story.append(build_overview_table(styles))
     story.append(Spacer(1, 12))
     story.append(Paragraph(
-        "Full instructions with screenshots: <b>handsonai.info/courses/leaders/setup-checklist/</b>",
+        "Full instructions with screenshots: <b>handsonai.info/courses/tools-setup-checklist/</b>",
         styles["Body9"]
     ))
 
@@ -414,7 +414,7 @@ def build_pdf():
     story.append(Spacer(1, 14))
 
     story.append(Paragraph(
-        "<b>Full interactive checklist:</b> handsonai.info/courses/leaders/setup-checklist/",
+        "<b>Full interactive checklist:</b> handsonai.info/courses/tools-setup-checklist/",
         styles["Body9"]
     ))
     story.append(Paragraph(

--- a/src/content/docs/blog/2026-02-25-orchestration-patterns-building-blocks-framework.md
+++ b/src/content/docs/blog/2026-02-25-orchestration-patterns-building-blocks-framework.md
@@ -18,4 +18,4 @@ title: "Orchestration patterns, new building blocks, and framework refinements"
 
 **Framework refinements.** Step 1 was renamed from "Discover" to [Analyze](../../business-first-ai-framework/), and Step 2 is now "Deconstruct Workflows into Structured Specifications." The [Build step](../../business-first-ai-framework/build/) added architecture approach guidance (no-code vs code-first) and the Launch Guide was renamed to Run Guide.
 
-**Leaders setup checklist.** A new [printable setup checklist](../../courses/leaders/setup-checklist/) walks Agentic AI for Leaders students through every tool installation step with checkboxes.
+**Leaders setup checklist.** A new [printable setup checklist](../../courses/tools-setup-checklist/) walks Agentic AI for Leaders students through every tool installation step with checkboxes.

--- a/src/content/docs/courses/tools-setup-checklist.md
+++ b/src/content/docs/courses/tools-setup-checklist.md
@@ -1,6 +1,6 @@
 ---
-title: Setup Checklist — Agentic AI for Leaders
-description: Complete setup guide for the Agentic AI for Leaders course — AI platform accounts, developer tools, and workflow management
+title: Tools Setup Checklist
+description: Complete setup guide for Hands-on AI courses — AI platform accounts, developer tools, and workflow management
 ---
 
 Everything you need to set up before Session 1. Work through the steps in order — later steps build on earlier ones. Budget **2–3 hours** total, split across two sittings if you prefer. Times are estimates — it's normal for some steps to take longer, especially if the tools are new to you.
@@ -275,4 +275,4 @@ You're all set for the course — nice work getting through the setup!
 
 Having trouble with any step? Bring your questions to the first session — we'll troubleshoot together.
 
-[→ Back to course overview](/courses/leaders/)
+[→ Back to courses overview](/courses/)


### PR DESCRIPTION
## Summary
- Rename **Setup Checklist — Agentic AI for Leaders** to **Tools Setup Checklist** so it serves both Maven courses (Agentic AI for Leaders and Claude for Builders) without implying it's leader-only.
- Move the page from `/courses/leaders/setup-checklist/` to `/courses/tools-setup-checklist/` and add an Astro redirect so existing Maven portal links keep working.
- Update the sidebar: `Tools Setup Checklist` is now a top-level item under "Learn with James", visible regardless of which course a student is in.
- Update internal references in the 2026-02-25 changelog blog post and `scripts/generate-leaders-checklist-pdf.py`.

## Test plan
- [x] `npm run build` — 190 pages built, no errors
- [x] Verified `dist/courses/tools-setup-checklist/index.html` exists
- [x] Verified `dist/courses/leaders/setup-checklist/index.html` contains `<meta http-equiv="refresh" content="0;url=/courses/tools-setup-checklist/">`
- [ ] Manually click through sidebar entry after deploy
- [ ] Confirm Maven portal links still resolve (via redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)