### PR TITLE
Surface open source repo + unify banner lime across themes

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -44,7 +44,7 @@ export default defineConfig({
       favicon: '/assets/logo.png',
       social: [
         { icon: 'linkedin', label: 'LinkedIn', href: 'https://www.linkedin.com/in/jamesgray/' },
-        { icon: 'github', label: 'GitHub', href: 'https://github.com/jamesgray-ai' },
+        { icon: 'github', label: 'GitHub', href: 'https://github.com/jamesgray-ai/handsonai' },
         { icon: 'rss', label: 'RSS', href: '/rss.xml' },
       ],
       customCss: ['./src/styles/custom.css'],

--- a/src/content/docs/index.md
+++ b/src/content/docs/index.md
@@ -23,6 +23,10 @@ Practical guides, patterns, ready-made tools, and direct answers to move you fro
 **Learn with James** — explore [Agentic AI for Leaders](courses/leaders/) or [Claude for Builders](courses/builders/) to go from curious to capable in weeks.
 :::
 
+:::note[Open source and free to reuse]
+Everything on this site is open source. [Browse the repo](https://github.com/jamesgray-ai/handsonai) to read the content, fork it, download skills and plugins, or [contribute](CONTRIBUTING/).
+:::
+
 ---
 
 > See [what others have built](what-people-built/) with the playbook.

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -210,14 +210,13 @@ header a,
    Banner renders inside <main> above page content when
    `banner.content` is set in page frontmatter. */
 
-/* Dark mode: lime background, charcoal text */
-:root {
+/* Lime background, charcoal text — consistent across light and dark modes */
+:root,
+:root[data-theme='light'] {
   --sl-color-banner-bg: #DDF222;
   --sl-color-banner-text: #282828;
 }
 
-/* Light mode: charcoal background (matches header), off-white text */
-:root[data-theme='light'] {
-  --sl-color-banner-bg: #282828;
-  --sl-color-banner-text: #f0f0ee;
+.sl-banner {
+  font-weight: 600;
 }


### PR DESCRIPTION
## Summary
- Point the header GitHub icon at `jamesgray-ai/handsonai` instead of the org so visitors land on browsable content
- Add an "Open source and free to reuse" `:::note` callout to the homepage, just under the Start Here tip
- Render the announcement banner lime-on-charcoal in both light and dark themes (previously charcoal-on-off-white in light mode) and bump banner font-weight to 600

## Test plan
- [ ] `npm run build` passes
- [ ] Header GitHub icon opens the repo
- [ ] Homepage shows the new open-source callout
- [ ] Announcement banner is lime in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)