### PR TITLE
docs: overhaul setup checklists around value, action, and verification

### DIFF
--- a/src/content/docs/builder-setup/index.md
+++ b/src/content/docs/builder-setup/index.md
@@ -1,178 +1,81 @@
 ---
 title: Builder Tools Setup Guide
-description: Step-by-step checklist for setting up your developer toolkit — terminal, editor, Git, CLIs, and workflow management
----Building with AI means more than using a chatbot — you'll read code, modify files, run commands, and connect AI tools to real workflows. This guide sets up the developer tools and workflow management you need.
+description: Step-by-step checklist for setting up your developer toolkit — terminal, editor, Git, GitHub, and workflow management
+---
+
+This guide sets up the developer tools and workflow management you need for building with AI.
 
 :::note[AI platform setup is in the Platforms section]
 Before starting here, make sure you've set up at least one AI platform — account, apps, personalization, memory, and connections. Each platform has its own Getting Started checklist:
 
 [→ Claude](../platforms/claude/getting-started/) · [→ OpenAI](../platforms/openai/getting-started/) · [→ Gemini](../platforms/google-gemini/getting-started/) · [→ M365 Copilot](../platforms/m365-copilot/getting-started/)
 :::
-## At a Glance
+
+## Why These Tools Matter
+
+Real AI workflows — the kind that save time, ship work, and scale beyond one-off chats — need more than a chatbot. You need an **AI platform** to think with, **builder tools** to build and manage your AI building blocks, and a **workflow registry** so you can track and reuse what you build.
+
+Each tool below was chosen intentionally. Here's what each one unlocks for you.
+
+### 1. AI Platform — the foundation
+
+Everything else sits on top of this. Your AI platform is the reasoning engine that powers every workflow you build — pick whichever you prefer, one is enough.
+
+| Capability | What it is | Why it matters to you |
+|---|---|---|
+| **Account + Apps** | A paid subscription (Claude, ChatGPT, Gemini, or Copilot) plus the web, desktop, and mobile apps | Paid plans unlock the features you'll use here — longer conversations, file uploads, connectors, and stronger reasoning models |
+| **Personalization** | Custom instructions that tell the AI about your role, industry, and style | Every conversation starts with context — you stop re-introducing yourself and answers arrive tailored from message one |
+| **Memory** | The AI remembers facts about you and your work across conversations | Your AI becomes a returning assistant who knows your projects, not a stranger every time you open a new chat |
+| **Connections** | Links your AI to apps you already use (Google Docs, Slack, Notion, GitHub, etc.) | AI can read and write inside your real systems — no more copy-paste between tools |
+
+### 2. Builder Tools — build and manage your AI building blocks
+
+These are the tools you use to build and manage your [AI building blocks](../agentic-building-blocks/) — prompts, skills, agents, and more — that power every AI workflow. Building a good one is just the start: like any asset that runs your business, they need to be refined, versioned, and shared over time. This toolkit handles all of that, whether your workflows run locally or in the cloud.
+
+| Capability | What it is | Why it matters to you |
+|---|---|---|
+| **Terminal** | The command-line interface built into your computer (Terminal on Mac, PowerShell on Windows) | Most AI developer tools run here — a little fluency unlocks everything else in this list |
+| **Code Editor** | Cursor or VS Code, with AI extensions installed | An organized home for every building block you create — browse them in folders, edit them in place, and let the built-in AI assistants read and update them directly as you work |
+| **Git** | Automatically tracks every change to every file | You'll constantly create and refine your building blocks — Git keeps the full history for you, so you never have to manage versions manually, and it connects to GitHub so everything gets backed up in the cloud |
+| **GitHub** | Cloud storage and backup for your files, built on top of Git | Your work is safe, versioned, accessible from any machine, and easy to share |
+| **Voice to Text** | Dictation software (Wispr Flow or your system's built-in voice input) | Talk instead of type — faster for long prompts and more natural when you're thinking out loud |
+| **Hands-on AI Skills** | Skills that walk you through the [Business-First AI Framework](../business-first-ai-framework/skills/) for building AI workflows | Learn how to go from "I think AI could help with this" to a shipped, improving workflow — with step-by-step guidance at every stage |
+| **Hands-on AI Knowledge Base** | The Hands-on AI playbook, connected to your AI tool as a live reference | Ask questions and get answers right inside the AI tool where you're already doing your work — no switching tabs or searching the website |
+
+### 3. Workflow Registry — your system of record for AI workflows
+
+Once you're building more than one workflow, you need a single place to track what they do, who uses them, and how they're built.
+
+| Capability | What it is | Why it matters to you |
+|---|---|---|
+| **AI Registry (Notion)** | A structured Notion workspace for your workflows, AI building blocks, and connected apps | The single source of truth for what you've built, who's using it, and how it all connects — essential once you're scaling beyond one-off experiments |
+
+## Setup Order
+
+Work through these in order — later steps build on earlier ones. Each link opens the full setup guide with step-by-step instructions and verification criteria.
 
 ### Builder Tools (~90 min)
 
-| What | Time | Status |
-|------|------|--------|
-| [Terminal Basics](#terminal-basics) | ~15 min | Required |
-| [AI Code Editor + Extensions](#ai-code-editor-extensions) | ~15 min | Required |
-| [Git](#git) | ~10 min | Required |
-| [GitHub](#github) | ~15 min | Required |
-| [Voice to Text](#voice-to-text) | ~10 min | Recommended |
-| [Hands-on AI Skills](#hands-on-ai-skills) | ~10 min | Recommended |
-| [Hands-on AI MCP Server](#hands-on-ai-mcp-server) | ~5 min | Recommended |
+| # | Tool | Time | Requires | Status |
+|---|---|---|---|---|
+| 1 | [Terminal Basics](terminal-basics/) | ~15 min | Nothing | Required |
+| 2 | [AI Code Editor + Extensions](editor-setup/) | ~15 min | Terminal | Required |
+| 3 | [Git](git-install/) | ~10 min | Terminal | Required |
+| 4 | [GitHub](github-setup/) | ~15 min | Editor + Git | Required |
+| 5 | [Voice to Text](voice-to-text-setup/) | ~10 min | Nothing | Recommended |
+| 6 | [Hands-on AI Skills](../business-first-ai-framework/skills/) | ~10 min | AI platform | Recommended |
+| 7 | [Hands-on AI Knowledge Base](../mcp-server/) | ~5 min | AI platform | Recommended |
 
 ### AI Workflow Management (~20 min)
 
-| What | Time | Status |
-|------|------|--------|
-| [AI Registry Setup](#ai-registry-setup) | ~20 min | Recommended |
+| # | Tool | Time | Requires | Status |
+|---|---|---|---|---|
+| 8 | [AI Registry (Notion)](notion-registry-setup/) | ~20 min | AI platform | Recommended |
 
----
-
-## Builder Tools
-
-## Terminal Basics
-
-**What:** Learn to navigate your computer's command line — Terminal on Mac, PowerShell on Windows.
-**Time:** ~15 minutes
-**Requires:** Nothing — this is where you start.
-
-Every tool in this stack runs through the terminal. You don't need to be an expert — just comfortable opening it, navigating folders, and running commands.
-
-[→ Go to Terminal Basics guide](terminal-basics/)
-
-**You're done when:** You can open a terminal, run `pwd`, and navigate to a folder with `cd`.
-
-- [ ] Terminal Basics — complete
-
----
-
-## AI Code Editor + Extensions
-
-**What:** Install and configure Cursor or VS Code with AI model integration.
-**Time:** ~15 minutes
-**Requires:** Terminal Basics
-
-Your editor is where you'll read, write, and edit code. This guide covers Cursor (has AI built in) and VS Code (free), plus AI extensions for Claude Code, OpenAI Codex, and Gemini Code Assist.
-
-[→ Go to Editor Setup guide](editor-setup/)
-
-**You're done when:** You can open your editor, navigate files and folders, and see at least one AI extension installed.
-
-- [ ] AI Code Editor — installed
-- [ ] AI extensions — installed
-
----
-
-## Git
-
-**What:** Install Git — a version control tool that tracks the changes you make to your AI building blocks.
-**Time:** ~10 minutes
-**Requires:** Terminal Basics
-
-Git ensures you never lose your work — every version is saved, and you can always recover or refine what you've built.
-
-[→ Go to Git Installation guide](git-install/)
-
-**You're done when:** Opening your terminal and typing `git --version` prints a version number.
-
-- [ ] Git — installed
-
----
-
-## GitHub
-
-**What:** Create a GitHub account, enable 2FA, and create a repository for your work.
-**Time:** ~15 minutes
-**Requires:** Editor and Git
-
-GitHub is where your files live in the cloud — backed up, versioned, and accessible from any machine.
-
-[→ Go to GitHub Setup guide](github-setup/)
-
-**You're done when:** You can download (clone) a project from GitHub into your editor.
-
-- [ ] GitHub — account created and connected
-
----
-
-## Voice to Text
-
-**What:** Configure system voice input or install a dedicated voice-to-text tool (Wispr Flow recommended).
-**Time:** ~10 minutes
-**Requires:** Nothing — this step is fully independent.
-
-Voice input can speed up how you write prompts, notes, and messages. This is recommended for anyone who thinks faster than they type.
-
-[→ Go to Voice to Text Setup guide](voice-to-text-setup/)
-
-**You're done when:** You can dictate text into any input field on your computer.
-
-- [ ] Voice to Text — set up
-
----
-
-## Hands-on AI Skills
-
-**What:** Skills teach your AI tool specific tasks — like editing to publication standards, naming workflows consistently, or generating meeting briefs — so you describe your goal and the AI follows your standards automatically.
-**Time:** ~10 minutes
-**Requires:** At least one AI platform set up
-
-Skills work across platforms — Claude Code, Claude.ai, Cowork, Cursor, Codex CLI, Gemini CLI, VS Code Copilot, and any tool that supports the skill format.
-
-For step-by-step install instructions for your platform:
-
-[→ How to Add Skills to Your Platform](../agentic-building-blocks/skills/#how-to-add-skills-to-your-platform)
-
-Browse all available plugins on the [Agents & Skills Marketplace](../use-the-playbook/build/).
-
-**You're done when:** At least one skill is installed or added to your platform.
-
-- [ ] At least one skill — installed or added to your platform
-
----
-
-## Hands-on AI MCP Server
-
-**What:** Access the Hands-on AI knowledge base where you do your work by adding a connector in your AI tool.
-**Time:** ~5 minutes
-**Requires:** An AI platform account
-
-The Hands-on AI MCP server gives your AI platform access to the playbook's reference material — building blocks, patterns, use cases, and more — right inside your conversations.
-
-[→ Go to MCP Server Connection Guide](../mcp-server/)
-
-**You're done when:** You can ask your AI platform a question about the playbook and get an answer from the MCP server.
-
-- [ ] Hands-on AI MCP server — connected
-
----
-
-## AI Workflow Management
-
-Keeping track of your workflows and the AI building blocks that power them is essential to change management and scaling your operations.
-
-## AI Registry Setup
-
-**What:** Get a free Notion account (or other database system), duplicate the AI Registry template, and connect Notion to your AI tool.
-**Time:** ~20 minutes
-**Requires:** An AI platform account
-
-The AI Registry is a Notion workspace template that gives you a structured system for tracking your workflows, AI building blocks, and connected applications. Once it's connected, Claude can name workflows, write SOPs (Standard Operating Procedures), and register skills directly in Notion.
-
-[→ Go to AI Registry Setup guide](notion-registry-setup/)
-
-After setting up the registry, install the AI Registry plugin so Claude can read from and write to your Notion workspace:
-
-```bash
-/plugin install ai-registry@handsonai
-```
-
-**You're done when:** You've duplicated the template and connected Notion to your AI tool.
-
-- [ ] AI Registry — Notion template duplicated and connected
-- [ ] AI Registry plugin — installed
+:::note[Heads up]
+- **Hands-on AI Knowledge Base:** Your AI tool may call this an "MCP server" or "MCP connector" — that's the underlying technology.
+- **AI Registry:** After setting up the Notion template, install the plugin so Claude can read from and write to your workspace: `/plugin install ai-registry@handsonai`
+:::
 
 ---
 
@@ -180,51 +83,8 @@ After setting up the registry, install the AI Registry plugin so Claude can read
 
 With your builder tools in place, you're ready to start building with AI.
 
-<style>
-.next-steps-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-  border: 1px solid var(--sl-color-gray-5);
-  border-radius: 8px;
-  overflow: hidden;
-}
-:root[data-theme='light'] .next-steps-list { border-color: #d4d4d0; }
-.next-step-row {
-  display: flex;
-  align-items: baseline;
-  gap: 1rem;
-  padding: 1rem 1.5rem;
-  border-bottom: 1px solid var(--sl-color-gray-5);
-  background: var(--sl-color-gray-6);
-}
-.next-step-row:last-child { border-bottom: none; }
-:root[data-theme='light'] .next-step-row { background: #fff; border-bottom-color: #eaeae6; }
-.next-step-row strong { flex-shrink: 0; min-width: 11rem; font-size: 0.95rem; }
-.next-step-row span { flex: 1; font-size: 0.88rem; color: var(--sl-color-gray-2); line-height: 1.5; }
-.next-step-row a { flex-shrink: 0; font-size: 0.85rem; font-weight: 600; color: var(--sl-color-accent) !important; text-decoration: none !important; white-space: nowrap; }
-.next-step-row a:hover { text-decoration: underline !important; }
-:root[data-theme='light'] .next-step-row a { color: #282828 !important; }
-@media (max-width: 600px) {
-  .next-step-row { flex-direction: column; gap: 0.25rem; }
-  .next-step-row strong { min-width: unset; }
-}
-</style>
-
-<div class="next-steps-list">
-  <div class="next-step-row">
-    <strong>Learn the Building Blocks</strong>
-    <span>The eleven components of every AI workflow — models, prompts, context, projects, skills, agents, and more</span>
-    <a href="../agentic-building-blocks/">Building Blocks →</a>
-  </div>
-  <div class="next-step-row">
-    <strong>Install Plugins</strong>
-    <span>Pre-built Claude Code agents and skills you can install in one command</span>
-    <a href="../use-the-playbook/build/">Marketplace →</a>
-  </div>
-  <div class="next-step-row">
-    <strong>Take a Course</strong>
-    <span>Structured learning that walks you through building with AI step by step</span>
-    <a href="../courses/">Learn with James →</a>
-  </div>
-</div>
+| Next Step | What it is |
+|---|---|
+| [**Learn the Building Blocks** →](../agentic-building-blocks/) | The eleven components of every AI workflow — models, prompts, context, projects, skills, agents, and more |
+| [**Install Plugins** →](../use-the-playbook/build/) | Pre-built Claude Code agents and skills you can install in one command |
+| [**Take a Course** →](../courses/) | Structured learning that walks you through building with AI step by step |

--- a/src/content/docs/builder-setup/voice-to-text-setup.md
+++ b/src/content/docs/builder-setup/voice-to-text-setup.md
@@ -11,7 +11,9 @@ howto_steps:
     text: Allow microphone access and configure your preferred activation method (keyboard shortcut or push-to-talk).
   - name: Test dictation
     text: Activate voice input and speak naturally. Verify transcription accuracy in a text field or Claude chat.
----## Why Voice Input?
+---
+
+## Why Voice Input?
 
 Writing good AI prompts often means describing complex ideas, explaining context, or thinking through a problem out loud. Voice input lets you speak those thoughts naturally — it's faster than typing and often more detailed, because talking feels more like having a conversation than writing a document.
 
@@ -34,7 +36,9 @@ Wispr Flow lets you dictate text anywhere on your computer using your voice.
 
 1. Grant microphone permissions when prompted
 2. Set your preferred activation method (keyboard shortcut or push-to-talk)
-3. Test dictation in any text field
+3. Open any text field (an email, a browser search bar, a note), activate voice input, and say a short test sentence
+
+**You're done when:** your spoken words appear as typed text in whatever field you picked.
 
 ### Tips for Wispr Flow
 
@@ -74,6 +78,8 @@ Claude Desktop has a Quick Entry feature that lets you access Claude from anywhe
 5. Press Enter or click the send button to run
 
 Claude Desktop launches with your transcribed prompt and responds.
+
+**You're done when:** Claude Desktop opens with your spoken words transcribed as a prompt, and Claude responds to it.
 
 ### Tips for Claude Desktop Voice
 

--- a/src/content/docs/courses/tools-setup-checklist.md
+++ b/src/content/docs/courses/tools-setup-checklist.md
@@ -5,43 +5,41 @@ description: Complete setup guide for Hands-on AI courses — AI platform accoun
 
 Everything you need to set up before Session 1. Work through the steps in order — later steps build on earlier ones. Budget **2–3 hours** total, split across two sittings if you prefer. Times are estimates — it's normal for some steps to take longer, especially if the tools are new to you.
 
-:::tip[Track your progress]
-The checkboxes below are visual markers — they won't save on the web. Use **Cmd + P** (Mac) or **Ctrl + P** (Windows) to print this page and check off steps by hand, or track progress in a notes app.
+:::note[New to these tools?]
+Before diving in, skim [Why These Tools Matter](/builder-setup/#why-these-tools-matter) (~2 minutes). It explains what each tool is and why we use it — the context that makes the rest of this checklist click.
 :::
+
 ## At a Glance
 
 ### Part 1: AI Platform Setup (~45 min)
 
 | Step | What | Time | Status |
 |------|------|------|--------|
-| 1 | [AI Platform Account + Apps](#step-1-ai-platform-account--apps) | ~15 min | Required |
-| 2 | [Personalization / Custom Instructions](#step-2-personalization--custom-instructions) | ~15 min | Recommended |
-| 3 | [Memory](#step-3-memory) | ~10 min | Recommended |
-| 4 | [Connections (MCP / Integrations)](#step-4-connections-mcp--integrations) | ~15 min | Recommended |
+| 1 | [AI Platform Setup](#step-1-ai-platform-setup) | ~45 min | Required |
 
 ### Part 2: Builder Tools (~90 min)
 
 | Step | What | Time | Status |
 |------|------|------|--------|
-| 5 | [Terminal Basics](#step-5-terminal-basics) | ~15 min | Required |
-| 6 | [Code Editor + Extensions](#step-6-code-editor--extensions) | ~15 min | Required |
-| 7 | [Git](#step-7-git) | ~10 min | Required |
-| 8 | [GitHub](#step-8-github) | ~15 min | Required |
-| 9 | [Voice to Text](#step-9-voice-to-text) | ~10 min | Recommended |
-| 10 | [Hands-on AI Skills](#step-10-hands-on-ai-skills) | ~10 min | Recommended |
-| 11 | [Connect the Course Knowledge Base](#step-11-connect-the-course-knowledge-base) | ~5 min | Recommended |
+| 2 | [Terminal Basics](#step-2-terminal-basics) | ~15 min | Required |
+| 3 | [Code Editor + Extensions](#step-3-code-editor--extensions) | ~15 min | Required |
+| 4 | [Git](#step-4-git) | ~10 min | Required |
+| 5 | [GitHub](#step-5-github) | ~15 min | Required |
+| 6 | [Voice to Text](#step-6-voice-to-text) | ~10 min | Recommended |
+| 7 | [Hands-on AI Skills](#step-7-hands-on-ai-skills) | ~10 min | Recommended |
+| 8 | [Hands-on AI Knowledge Base](#step-8-hands-on-ai-knowledge-base) | ~5 min | Recommended |
 
 ### Part 3: AI Workflow Management (~20 min)
 
 | Step | What | Time | Status |
 |------|------|------|--------|
-| 12 | [AI Registry Setup](#step-12-ai-registry-setup) | ~20 min | Recommended |
+| 9 | [AI Registry Setup](#step-9-ai-registry-setup) | ~20 min | Recommended |
 
 ---
 
 ## Part 1 — AI Platform Setup
 
-These steps set up your AI platform accounts and configure them for the best experience in the course. You only need **one** platform set up — use whichever you prefer. Each platform has a Getting Started checklist that covers all four steps below:
+You need at least one AI platform set up before starting on builder tools. Pick whichever you prefer — you only need one. Each platform has a Getting Started guide that walks you through everything in one place.
 
 | Platform | Getting Started Guide |
 |----------|----------------------|
@@ -50,89 +48,44 @@ These steps set up your AI platform accounts and configure them for the best exp
 | Gemini (Google) | [Getting Started with Gemini](/platforms/google-gemini/getting-started/) |
 | M365 Copilot (Microsoft) | [Getting Started with M365 Copilot](/platforms/m365-copilot/getting-started/) |
 
-Pick your platform(s), open the Getting Started guide, and work through the steps below. Each guide has the platform-specific instructions.
+### Step 1: AI Platform Setup
 
-### Step 1: AI Platform Account + Apps
+**What:** Create a paid AI platform account, configure it for your work, and connect it to the apps you already use. Your platform's Getting Started guide walks you through all of this in one place — account creation, apps, personalization, memory, and connections.
 
-**What:** Create an account with a paid subscription and install all available apps (web, desktop, mobile). The course requires a paid plan (e.g., ChatGPT Plus, Claude Pro, Gemini Advanced) — free tiers don't support features you'll need. Your Getting Started guide has pricing details.
+**Action:** Follow your platform's Getting Started guide from the table above.
 
-- [ ] I have a paid AI platform account and can start conversations
-- [ ] I've installed the desktop and mobile apps for my platform(s)
+**Done when:**
 
-<details>
-<summary>Stuck? Ask AI for help</summary>
-
-> I'm trying to sign up for [Claude / ChatGPT / Gemini / Copilot] and running into this issue: [describe what's happening]. What should I try?
-
-Still stuck? Check your platform's [Getting Started guide](#part-1--ai-platform-setup) or bring your question to Session 1.
-
-</details>
----
-
-### Step 2: Personalization / Custom Instructions
-
-**What:** Tell your AI platform about yourself so every conversation starts with context about your role, industry, and preferences.
-
-- [ ] I've added personalization / custom instructions to my AI platform
+- You have a paid AI platform account and can start conversations (Claude Pro, ChatGPT Plus, Gemini Advanced, or Copilot Pro)
+- You've installed the desktop and mobile apps for your platform
+- You've added personalization / custom instructions so the AI knows about your role and work
+- Memory is enabled so the AI remembers context across conversations
+- You've connected at least one external tool or data source (Google Docs, Slack, Notion, etc.)
 
 <details>
 <summary>Stuck? Ask AI for help</summary>
 
-> I'm trying to set up custom instructions in [ChatGPT / Claude / Gemini] and can't find the setting. I'm on [web / desktop / mobile]. Where do I go?
+> I'm setting up [Claude / ChatGPT / Gemini / Copilot] and running into this issue: [describe what's happening]. What should I try?
 
-Still stuck? Check your platform's [Getting Started guide](#part-1--ai-platform-setup) or bring your question to Session 1.
-
-</details>
----
-
-### Step 3: Memory
-
-**What:** Enable memory so your AI platform remembers context across conversations.
-
-- [ ] Memory is enabled on my AI platform
-
-<details>
-<summary>Stuck? Ask AI for help</summary>
-
-> I'm trying to enable memory in [ChatGPT / Claude / Gemini] but can't find the toggle. I'm on [web / desktop / mobile] with a [Free / Plus / Pro] plan. Where do I look?
-
-Still stuck? Check your platform's [Getting Started guide](#part-1--ai-platform-setup) or bring your question to Session 1.
-
-</details>
----
-
-### Step 4: Connections (MCP / Integrations)
-
-**What:** Connect your AI platform to external tools and data sources so it can read from and write to apps you already use — like Google Docs, Slack, or your company's knowledge base. Each platform calls these something different (MCP servers, connectors, extensions, or connected apps).
-
-You can skip this for now — you'll set up specific connections later in the course when you need them.
-
-- [ ] I've connected at least one external tool or data source (optional — can do later)
-
-<details>
-<summary>Stuck? Ask AI for help</summary>
-
-> I'm trying to connect [tool name] to [ChatGPT / Claude / Gemini] and running into this issue: [describe what's happening]. What should I check?
-
-Still stuck? Check your platform's [Getting Started guide](#part-1--ai-platform-setup) or bring your question to Session 1.
+Still stuck? Bring your question to Session 1.
 
 </details>
 ---
 
 ## Part 2 — Builder Tools
 
-Your AI platform is ready. Next, you'll set up the developer tools that let you build with AI.
+Your AI platform is ready. Next, you'll set up the developer tools you'll use throughout the course. For each step, follow the Action link to the setup guide, complete the setup, then come back here and confirm the "Done when" criteria before moving on.
 
-These steps install the developer tools you'll use throughout the course. Each step has a detailed guide — follow the link, complete the setup, then come back here and check the box.
+### Step 2: Terminal Basics
 
-### Step 5: Terminal Basics
+**What:** Learn to open the terminal, see where you are, and navigate between folders — on Mac (Terminal) and Windows (PowerShell). You don't need to be an expert.
 
-**What:** Familiarize yourself with the basics of the terminal on Mac and PowerShell on Windows.
+**Action:** [Follow the Terminal Basics setup guide →](/builder-setup/terminal-basics/)
 
-[→ Go to Terminal Basics guide](/builder-setup/terminal-basics/)
+**Done when:**
 
-- [ ] I can open a terminal and see a prompt (`$`, `%`, or `>`)
-- [ ] Running `pwd` (Mac) or `Get-Location` (Windows) shows my current directory
+- You can open a terminal and see a prompt (`$`, `%`, or `>`)
+- Running `pwd` (Mac) or `Get-Location` (Windows) shows your current directory
 
 <details>
 <summary>Stuck? Ask AI for help</summary>
@@ -142,14 +95,16 @@ These steps install the developer tools you'll use throughout the course. Each s
 </details>
 ---
 
-### Step 6: Code Editor + Extensions
+### Step 3: Code Editor + Extensions
 
 **What:** Install and configure Cursor or VS Code with AI model integration (Claude, ChatGPT Codex, Gemini Code Assist, or similar).
 
-[→ Go to Editor Setup guide](/builder-setup/editor-setup/)
+**Action:** [Follow the Code Editor setup guide →](/builder-setup/editor-setup/)
 
-- [ ] I can open my editor and see the welcome screen or an empty workspace
-- [ ] At least one AI extension installed for a platform I have a paid subscription to
+**Done when:**
+
+- You can open your editor and see the welcome screen or an empty workspace
+- At least one AI extension is installed for a platform you have a paid subscription to
 
 <details>
 <summary>Stuck? Ask AI for help</summary>
@@ -159,13 +114,15 @@ These steps install the developer tools you'll use throughout the course. Each s
 </details>
 ---
 
-### Step 7: Git
+### Step 4: Git
 
-**What:** Install Git — a version control tool that tracks the changes you make to your AI building blocks. Git ensures you never lose them — every version is saved, and you can always recover or refine what you've built.
+**What:** Install Git and configure your name and email so it can sign your commits.
 
-[→ Go to Git Installation guide](/builder-setup/git-install/)
+**Action:** [Follow the Git installation guide →](/builder-setup/git-install/)
 
-- [ ] Running `git --version` in my terminal shows a version number
+**Done when:**
+
+- Running `git --version` in your terminal shows a version number
 
 <details>
 <summary>Stuck? Ask AI for help</summary>
@@ -175,15 +132,17 @@ These steps install the developer tools you'll use throughout the course. Each s
 </details>
 ---
 
-### Step 8: GitHub
+### Step 5: GitHub
 
-**What:** Create an account, enable 2FA, and create a repository for your coursework. GitHub is where your files live in the cloud — backed up, versioned, and accessible from any machine.
+**What:** Create an account, enable two-factor authentication (2FA), and create a repository for your coursework.
 
-[→ Go to GitHub Setup guide](/builder-setup/github-setup/)
+**Action:** [Follow the GitHub setup guide →](/builder-setup/github-setup/)
 
-- [ ] I have a GitHub account
-- [ ] I can clone a repository and see the files in my editor
-- [ ] In my terminal, I can navigate to the cloned folder (`cd my-repo-name`) and run `git status` — it shows `On branch main`
+**Done when:**
+
+- You have a GitHub account
+- You can clone a repository and see the files in your editor
+- In your terminal, you can navigate to the cloned folder (`cd my-repo-name`) and run `git status` — it shows `On branch main`
 
 <details>
 <summary>Stuck? Ask AI for help</summary>
@@ -193,13 +152,15 @@ These steps install the developer tools you'll use throughout the course. Each s
 </details>
 ---
 
-### Step 9: Voice to Text
+### Step 6: Voice to Text
 
 **What:** Configure system voice input or install a dedicated voice-to-text tool (Wispr Flow recommended).
 
-[→ Go to Voice to Text Setup guide](/builder-setup/voice-to-text-setup/)
+**Action:** [Follow the Voice to Text setup guide →](/builder-setup/voice-to-text-setup/)
 
-- [ ] I can dictate text into any input field on my computer
+**Done when:**
+
+- You can dictate text into any input field on your computer
 
 <details>
 <summary>Stuck? Ask AI for help</summary>
@@ -209,30 +170,34 @@ These steps install the developer tools you'll use throughout the course. Each s
 </details>
 ---
 
-### Step 10: Hands-on AI Skills
+### Step 7: Hands-on AI Skills
 
-**What:** Skills are reusable instructions that teach your AI tool how to do specific tasks your way — like editing to publication standards or generating meeting briefs. You'll use these throughout the course.
+**What:** Install the Hands-on AI skills that walk you through the Business-First AI Framework — analyze, deconstruct, design, build, test, run, improve. These are the step-by-step guides you'll use throughout the course to take a workflow from "I think AI could help with this" to shipped and improving.
 
-[→ How to Add Skills to Your Platform](/agentic-building-blocks/skills/#how-to-add-skills-to-your-platform)
+**Action:** [Follow the Framework Skills setup guide →](/business-first-ai-framework/skills/)
 
-- [ ] At least one skill installed or added to your platform
-- [ ] Skill verified — invoked it in your AI tool and got a response
+**Done when:**
+
+- At least one skill is installed or added to your platform
+- You've invoked a skill in your AI tool and received a response
 
 <details>
 <summary>Stuck? Ask AI for help</summary>
 
-> I'm trying to add a skill to [your platform] and it's not working. What should I check?
+> I'm trying to add a skill to [your AI tool] on [Mac / Windows] and running into this issue: [describe what's happening]. What should I check?
 
 </details>
 ---
 
-### Step 11: Connect the Course Knowledge Base
+### Step 8: Hands-on AI Knowledge Base
 
-**What:** Connect the Hands-on AI knowledge base to your AI tool so you can search course content, building blocks, and reference material right where you work.
+**What:** Connect the Hands-on AI Knowledge Base to your AI tool so you can search course content, building blocks, and reference material right where you work. Your AI tool may call this an "MCP server" or "MCP connector" — that's the underlying technology.
 
-[→ Go to MCP Server Connection Guide](/mcp-server/)
+**Action:** [Follow the Knowledge Base connection guide →](/mcp-server/)
 
-- [ ] Hands-on AI MCP server connected to my AI platform
+**Done when:**
+
+- The Hands-on AI Knowledge Base is connected to your AI platform
 
 <details>
 <summary>Stuck? Ask AI for help</summary>
@@ -248,14 +213,16 @@ Your toolkit is complete. One last step to set up your workflow management syste
 
 Keeping track of your workflows and the AI building blocks that power them is essential to change management and scaling your operations.
 
-### Step 12: AI Registry Setup
+### Step 9: AI Registry Setup
 
 **What:** Get a free Notion account, duplicate the AI Registry template, and connect Notion to your AI tool.
 
-[→ Go to AI Registry Setup guide](/builder-setup/notion-registry-setup/)
+**Action:** [Follow the AI Registry setup guide →](/builder-setup/notion-registry-setup/)
 
-- [ ] Notion AI Registry template duplicated to my workspace
-- [ ] AI Registry plugin installed (`/plugin install ai-registry@handsonai`)
+**Done when:**
+
+- The Notion AI Registry template is duplicated to your workspace
+- The AI Registry plugin is installed (`/plugin install ai-registry@handsonai`)
 
 <details>
 <summary>Stuck? Ask AI for help</summary>
@@ -270,7 +237,7 @@ Keeping track of your workflows and the AI building blocks that power them is es
 You're all set for the course — nice work getting through the setup!
 
 - **Quick test:** Open your AI tool and ask: "What tools and connections do I have set up?" — this confirms everything is working together
-- **Bookmark this page** — come back to finish any steps you skipped
+- **Bookmark this page** — it's your ongoing reference for the tool setup
 - **Start Session 1** — you'll put these tools to work right away
 
 Having trouble with any step? Bring your questions to the first session — we'll troubleshoot together.

--- a/src/content/docs/mcp-server/index.md
+++ b/src/content/docs/mcp-server/index.md
@@ -1,7 +1,9 @@
 ---
 title: MCP Server
 description: Connect to the Hands-on AI Playbook from Claude, ChatGPT, Claude Code, Cursor, VS Code, and other MCP-compatible tools
----The Hands-on AI Playbook is available as an MCP (Model Context Protocol) server, so you can get playbook-informed answers directly in your AI tools — no API keys or authentication required.
+---
+
+The Hands-on AI Playbook is available as an MCP (Model Context Protocol) server, so you can get playbook-informed answers directly in your AI tools — no API keys or authentication required.
 
 **MCP server URL:** `https://mcp.handsonai.info/mcp`
 
@@ -161,11 +163,18 @@ Any MCP client that supports Streamable HTTP transport can connect:
 | `list_questions` | List all Q&A pages with question text and short answers |
 | `get_setup_guide` | Get a Builder Tools setup guide (terminal, editor, git, claude-code, etc.) |
 
+## Verify It's Working
+
+Once you've added the connector, start a new conversation in your AI tool and ask:
+
+> What are the agentic building blocks?
+
+**You're done when:** your AI tool answers with playbook content — you should see it search the playbook and return a response that references the eleven building blocks (Model, Prompt, Context, Project, Memory, Skill, Agent, MCP, API, SDK, CLI). If your AI tool answers from general knowledge without searching the playbook, the connector isn't enabled in that conversation — enable it and try again.
+
 ## Example Prompts
 
-Once connected, try asking your AI assistant:
+Other prompts to try once the connector is working:
 
-- "What are the agentic building blocks?"
 - "How do I set up Claude Code?"
 - "Search the playbook for prompt engineering techniques"
 - "What's the Business-First AI Framework?"


### PR DESCRIPTION
## Summary

Reorients the Builder Tools Setup page and the course Tools Setup Checklist so non-technical students can understand what each tool does, why it matters, what to do, and how to verify they're done.

- **`/builder-setup/`** drops from 203 → 91 lines. Adds a "Why These Tools Matter" three-area orientation (AI Platform / Builder Tools / Workflow Registry), collapses eight per-tool detail sections into a single Setup Order table with prereqs, and replaces the custom HTML "What's Next?" block with a native Markdown table.
- **`/courses/tools-setup-checklist/`** goes from 12 steps to 9. Collapses the four circular Part 1 sub-steps into a single honest "AI Platform Setup" step with five Done-when criteria. Every step now follows a consistent **What → Action → Done when → Stuck?** pattern with prominent bolded action links directly beneath each heading.
- **Supporting guides** (`voice-to-text-setup.md`, `mcp-server/index.md`) get explicit verification sections and frontmatter formatting fixes so the individual guides are fully self-sufficient.

## Key content decisions

- **Orientation lives in one place.** The "Why These Tools Matter" tables live only on `/builder-setup/`; the course checklist links to them via a small callout at the top. No duplication to maintain.
- **Hands-on AI Skills now point at the framework skills setup guide** (`/business-first-ai-framework/skills/`) instead of the generic building blocks skills section.
- **Knowledge Base is now the student-facing name**, with the "MCP server / MCP connector" technical term introduced parenthetically once so students recognize it in their AI tool's settings.
- **Task-list checkboxes removed** — they didn't persist on the web and were visual clutter. Replaced with labeled "Done when:" bullet lists in second-person voice.
- **Per-tool detail sections on `/builder-setup/` were removed** after verifying that each individual setup guide (terminal, editor, Git, GitHub, voice, skills, MCP, Notion registry) is self-sufficient with its own verification criteria.

## Test plan

- [ ] `npm run build` passes (190 pages built, no broken links — verified locally)
- [ ] Visit http://localhost:4321/builder-setup/ and confirm the three-area orientation, Setup Order table with prereqs, and Heads up callout render correctly
- [ ] Visit http://localhost:4321/courses/tools-setup-checklist/ and confirm all 9 steps follow the What → Action → Done when → Stuck pattern, and all anchor links and external setup guide links resolve
- [ ] Spot-check the cross-links: `/builder-setup/#why-these-tools-matter`, `/business-first-ai-framework/skills/`, `/mcp-server/`, and the four `/platforms/*/getting-started/` links
- [ ] Read the course checklist from a beginner lens — does every step make it obvious what to click, what to do, and when you're done?

🤖 Generated with [Claude Code](https://claude.com/claude-code)