### PR TITLE
fix: restore search box contrast on charcoal header

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -186,13 +186,36 @@ header a,
   border-bottom: none;
 }
 
-:root[data-theme='light'] header.header a,
-:root[data-theme='light'] header.header button {
+/* Cream text for header chrome (logo, social icons, theme toggle) — but NOT
+   for the search component, which has its own pill bg, and NOT for content
+   inside the search modal dialog, which renders on the page background. */
+:root[data-theme='light'] header.header a:not(site-search *):not(dialog *),
+:root[data-theme='light'] header.header button:not(site-search *):not(dialog *) {
   color: #f0f0ee;
 }
 
-:root[data-theme='light'] header.header a:hover {
+:root[data-theme='light'] header.header a:not(site-search *):not(dialog *):hover {
   color: #DDF222;
+}
+
+/* ── Search box ──
+   The header is charcoal in both themes, so style the open-modal button
+   for a dark surface regardless of color scheme. */
+header.header site-search button[data-open-modal] {
+  background-color: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.18);
+  color: #d4d4d0;
+}
+
+header.header site-search button[data-open-modal]:hover {
+  background-color: rgba(255, 255, 255, 0.10);
+  border-color: #DDF222;
+  color: #f0f0ee;
+}
+
+header.header site-search button[data-open-modal] kbd {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: #d4d4d0;
 }
 
 /* ── Light mode sidebar contrast ──


### PR DESCRIPTION
## Summary

- The light-mode rule `header.header a/button { color: #f0f0ee }` was cascading into the Starlight/Pagefind search component, making the open-modal button's placeholder, magnifier icon, and ⌘K kbd invisible (cream-on-cream) and rendering search modal result titles/links in cream-on-light.
- Scoped the header chrome cream-text rule to exclude `site-search` and `dialog` descendants, so Pagefind UI's default theming applies inside the modal.
- Restyled the open-modal button explicitly for the charcoal header (works in both themes since the header is charcoal in both): subtle translucent pill, gray-1 text, lime hover border.

## Test plan

- [x] Built site (`npm run build`) — passes
- [x] Light mode: search button placeholder, icon, ⌘K all legible on charcoal header
- [x] Light mode: modal result titles render dark (`rgb(26,26,24)`) on light cards
- [x] Dark mode: header search button still looks correct
- [x] Search functions: query "skills" returns 29 results, clicking navigates to the page