### PR TITLE
docs: add CLI sidebar group to platform navs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -348,6 +348,13 @@ export default defineConfig({
                 { label: 'Getting Started', link: '/platforms/claude/getting-started/' },
                 { label: 'Claude Projects', link: '/platforms/claude/projects/claude-projects-setup/' },
                 {
+                  label: 'CLI',
+                  collapsed: true,
+                  items: [
+                    { label: 'Claude Code', link: '/platforms/claude/cli/' },
+                  ],
+                },
+                {
                   label: 'Agents',
                   collapsed: true,
                   items: [
@@ -398,6 +405,13 @@ export default defineConfig({
               items: [
                 { label: 'Overview', link: '/platforms/google-gemini/' },
                 { label: 'Getting Started', link: '/platforms/google-gemini/getting-started/' },
+                {
+                  label: 'CLI',
+                  collapsed: true,
+                  items: [
+                    { label: 'Gemini CLI', link: '/platforms/google-gemini/cli/' },
+                  ],
+                },
                 { label: 'Building Agents on Google', link: '/platforms/google-gemini/agents/building-agents/' },
                 {
                   label: 'Skills',
@@ -435,6 +449,13 @@ export default defineConfig({
               items: [
                 { label: 'Overview', link: '/platforms/openai/' },
                 { label: 'Getting Started', link: '/platforms/openai/getting-started/' },
+                {
+                  label: 'CLI',
+                  collapsed: true,
+                  items: [
+                    { label: 'Codex CLI', link: '/platforms/openai/cli/' },
+                  ],
+                },
                 { label: 'Building Agents on OpenAI', link: '/platforms/openai/agents/building-agents/' },
                 {
                   label: 'Skills',

--- a/src/content/docs/platforms/claude/cli/index.md
+++ b/src/content/docs/platforms/claude/cli/index.md
@@ -1,0 +1,30 @@
+---
+title: Claude Code
+description: Anthropic's terminal-native AI coding assistant — install, configure, and use Claude Code with skills, plugins, hooks, and MCP
+---
+
+**Claude Code** is Anthropic's terminal-native AI coding assistant. It runs interactive sessions and headless jobs, reads and writes files in your project, runs shell commands, and supports the full stack of Claude building blocks — [skills](../skills/installing-skills/), plugins, hooks, subagents, MCP, and `CLAUDE.md` project memory.
+
+## Install
+
+Follow the official install instructions, which stay current as Anthropic updates the recommended method:
+
+→ <a href="https://docs.anthropic.com/en/docs/claude-code/setup" target="_blank">Claude Code setup (official docs)</a>
+
+For the broader Claude onboarding (account, plan, apps), see [Getting Started with Claude](../getting-started/).
+
+## What you can do with it
+
+- **Interactive coding** — refactor, debug, write tests, explore a codebase with the AI navigating files and running commands
+- **Headless automation** — `claude -p "prompt" --dangerously-skip-permissions` in CI/CD or scheduled jobs
+- **Extend with skills and plugins** — install from [handsonai-plugins](https://github.com/jamesgray-ai/handsonai-plugins) or write your own
+- **Connect to external systems** — MCP servers give Claude Code access to databases, APIs, and project tooling
+- **Project memory** — `CLAUDE.md` persists conventions and context across sessions
+
+## Related
+
+- [CLI building block](../../../agentic-building-blocks/cli/) — how CLIs fit alongside APIs, SDKs, and agents
+- [Installing Skills on Claude](../skills/installing-skills/) — native skill support in Claude Code
+- [Building Agents on Claude](../agents/building-agents/) — subagents, orchestration, and scheduled work
+- [Scheduling Subagents](../subagents/scheduling-subagents/) — run Claude Code on a schedule
+- <a href="https://docs.anthropic.com/en/docs/claude-code" target="_blank">Official Claude Code docs</a>

--- a/src/content/docs/platforms/google-gemini/cli/index.md
+++ b/src/content/docs/platforms/google-gemini/cli/index.md
@@ -1,0 +1,39 @@
+---
+title: Gemini CLI
+description: Google's terminal-native AI assistant — install, authenticate, and use Gemini CLI with skills and MCP
+---
+
+**Gemini CLI** is Google's open-source command-line AI assistant. It works directly with your files and terminal for coding, file operations, and automation, and supports the same building blocks as Claude Code and Codex CLI — [skills](../skills/), MCP, and project memory (`GEMINI.md`).
+
+## Install
+
+Requires [Node.js](https://nodejs.org/) 18+ and a Google account.
+
+```bash
+npm install -g @google/gemini-cli
+```
+
+Verify:
+
+```bash
+gemini --version
+```
+
+Full walk-through: [Getting Started with Gemini → Install Gemini CLI](../getting-started/#3-install-gemini-cli).
+
+## Authenticate
+
+Gemini CLI authenticates directly through your Google account — no separate Vertex AI setup needed for most users. On first run, `gemini` will open a browser to sign you in.
+
+## Add Skills
+
+Place skill folders in `.gemini/skills/` (or `.agents/skills/`) at your project root. Gemini CLI discovers them automatically.
+
+See [Skills on Google Gemini](../skills/) for the full pattern, or download ready-made skills from [handsonai-plugins](https://github.com/jamesgray-ai/handsonai-plugins/tree/main/plugins).
+
+## Related
+
+- [CLI building block](../../../agentic-building-blocks/cli/) — how CLIs fit alongside APIs, SDKs, and agents
+- [Skills on Google Gemini](../skills/) — native skill support in Gemini CLI and Antigravity
+- [Antigravity IDE](../getting-started/#1-install-antigravity-ide) — Google's agent-first IDE, also powered by Gemini
+- <a href="https://github.com/google-gemini/gemini-cli" target="_blank">Gemini CLI on GitHub</a> · <a href="https://geminicli.com/docs/" target="_blank">Official docs</a>

--- a/src/content/docs/platforms/google-gemini/index.md
+++ b/src/content/docs/platforms/google-gemini/index.md
@@ -6,6 +6,14 @@ description: Guides for Google's Gemini models and Vertex AI
 :::tip[New to Gemini?]
 Start with the [Getting Started with Gemini](getting-started/) checklist — account setup, apps, personalization, memory, and extensions.
 :::
+## Developer Tools
+
+| Tool | Description |
+|------|-------------|
+| [Antigravity IDE](getting-started/#1-install-antigravity-ide) | Google's AI-powered VS Code fork with autonomous coding agents |
+| [Gemini CLI](cli/) | Terminal-native AI assistant — maps to the [CLI building block](../../agentic-building-blocks/cli/) |
+| [Gemini Code Assist](getting-started/#2-ide-extension--gemini-code-assist) | Gemini inside VS Code or Cursor |
+
 ## Agents
 
 | Guide | Description |

--- a/src/content/docs/platforms/openai/cli/index.md
+++ b/src/content/docs/platforms/openai/cli/index.md
@@ -1,0 +1,42 @@
+---
+title: Codex CLI
+description: OpenAI's terminal-native AI coding agent — install, authenticate, and use Codex CLI for coding, file operations, and automation
+---
+
+**Codex CLI** is OpenAI's terminal-native AI coding agent. It works with your files and shell, is sandboxed by default, and supports both interactive and headless modes. Codex is included with ChatGPT Plus, Pro, Business, Enterprise, and Edu plans.
+
+## Install
+
+Requires [Node.js](https://nodejs.org/) 22+. Works on macOS, Windows, and Linux.
+
+```bash
+npm install -g @openai/codex
+```
+
+Run `codex` and sign in with your ChatGPT account when prompted:
+
+```bash
+codex
+```
+
+Verify:
+
+```bash
+codex --version
+```
+
+Full walk-through: [Getting Started with OpenAI → Install Codex](../getting-started/#1-install-codex). The Codex section also covers the **Codex app** and **IDE extension** options.
+
+## What you can do with it
+
+- **Interactive coding** — refactor, debug, explore a codebase with Codex reading files, running commands, and iterating
+- **Sandboxed execution** — Codex runs in a sandbox by default, so it won't touch files outside your project without approval
+- **Headless automation** — pass a prompt as an argument for CI/CD pipelines and scheduled jobs
+- **Multiple surfaces** — same Codex logic across the CLI, desktop app, and IDE extension
+
+## Related
+
+- [CLI building block](../../../agentic-building-blocks/cli/) — how CLIs fit alongside APIs, SDKs, and agents
+- [Skills on OpenAI](../skills/) — skills support in Codex
+- [Building Agents on OpenAI](../agents/building-agents/) — Codex, Agents SDK, and orchestration patterns
+- <a href="https://developers.openai.com/codex/cli" target="_blank">Official Codex CLI docs</a> · <a href="https://github.com/openai/codex" target="_blank">GitHub</a>


### PR DESCRIPTION
## Summary
- Adds a **CLI** sidebar group under Claude, OpenAI, and Google Gemini platforms — matches the existing building-block vocabulary (Agents, Skills) and makes Claude Code / Codex CLI / Gemini CLI discoverable from the sidebar
- Creates three stub pages (`/platforms/<platform>/cli/`) that describe each CLI and link out to official install docs (Claude Code page defers to Anthropic's setup docs since the npm install path is outdated)
- Adds a **Developer Tools** table to the Google Gemini overview so Antigravity IDE and Gemini Code Assist stay discoverable alongside Gemini CLI

Stub pages were used instead of hash-fragment sidebar links because `trailingSlash: 'always'` mangles `#anchor` into `#anchor/`, breaking the scroll.

## Test plan
- [ ] `npm run build` passes (197 pages)
- [ ] `/platforms/claude/` sidebar shows **CLI → Claude Code**, link routes to `/platforms/claude/cli/`
- [ ] `/platforms/openai/` sidebar shows **CLI → Codex CLI**, link routes to `/platforms/openai/cli/`
- [ ] `/platforms/google-gemini/` sidebar shows **CLI → Gemini CLI**, link routes to `/platforms/google-gemini/cli/`
- [ ] Gemini overview renders the Developer Tools table with working links to Antigravity, Gemini CLI, and Code Assist

🤖 Generated with [Claude Code](https://claude.com/claude-code)