### PR TITLE
docs: restructure builder setup into two-part framing

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -419,12 +419,12 @@ export default defineConfig({
           collapsed: true,
           items: [
             { label: 'Overview', link: '/builder-setup/' },
-            { label: 'Terminal Basics', link: '/builder-setup/terminal-basics/' },
             { label: 'AI Code Editor', link: '/builder-setup/editor-setup/' },
             { label: 'Git', link: '/builder-setup/git-install/' },
             { label: 'GitHub', link: '/builder-setup/github-setup/' },
             { label: 'Voice to Text', link: '/builder-setup/voice-to-text-setup/' },
             { label: 'AI Registry', link: '/builder-setup/notion-registry-setup/' },
+            { label: 'Terminal Basics (reference)', link: '/builder-setup/terminal-basics/' },
           ],
         },
         {

--- a/src/content/docs/builder-setup/index.md
+++ b/src/content/docs/builder-setup/index.md
@@ -1,25 +1,25 @@
 ---
 title: Builder Tools Setup Guide
-description: Step-by-step checklist for setting up your developer toolkit — terminal, editor, Git, GitHub, and workflow management
+description: Two-part setup guide — your AI platform with Hands-on AI add-ons, plus optional advanced tools for power users
 ---
 
-This guide sets up the developer tools and workflow management you need for building with AI.
+Two parts. **Part 1** is everything you need to start getting real value — your AI platform plus two add-ons that live inside it. **Part 2** is optional, for power users who want advanced capabilities (local files, version control, voice input, a workflow registry) that work alongside their AI platform.
 
-:::note[AI platform setup is in the Platforms section]
-Before starting here, make sure you've set up at least one AI platform — account, apps, personalization, memory, and connections. Each platform has its own Getting Started checklist:
+:::note[Already have an AI platform set up?]
+If you've already completed your platform's Getting Started checklist, skip straight to [Hands-on AI Skills](#part-1--what-you-need-60-min) below. If not, pick one:
 
 [→ Claude](../platforms/claude/getting-started/) · [→ OpenAI](../platforms/openai/getting-started/) · [→ Gemini](../platforms/google-gemini/getting-started/) · [→ M365 Copilot](../platforms/m365-copilot/getting-started/)
 :::
 
 ## Why These Tools Matter
 
-Real AI workflows — the kind that save time, ship work, and scale beyond one-off chats — need more than a chatbot. You need an **AI platform** to think with, **builder tools** to build and manage your AI building blocks, and a **workflow registry** so you can track and reuse what you build.
+Real AI workflows — the kind that save time, ship work, and scale beyond one-off chats — need more than a chatbot. Two parts: **Part 1** is what you need to start getting real value — your AI platform plus two add-ons that live inside it. **Part 2** is for power users who want advanced capabilities that work in collaboration with their AI platform.
 
 Each tool below was chosen intentionally. Here's what each one unlocks for you.
 
-### 1. AI Platform — the foundation
+### Part 1 — What You Need
 
-Everything else sits on top of this. Your AI platform is the reasoning engine that powers every workflow you build — pick whichever you prefer, one is enough.
+Your AI platform is the reasoning engine that powers every workflow you build — one account is enough. Two add-ons then run inside it: one gives you step-by-step framework guidance, the other makes the Hands-on AI playbook searchable from your AI tool.
 
 | Capability | What it is | Why it matters to you |
 |---|---|---|
@@ -27,50 +27,48 @@ Everything else sits on top of this. Your AI platform is the reasoning engine th
 | **Personalization** | Custom instructions that tell the AI about your role, industry, and style | Every conversation starts with context — you stop re-introducing yourself and answers arrive tailored from message one |
 | **Memory** | The AI remembers facts about you and your work across conversations | Your AI becomes a returning assistant who knows your projects, not a stranger every time you open a new chat |
 | **Connections** | Links your AI to apps you already use (Google Docs, Slack, Notion, GitHub, etc.) | AI can read and write inside your real systems — no more copy-paste between tools |
+| **Hands-on AI Skills** | Skills that walk you through the [Business-First AI Framework](../business-first-ai-framework/skills/) for building AI workflows | Learn how to go from "I think AI could help with this" to a shipped, improving workflow — with step-by-step guidance at every stage |
+| **Hands-on AI Knowledge Base** | The Hands-on AI playbook, connected to your AI tool as a live reference | Ask questions and get answers right inside the AI tool where you're already doing your work — no switching tabs or searching the website |
 
-### 2. Builder Tools — build and manage your AI building blocks
+### Part 2 — For Power Users
 
-These are the tools you use to build and manage your [AI building blocks](../agentic-building-blocks/) — prompts, skills, agents, and more — that power every AI workflow. Building a good one is just the start: like any asset that runs your business, they need to be refined, versioned, and shared over time. This toolkit handles all of that, whether your workflows run locally or in the cloud.
+Optional tools that work in collaboration with your AI platform to build and manage your [AI building blocks](../agentic-building-blocks/) — prompts, skills, agents, and more — as files you can version, back up, and share. Pick any combination; you can come back and add more later.
 
 | Capability | What it is | Why it matters to you |
 |---|---|---|
-| **Terminal** | The command-line interface built into your computer (Terminal on Mac, PowerShell on Windows) | Most AI developer tools run here — a little fluency unlocks everything else in this list |
 | **Code Editor** | Cursor or VS Code, with AI extensions installed | An organized home for every building block you create — browse them in folders, edit them in place, and let the built-in AI assistants read and update them directly as you work |
 | **Git** | Automatically tracks every change to every file | You'll constantly create and refine your building blocks — Git keeps the full history for you, so you never have to manage versions manually, and it connects to GitHub so everything gets backed up in the cloud |
 | **GitHub** | Cloud storage and backup for your files, built on top of Git | Your work is safe, versioned, accessible from any machine, and easy to share |
 | **Voice to Text** | Dictation software (Wispr Flow or your system's built-in voice input) | Talk instead of type — faster for long prompts and more natural when you're thinking out loud |
-| **Hands-on AI Skills** | Skills that walk you through the [Business-First AI Framework](../business-first-ai-framework/skills/) for building AI workflows | Learn how to go from "I think AI could help with this" to a shipped, improving workflow — with step-by-step guidance at every stage |
-| **Hands-on AI Knowledge Base** | The Hands-on AI playbook, connected to your AI tool as a live reference | Ask questions and get answers right inside the AI tool where you're already doing your work — no switching tabs or searching the website |
-
-### 3. Workflow Registry — your system of record for AI workflows
-
-Once you're building more than one workflow, you need a single place to track what they do, who uses them, and how they're built.
-
-| Capability | What it is | Why it matters to you |
-|---|---|---|
 | **AI Registry (Notion)** | A structured Notion workspace for your workflows, AI building blocks, and connected apps | The single source of truth for what you've built, who's using it, and how it all connects — essential once you're scaling beyond one-off experiments |
 
 ## Setup Order
 
-Work through these in order — later steps build on earlier ones. Each link opens the full setup guide with step-by-step instructions and verification criteria.
+Start with Part 1 and complete the steps in order. Part 2 is optional — pick any combination of tools when you need them. Each link opens the full setup guide with step-by-step instructions and verification criteria. For students working through a course, the [Tools Setup Checklist](/courses/tools-setup-checklist/) adds per-step "Done when" criteria and troubleshooting prompts.
 
-### Builder Tools (~90 min)
+### Part 1 — What You Need (~60 min)
 
-| # | Tool | Time | Requires | Status |
+| # | Tool | Time | Status | Why it matters |
 |---|---|---|---|---|
-| 1 | [Terminal Basics](terminal-basics/) | ~15 min | Nothing | Required |
-| 2 | [AI Code Editor + Extensions](editor-setup/) | ~15 min | Terminal | Required |
-| 3 | [Git](git-install/) | ~10 min | Terminal | Required |
-| 4 | [GitHub](github-setup/) | ~15 min | Editor + Git | Required |
-| 5 | [Voice to Text](voice-to-text-setup/) | ~10 min | Nothing | Recommended |
-| 6 | [Hands-on AI Skills](../business-first-ai-framework/skills/) | ~10 min | AI platform | Recommended |
-| 7 | [Hands-on AI Knowledge Base](../mcp-server/) | ~5 min | AI platform | Recommended |
+| 1 | AI Platform (see [Platforms](../platforms/)) | ~45 min | Required | The reasoning engine that powers every workflow — one account is enough |
+| 2 | [Hands-on AI Skills](../business-first-ai-framework/skills/) | ~10 min | Recommended | Step-by-step guidance for building AI workflows, right inside your AI tool |
+| 3 | [Hands-on AI Knowledge Base](../mcp-server/) | ~5 min | Recommended | Ask the Hands-on AI playbook questions without leaving your AI tool |
 
-### AI Workflow Management (~20 min)
+### Part 2 — For Power Users (~70 min total)
 
-| # | Tool | Time | Requires | Status |
+Pick any combination — each row names the specific capability it unlocks.
+
+| # | Tool | Time | Requires | Install this if you want to… |
 |---|---|---|---|---|
-| 8 | [AI Registry (Notion)](notion-registry-setup/) | ~20 min | AI platform | Recommended |
+| 4 | [AI Code Editor + Extensions](editor-setup/) | ~15 min | Nothing | Store building blocks as files on your computer and edit them with AI assistance |
+| 5 | [Git](git-install/) | ~10 min | Editor | Keep a full version history of your building blocks automatically |
+| 6 | [GitHub](github-setup/) | ~15 min | Editor + Git | Back up your building blocks to the cloud and share them across machines |
+| 7 | [Voice to Text](voice-to-text-setup/) | ~10 min | Nothing | Talk instead of type when writing prompts |
+| 8 | [AI Registry (Notion)](notion-registry-setup/) | ~20 min | AI platform | Track every workflow, building block, and connected app in one workspace |
+
+:::note[New to the terminal?]
+Some Power User tools (Editor, Git, GitHub) involve running commands in the terminal. If that's unfamiliar, skim [Terminal Basics](terminal-basics/) first — it's a ~15-minute fluency primer, not a setup step.
+:::
 
 :::note[Heads up]
 - **Hands-on AI Knowledge Base:** Your AI tool may call this an "MCP server" or "MCP connector" — that's the underlying technology.

--- a/src/content/docs/courses/tools-setup-checklist.md
+++ b/src/content/docs/courses/tools-setup-checklist.md
@@ -1,9 +1,9 @@
 ---
 title: Tools Setup Checklist
-description: Complete setup guide for Hands-on AI courses — AI platform accounts, developer tools, and workflow management
+description: Complete setup guide for Hands-on AI courses — AI platform, in-platform add-ons, and advanced tools for power users
 ---
 
-Everything you need to set up before Session 1. Work through the steps in order — later steps build on earlier ones. Budget **2–3 hours** total, split across two sittings if you prefer. Times are estimates — it's normal for some steps to take longer, especially if the tools are new to you.
+Everything you need to set up before Session 1. Work through the steps in order — later steps build on earlier ones. Budget **1–3 hours** total depending on how far you go. Times are estimates — it's normal for some steps to take longer, especially if the tools are new to you.
 
 :::note[New to these tools?]
 Before diving in, skim [Why These Tools Matter](/builder-setup/#why-these-tools-matter) (~2 minutes). It explains what each tool is and why we use it — the context that makes the rest of this checklist click.
@@ -11,35 +11,37 @@ Before diving in, skim [Why These Tools Matter](/builder-setup/#why-these-tools-
 
 ## At a Glance
 
-### Part 1: AI Platform Setup (~45 min)
+### Part 1: What You Need for the Course (~60 min)
+
+Your AI platform plus two add-ons that run entirely inside it. This is the baseline every student needs to get real value from the course.
 
 | Step | What | Time | Status |
 |------|------|------|--------|
 | 1 | [AI Platform Setup](#step-1-ai-platform-setup) | ~45 min | Required |
+| 2 | [Hands-on AI Skills](#step-2-hands-on-ai-skills) | ~10 min | Recommended |
+| 3 | [Hands-on AI Knowledge Base](#step-3-hands-on-ai-knowledge-base) | ~5 min | Recommended |
 
-### Part 2: Builder Tools (~90 min)
+### Part 2: For Power Users (~70 min)
 
-| Step | What | Time | Status |
-|------|------|------|--------|
-| 2 | [Terminal Basics](#step-2-terminal-basics) | ~15 min | Required |
-| 3 | [Code Editor + Extensions](#step-3-code-editor--extensions) | ~15 min | Required |
-| 4 | [Git](#step-4-git) | ~10 min | Required |
-| 5 | [GitHub](#step-5-github) | ~15 min | Required |
-| 6 | [Voice to Text](#step-6-voice-to-text) | ~10 min | Recommended |
-| 7 | [Hands-on AI Skills](#step-7-hands-on-ai-skills) | ~10 min | Recommended |
-| 8 | [Hands-on AI Knowledge Base](#step-8-hands-on-ai-knowledge-base) | ~5 min | Recommended |
-
-### Part 3: AI Workflow Management (~20 min)
+More advanced tools that work in collaboration with your AI platform. Pick any combination — each unlocks a specific capability. Optional, and you can come back and add more later.
 
 | Step | What | Time | Status |
 |------|------|------|--------|
-| 9 | [AI Registry Setup](#step-9-ai-registry-setup) | ~20 min | Recommended |
+| 4 | [Code Editor + Extensions](#step-4-code-editor--extensions) | ~15 min | Optional |
+| 5 | [Git](#step-5-git) | ~10 min | Optional |
+| 6 | [GitHub](#step-6-github) | ~15 min | Optional |
+| 7 | [Voice to Text](#step-7-voice-to-text) | ~10 min | Optional |
+| 8 | [AI Registry (Notion)](#step-8-ai-registry-notion) | ~20 min | Optional |
 
 ---
 
-## Part 1 — AI Platform Setup
+## Part 1 — What You Need for the Course
 
-You need at least one AI platform set up before starting on builder tools. Pick whichever you prefer — you only need one. Each platform has a Getting Started guide that walks you through everything in one place.
+Your AI platform plus two add-ons that live inside it. Most students only need Part 1 to start getting real value from the course.
+
+### Choose Your AI Platform
+
+You need at least one AI platform set up before starting anything else. Pick whichever you prefer — you only need one. Each platform has a Getting Started guide that walks you through everything in one place.
 
 | Platform | Getting Started Guide |
 |----------|----------------------|
@@ -72,106 +74,7 @@ Still stuck? Bring your question to Session 1.
 </details>
 ---
 
-## Part 2 — Builder Tools
-
-Your AI platform is ready. Next, you'll set up the developer tools you'll use throughout the course. For each step, follow the Action link to the setup guide, complete the setup, then come back here and confirm the "Done when" criteria before moving on.
-
-### Step 2: Terminal Basics
-
-**What:** Learn to open the terminal, see where you are, and navigate between folders — on Mac (Terminal) and Windows (PowerShell). You don't need to be an expert.
-
-**Action:** [Follow the Terminal Basics setup guide →](/builder-setup/terminal-basics/)
-
-**Done when:**
-
-- You can open a terminal and see a prompt (`$`, `%`, or `>`)
-- Running `pwd` (Mac) or `Get-Location` (Windows) shows your current directory
-
-<details>
-<summary>Stuck? Ask AI for help</summary>
-
-> I'm learning to use the terminal on [Mac / Windows] and ran into this issue: [describe what happened]. What does this mean and what should I try?
-
-</details>
----
-
-### Step 3: Code Editor + Extensions
-
-**What:** Install and configure Cursor or VS Code with AI model integration (Claude, ChatGPT Codex, Gemini Code Assist, or similar).
-
-**Action:** [Follow the Code Editor setup guide →](/builder-setup/editor-setup/)
-
-**Done when:**
-
-- You can open your editor and see the welcome screen or an empty workspace
-- At least one AI extension is installed for a platform you have a paid subscription to
-
-<details>
-<summary>Stuck? Ask AI for help</summary>
-
-> I'm setting up [Cursor / VS Code] on [Mac / Windows] and running into this issue: [describe what's happening]. What should I try next?
-
-</details>
----
-
-### Step 4: Git
-
-**What:** Install Git and configure your name and email so it can sign your commits.
-
-**Action:** [Follow the Git installation guide →](/builder-setup/git-install/)
-
-**Done when:**
-
-- Running `git --version` in your terminal shows a version number
-
-<details>
-<summary>Stuck? Ask AI for help</summary>
-
-> I'm trying to install Git on [Mac / Windows] and getting this error: [paste error]. What should I try next?
-
-</details>
----
-
-### Step 5: GitHub
-
-**What:** Create an account, enable two-factor authentication (2FA), install the GitHub CLI, and create a repository for your coursework.
-
-**Action:** [Follow the GitHub setup guide →](/builder-setup/github-setup/)
-
-**Done when:**
-
-- You have a GitHub account
-- `gh auth status` shows you are logged in to `github.com`
-- You can clone a repository and see the files in your editor (or in the Claude Desktop Code tab)
-- In your terminal, you can navigate to the cloned folder (`cd my-repo-name`) and run `git status` — it shows `On branch main`
-
-<details>
-<summary>Stuck? Ask AI for help</summary>
-
-> I'm trying to clone a GitHub repository in [Cursor / VS Code] on [Mac / Windows] and getting this error: [paste error]. What should I try?
-
-</details>
----
-
-### Step 6: Voice to Text
-
-**What:** Configure system voice input or install a dedicated voice-to-text tool (Wispr Flow recommended).
-
-**Action:** [Follow the Voice to Text setup guide →](/builder-setup/voice-to-text-setup/)
-
-**Done when:**
-
-- You can dictate text into any input field on your computer
-
-<details>
-<summary>Stuck? Ask AI for help</summary>
-
-> I'm setting up [Wispr Flow / Claude Desktop Quick Entry] on [Mac / Windows] for voice-to-text and running into this issue: [describe what's happening]. What should I check?
-
-</details>
----
-
-### Step 7: Hands-on AI Skills
+### Step 2: Hands-on AI Skills
 
 **What:** Install the Hands-on AI skills that walk you through the Business-First AI Framework — analyze, deconstruct, design, build, test, run, improve. These are the step-by-step guides you'll use throughout the course to take a workflow from "I think AI could help with this" to shipped and improving.
 
@@ -190,7 +93,7 @@ Your AI platform is ready. Next, you'll set up the developer tools you'll use th
 </details>
 ---
 
-### Step 8: Hands-on AI Knowledge Base
+### Step 3: Hands-on AI Knowledge Base
 
 **What:** Connect the Hands-on AI Knowledge Base to your AI tool so you can search course content, building blocks, and reference material right where you work. Your AI tool may call this an "MCP server" or "MCP connector" — that's the underlying technology.
 
@@ -208,15 +111,93 @@ Your AI platform is ready. Next, you'll set up the developer tools you'll use th
 </details>
 ---
 
-## Part 3 — AI Workflow Management
+## Part 2 — For Power Users
 
-Your toolkit is complete. One last step to set up your workflow management system.
+Optional tools that work in collaboration with your AI platform. Pick any combination — you don't need all of them, and you can come back and add more later as your workflows grow.
 
-Keeping track of your workflows and the AI building blocks that power them is essential to change management and scaling your operations.
+:::note[New to the terminal?]
+Some steps below (Code Editor, Git, GitHub) involve running commands in the terminal. If that's unfamiliar, skim [Terminal Basics](/builder-setup/terminal-basics/) first — it's a ~15-minute fluency primer, not a setup step.
+:::
 
-### Step 9: AI Registry Setup
+### Step 4: Code Editor + Extensions
 
-**What:** Get a free Notion account, duplicate the AI Registry template, and connect Notion to your AI tool.
+**What:** Install and configure Cursor or VS Code with AI model integration (Claude, ChatGPT Codex, Gemini Code Assist, or similar). Unlocks the ability to store your building blocks as files on your computer and edit them with AI assistance.
+
+**Action:** [Follow the Code Editor setup guide →](/builder-setup/editor-setup/)
+
+**Done when:**
+
+- You can open your editor and see the welcome screen or an empty workspace
+- At least one AI extension is installed for a platform you have a paid subscription to
+
+<details>
+<summary>Stuck? Ask AI for help</summary>
+
+> I'm setting up [Cursor / VS Code] on [Mac / Windows] and running into this issue: [describe what's happening]. What should I try next?
+
+</details>
+---
+
+### Step 5: Git
+
+**What:** Install Git and configure your name and email so it can sign your commits. Keeps a full version history of your building blocks automatically.
+
+**Action:** [Follow the Git installation guide →](/builder-setup/git-install/)
+
+**Done when:**
+
+- Running `git --version` in your terminal shows a version number
+
+<details>
+<summary>Stuck? Ask AI for help</summary>
+
+> I'm trying to install Git on [Mac / Windows] and getting this error: [paste error]. What should I try next?
+
+</details>
+---
+
+### Step 6: GitHub
+
+**What:** Create an account, enable two-factor authentication (2FA), install the GitHub CLI, and create a repository for your coursework. Backs your building blocks up to the cloud and makes them accessible from any machine.
+
+**Action:** [Follow the GitHub setup guide →](/builder-setup/github-setup/)
+
+**Done when:**
+
+- You have a GitHub account
+- `gh auth status` shows you are logged in to `github.com`
+- You can clone a repository and see the files in your editor (or in the Claude Desktop Code tab)
+- In your terminal, you can navigate to the cloned folder (`cd my-repo-name`) and run `git status` — it shows `On branch main`
+
+<details>
+<summary>Stuck? Ask AI for help</summary>
+
+> I'm trying to clone a GitHub repository in [Cursor / VS Code] on [Mac / Windows] and getting this error: [paste error]. What should I try?
+
+</details>
+---
+
+### Step 7: Voice to Text
+
+**What:** Configure system voice input or install a dedicated voice-to-text tool (Wispr Flow recommended). Lets you talk instead of type — faster for long prompts and more natural when you're thinking out loud.
+
+**Action:** [Follow the Voice to Text setup guide →](/builder-setup/voice-to-text-setup/)
+
+**Done when:**
+
+- You can dictate text into any input field on your computer
+
+<details>
+<summary>Stuck? Ask AI for help</summary>
+
+> I'm setting up [Wispr Flow / Claude Desktop Quick Entry] on [Mac / Windows] for voice-to-text and running into this issue: [describe what's happening]. What should I check?
+
+</details>
+---
+
+### Step 8: AI Registry (Notion)
+
+**What:** Get a free Notion account, duplicate the AI Registry template, and connect Notion to your AI tool. Tracks every workflow, building block, and connected app in one workspace — essential once you're scaling beyond one-off experiments.
 
 **Action:** [Follow the AI Registry setup guide →](/builder-setup/notion-registry-setup/)
 


### PR DESCRIPTION
## Summary
- Restructures `/builder-setup/` and `/courses/tools-setup-checklist/` into a consistent two-part model: **Part 1 — What You Need** (AI Platform + Hands-on AI Skills + Knowledge Base) and **Part 2 — For Power Users** (Editor, Git, GitHub, Voice, AI Registry).
- Removes Terminal Basics from the numbered setup checklist (no setup required); kept as a reference primer in the sidebar and surfaced via a contextual "New to the terminal?" callout in Part 2.
- Reframes advanced tools from "Required" to optional capabilities, each row named by what it unlocks — so non-technical students aren't pressured into installing Editor/Git/GitHub before they're ready.
- Aligns step numbering (1–3 / 4–8) across both pages and updates the overview's "Why These Tools Matter" section to mirror the same two-part split.

## Test plan
- [ ] `npm run build` passes
- [ ] Visit `/builder-setup/` — Part 1 and Part 2 render with matching structure, no "Required" labels on advanced tools
- [ ] Visit `/courses/tools-setup-checklist/` — Steps 1–3 in Part 1, Steps 4–8 in Part 2, Terminal Basics no longer a numbered step
- [ ] Sidebar shows Terminal Basics at the bottom labeled "(reference)"
- [ ] Cross-links between overview and checklist work

🤖 Generated with [Claude Code](https://claude.com/claude-code)