### PR TITLE
docs: add Developer Tools table to OpenAI overview

### DIFF
--- a/src/content/docs/platforms/openai/index.md
+++ b/src/content/docs/platforms/openai/index.md
@@ -6,6 +6,14 @@ description: Guides for OpenAI GPT models, Assistants API, and function calling
 :::tip[New to OpenAI?]
 Start with the [Getting Started with OpenAI](getting-started/) checklist — account setup, ChatGPT apps, Codex, custom instructions, memory, and connected apps.
 :::
+## Developer Tools
+
+| Tool | Description |
+|------|-------------|
+| [Codex App](getting-started/#1-install-codex) | OpenAI's desktop Codex app — <a href="https://openai.com/codex/" target="_blank">download</a> |
+| [Codex CLI](cli/) | Terminal-native AI coding agent — maps to the [CLI building block](../../agentic-building-blocks/cli/) |
+| [Codex IDE Extension](../../builder-setup/editor-setup/#openai-codex) | Codex inside VS Code or Cursor |
+
 ## Agents
 
 | Guide | Description |


### PR DESCRIPTION
## Summary
- Adds a **Developer Tools** table to the OpenAI platform overview surfacing Codex App (desktop download), Codex CLI (stub page), and Codex IDE Extension (editor setup page)
- Mirrors the Developer Tools section already on the Google Gemini overview, giving both platforms consistent surfacing of their coding agent surfaces

## Test plan
- [ ] `npm run build` passes
- [ ] `/platforms/openai/` renders the Developer Tools table
- [ ] All three links resolve (Codex App → Getting Started anchor + external download, Codex CLI → `/platforms/openai/cli/`, IDE Extension → editor setup page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)