### PR TITLE
Rename Step 3 deliverable: AI Building Block Spec → Design Spec

### DIFF
--- a/.claude/agents/framework-agent.md
+++ b/.claude/agents/framework-agent.md
@@ -25,7 +25,7 @@ You run seven skills sequentially, using files as handoffs between stages. Steps
 |------|-------|-------|--------|---------|
 | 1 (Analyze) | `analyze` | User interview | `ai-opportunity-report.md` | User picks candidate |
 | 2 (Deconstruct) | `deconstruct` | Candidate + interview | `[name]-definition.md` | Auto→Step 3 |
-| 3 (Design) | `design` | Workflow Definition | `[name]-building-block-spec.md` | Explicit approval gate |
+| 3 (Design) | `design` | Workflow Definition | `[name]-design-spec.md` | Explicit approval gate |
 | 4 (Build) | `build` | Approved spec | Platform artifacts | Auto→Step 5 |
 | 5 (Test) | `test` | Artifacts + spec | `[name]-test-results.md` | Ready OR loop to Build |
 | 6 (Run) | `run` | Tested artifacts + spec | `[name]-run-guide.md` | User follows guide |
@@ -65,25 +65,25 @@ Read the Workflow Definition and run the Design phase:
 6. Identify skill candidates with generation-ready detail
 7. Configure agents (when the mechanism calls for them)
 8. Define Evaluation Criteria — test scenarios and scoring dimensions for Step 5
-9. Generate the AI Building Block Spec (with "Integration Research Needed" section — availability research is deferred to Build)
+9. Generate the Design Spec (with "Integration Research Needed" section — availability research is deferred to Build)
 10. **Spec Approval Gate** — present the spec for explicit user approval. Do NOT proceed to Build without approval. Loop if changes are requested. After approval, prompt the user to exit plan mode.
 
 **Reads:** `outputs/[name]-definition.md`
-**Produces:** `outputs/[name]-building-block-spec.md`
+**Produces:** `outputs/[name]-design-spec.md`
 
 After the spec is approved, tell the user you're moving to Step 4 and proceed automatically.
 
 ### Step 4 — Build
 **Skill:** `build`
 
-Read the approved AI Building Block Spec and generate platform artifacts:
+Read the approved Design Spec and generate platform artifacts:
 1. **Build path choice** — offer "I'll build it" (model generates artifacts) or "I'll build it myself" (spec is the deliverable, skip to Run with construction guide)
 2. Present the mechanism-specific build path (only the steps that apply)
 3. Research integration availability via web search (deferred from Design)
 4. Generate platform artifacts (prompts, skills, agents, configs) — following agentskills.io format for skills and Claude Code subagent format for agents
 5. Write SOP to Notion (if available)
 
-**Reads:** `outputs/[name]-building-block-spec.md`
+**Reads:** `outputs/[name]-design-spec.md`
 **Produces:** Platform artifacts — prompts, skills, agents, configs (if model-built)
 
 After Build is complete, tell the user you're moving to Step 5 and proceed automatically.
@@ -92,7 +92,7 @@ After Build is complete, tell the user you're moving to Step 5 and proceed autom
 **Skill:** `test`
 
 Guide structured testing of the built workflow artifacts:
-1. Load the Building Block Spec (including Evaluation Criteria) and the built artifacts
+1. Load the Design Spec (including Evaluation Criteria) and the built artifacts
 2. Run a quick smoke test — one representative input, manual check
 3. Execute each test scenario from the Evaluation Criteria, scoring output on each dimension (1–5 scale)
 4. Test individual building blocks (skills, prompts) in isolation
@@ -100,7 +100,7 @@ Guide structured testing of the built workflow artifacts:
 6. Diagnose issues — map each problem to the specific building block to adjust
 7. Readiness decision — Ready (proceed to Step 6) or Not Ready (loop back to Step 4 with specific adjustments)
 
-**Reads:** `outputs/[name]-building-block-spec.md` + platform artifacts
+**Reads:** `outputs/[name]-design-spec.md` + platform artifacts
 **Produces:** `outputs/[name]-test-results.md`
 
 If ready, tell the user you're moving to Step 6 and proceed automatically. If not ready, return to Step 4 with the diagnosed issues.
@@ -112,7 +112,7 @@ Generate the Run Guide — two variants based on build path choice:
 - Model-built: setup instructions, first run, next steps
 - Manual build: construction guide with build sequence, format guidance, first run, next steps
 
-**Reads:** `outputs/[name]-building-block-spec.md` + platform artifacts + `outputs/[name]-test-results.md`
+**Reads:** `outputs/[name]-design-spec.md` + platform artifacts + `outputs/[name]-test-results.md`
 **Produces:** `outputs/[name]-run-guide.md`
 
 ### Step 7 — Improve
@@ -120,7 +120,7 @@ Generate the Run Guide — two variants based on build path choice:
 
 Evaluate a running workflow for quality, relevance, and evolution opportunities. This step is typically invoked in a separate session — weeks or months after initial deployment — not as part of the initial build flow.
 
-1. Load the Building Block Spec, Run Guide, and original Test Results (baseline scores)
+1. Load the Design Spec, Run Guide, and original Test Results (baseline scores)
 2. Interview the user about current performance and changing requirements
 3. Identify quality signals (increasing edits, new decision types, skipped steps)
 4. Assess whether the orchestration mechanism should graduate
@@ -128,7 +128,7 @@ Evaluate a running workflow for quality, relevance, and evolution opportunities.
 6. Review operationalization (for organizational workflows)
 7. Recommend: No changes / Tune / Redesign / Evolve
 
-**Reads:** `outputs/[name]-building-block-spec.md` + `outputs/[name]-run-guide.md` + `outputs/[name]-test-results.md`
+**Reads:** `outputs/[name]-design-spec.md` + `outputs/[name]-run-guide.md` + `outputs/[name]-test-results.md`
 **Produces:** `outputs/[name]-improvement-plan.md`
 
 ### Post-Build — Registry & SOP (if Notion available)
@@ -172,7 +172,7 @@ After Steps 1–6 are complete, present a summary:
 >
 > **Step 3 — Design:**
 >
-> 3. **AI Building Block Spec** — `outputs/[name]-building-block-spec.md`
+> 3. **Design Spec** — `outputs/[name]-design-spec.md`
 >
 > **Step 4 — Build:**
 >

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: build
 description: >
-  This skill should be used when the user has an approved AI Building Block Spec and wants to
+  This skill should be used when the user has an approved Design Spec and wants to
   build platform artifacts for their AI workflow. It offers a build path choice, researches
   integration availability, generates platform-appropriate artifacts (prompts, skills, agents, configs),
   This is Step 4 (Build) of the AI Workflow Framework.
@@ -10,7 +10,7 @@ user-invocable: true
 
 # Workflow Build
 
-Take an approved AI Building Block Spec and generate platform-appropriate artifacts: prompts, skills, agents, configs, and connectors.
+Take an approved Design Spec and generate platform-appropriate artifacts: prompts, skills, agents, configs, and connectors.
 
 **Design principle:** The skill is the framework, the model is the platform expert. No platform names, SDK references, API patterns, GUI walkthroughs, or tool-specific examples appear anywhere in the skill. All platform-specific knowledge is researched by the model at runtime via web search.
 
@@ -18,11 +18,11 @@ Take an approved AI Building Block Spec and generate platform-appropriate artifa
 
 ## Workflow
 
-Artifact generation begins only after the AI Building Block Spec has been approved in the Design phase.
+Artifact generation begins only after the Design Spec has been approved in the Design phase.
 
-#### Step 1 — Load Building Block Spec
+#### Step 1 — Load Design Spec
 
-Read the AI Building Block Spec from `outputs/[workflow-name]-building-block-spec.md`. If the user specifies a file path, use that. Otherwise, look for the most recent Building Block Spec in `outputs/`.
+Read the Design Spec from `outputs/[workflow-name]-design-spec.md`. If the user specifies a file path, use that. Otherwise, look for the most recent Design Spec in `outputs/`.
 
 Confirm you've loaded the spec by summarizing: workflow name, orchestration mechanism, involvement mode, number of steps, number of skill candidates, and number of agents.
 
@@ -84,7 +84,7 @@ After presenting the mechanism-specific build path, proceed to Step 3.5 to disco
 
 Before generating artifacts, discover what creation tools are available in this session. Skills are an open standard — they live in platform-specific directories but follow the same SKILL.md format everywhere.
 
-1. **Extract building block types** from the loaded Building Block Spec — list each type and count (e.g., "3 skills, 1 agent, 1 MCP server config").
+1. **Extract building block types** from the loaded Design Spec — list each type and count (e.g., "3 skills, 1 agent, 1 MCP server config").
 
 2. **Discover available creation skills** using two tiers:
 
@@ -148,7 +148,7 @@ Before generating artifacts, resolve platform-specific format requirements and i
 
 **Tier 2 — Integration Doc Resolver**
 
-For each integration listed in the Building Block Spec's "Integration Options" section, resolve platform-specific integration documentation:
+For each integration listed in the Design Spec's "Integration Options" section, resolve platform-specific integration documentation:
 
 1. **Read `integration-registries`** from the cached registry JSON. This section catalogs known sources for integration documentation (e.g., MCP registry, platform marketplaces, connector catalogs).
 
@@ -172,7 +172,7 @@ Before generating artifacts:
 
 #### Step 5 — Integration Research
 
-Read the "Integration Options" section from the loaded Building Block Spec. This section already identifies each integration, its category (built-in, available with setup, possible with code, manual), and source URLs discovered during the Design phase.
+Read the "Integration Options" section from the loaded Design Spec. This section already identifies each integration, its category (built-in, available with setup, possible with code, manual), and source URLs discovered during the Design phase.
 
 **Use the carried-forward URLs as starting points.** The Design phase's Integration Discovery already answered "what's available?" — the focus here is "how do I connect it on the user's platform?"
 
@@ -216,10 +216,10 @@ If playbook platform guides are available locally (e.g., `docs/platforms/claude/
   **If a creation skill was matched for this block type:**
 
   1. Invoke it via the Skill tool, passing:
-     - The building block's full spec from the Building Block Spec (name, purpose, inputs, outputs, decision logic, failure modes, which workflow steps it covers)
+     - The building block's full spec from the Design Spec (name, purpose, inputs, outputs, decision logic, failure modes, which workflow steps it covers)
      - The artifact format requirements resolved in Step 3.6 (or the fallback reference if Step 3.6 did not resolve a format)
      - Whether platform-specific extensions should be applied (based on Architecture Decisions)
-     - This context: "This building block spec comes from an approved AI Building Block Spec (AI Workflow Framework, Step 3 Design). The intent, inputs, outputs, decision logic, and failure modes are already defined. Use this as your starting context."
+     - This context: "This building block comes from an approved Design Spec (AI Workflow Framework, Step 3 Design). The intent, inputs, outputs, decision logic, and failure modes are already defined. Use this as your starting context."
   2. Let the creation skill run its full workflow. Do not skip or abbreviate any stage.
   3. After completion, move to the next building block. Later blocks may reference earlier ones.
 
@@ -237,11 +237,11 @@ After completing Build, tell the user: "To test the workflow, run the `test` ski
 
 ### Platform Artifacts
 
-Prompts, skills, agents, orchestration configs, and connector setups in whatever format is appropriate to the user's chosen platform. Generated by the model based on the Building Block Spec and Architecture Decisions. For code-mode platforms, these are source files; for guided-mode platforms, these are step-by-step GUI instruction documents. For building blocks with a matched creation skill (discovered at runtime in Step 3.5), artifacts are built by delegating to that skill's full workflow. For building blocks without a matched creation skill, artifacts are generated inline using the format resolved from the platform registry in Step 3.6 (falling back to `references/skill-spec.md` for skills, `references/agent-spec.md` for Claude Code agents, or web search for other platforms).
+Prompts, skills, agents, orchestration configs, and connector setups in whatever format is appropriate to the user's chosen platform. Generated by the model based on the Design Spec and Architecture Decisions. For code-mode platforms, these are source files; for guided-mode platforms, these are step-by-step GUI instruction documents. For building blocks with a matched creation skill (discovered at runtime in Step 3.5), artifacts are built by delegating to that skill's full workflow. For building blocks without a matched creation skill, artifacts are generated inline using the format resolved from the platform registry in Step 3.6 (falling back to `references/skill-spec.md` for skills, `references/agent-spec.md` for Claude Code agents, or web search for other platforms).
 
 ## Guidelines
 
 - Use plain language; avoid jargon unless the user introduced it
 - After generating platform artifacts, summarize what was produced and where each artifact was saved
-- Do not start Build without a loaded and approved Building Block Spec
+- Do not start Build without a loaded and approved Design Spec
 - Web search is required for integration research and platform documentation verification

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -4,7 +4,7 @@ description: >
   This skill should be used when the user has a Workflow Definition and wants to design
   an AI workflow. It gathers architecture decisions, assesses workflow autonomy level,
   chooses an orchestration mechanism and involvement mode, classifies steps, maps building blocks,
-  identifies skill candidates, configures agents, and produces a Building Block Spec for approval.
+  identifies skill candidates, configures agents, and produces a Design Spec for approval.
   Supports both step-decomposed and outcome-driven Workflow Definitions.
   This is Step 3 (Design) of the AI Workflow Framework.
 user-invocable: true
@@ -12,7 +12,7 @@ user-invocable: true
 
 # Workflow Design
 
-Take a Workflow Definition and produce the Design deliverable: an AI Building Block Spec that captures architecture decisions, autonomy assessment, orchestration mechanism, per-step classifications (step-decomposed) or capability domain mapping (outcome-driven), skill candidates, and agent blueprints.
+Take a Workflow Definition and produce the Design deliverable: a Design Spec that captures architecture decisions, autonomy assessment, orchestration mechanism, per-step classifications (step-decomposed) or capability domain mapping (outcome-driven), skill candidates, and agent blueprints.
 
 **Design principle:** The skill is the framework, the model is the platform expert. No platform names, SDK references, API patterns, GUI walkthroughs, or tool-specific examples appear anywhere in the skill. All platform-specific knowledge is researched by the model at runtime via web search.
 
@@ -405,9 +405,9 @@ Then ask only the supplementary questions not already covered:
 - If test scenarios are missing: "Give me 3-5 real or realistic scenarios you'd run this on."
 - If minimum bar is missing: "What's your minimum bar? What quality level is acceptable vs. needs more work?"
 
-#### Step 9 — Generate AI Building Block Spec
+#### Step 9 — Generate Design Spec
 
-Write to `outputs/[workflow-name]-building-block-spec.md` using the template below. Every section is mandatory unless marked (optional). Do not add, remove, rename, or reorder sections.
+Write to `outputs/[workflow-name]-design-spec.md` using the template below. Every section is mandatory unless marked (optional). Do not add, remove, rename, or reorder sections.
 
 **Before writing, run the Build Skill Needs Checklist** (at the end of this step) to verify all required data has been captured.
 
@@ -416,7 +416,7 @@ Write to `outputs/[workflow-name]-building-block-spec.md` using the template bel
 **Template:**
 
 ```markdown
-# [Workflow Name] — AI Building Block Spec
+# [Workflow Name] — Design Spec
 
 ## Execution Pattern
 
@@ -615,9 +615,9 @@ Before saving the spec, verify every item. If any is missing, go back and add it
 
 **This is a hard gate. Do not proceed without explicit approval.**
 
-Present a summary of the Building Block Spec:
+Present a summary of the Design Spec:
 
-> "Here's the Building Block Spec summary:
+> "Here's the Design Spec summary:
 >
 > - **Autonomy:** [level] (for outcome-driven: Autonomous)
 > - **Mechanism:** [orchestration mechanism] ([involvement mode])
@@ -625,7 +625,7 @@ Present a summary of the Building Block Spec:
 > - **Integration options:** [count] tools with recommended integration approaches
 > - **Implementation order:** [brief summary]
 >
-> The full spec is saved to `outputs/[workflow-name]-building-block-spec.md`.
+> The full spec is saved to `outputs/[workflow-name]-design-spec.md`.
 >
 > **Do you approve this spec?** I won't generate any artifacts until you confirm. If you want changes, tell me what to adjust and I'll revise."
 
@@ -635,7 +635,7 @@ After the user approves, instruct them to **exit plan mode** if they entered it 
 
 > "Spec approved. **Exit plan mode now** (in Claude Code: `shift+tab` or `/plan`) so artifacts can be generated in the Build phase."
 >
-> "To build the workflow, run the `build` skill (Step 4) (or say *'Build the workflow from my Building Block Spec'*)."
+> "To build the workflow, run the `build` skill (Step 4) (or say *'Build the workflow from my Design Spec'*)."
 
 ### Outcome-Driven Processing Path
 
@@ -699,7 +699,7 @@ All other spec sections remain the same, except **Step Sequence and Dependencies
 
 ## Outputs
 
-### `outputs/[workflow-name]-building-block-spec.md` — AI Building Block Spec
+### `outputs/[workflow-name]-design-spec.md` — Design Spec
 
 Uses the mandatory template defined in Step 9. For step-decomposed definitions: Execution Pattern, Architecture Decisions, Scenario Summary, Step-by-Step Decomposition (with separate Orchestration/Integration/Intelligence columns), Autonomy Spectrum Summary, Skill Candidates (8 fields each), Agent Configuration (optional, with Skills and Trigger Examples), Step Sequence and Dependencies, Prerequisites, Context Inventory (with Location column), Data Readiness Summary, Integration Options (with Source URLs), Model Recommendation, Recommended Implementation Order, Where to Run, Evaluation Criteria (with test scenarios), Stakeholders (optional).
 
@@ -708,7 +708,7 @@ For outcome-driven definitions: Execution Pattern, Architecture Decisions, Scena
 ## Guidelines
 
 - Use plain language; avoid jargon unless the user introduced it
-- After writing the spec, tell the user: "AI Building Block Spec saved to `outputs/[name]-building-block-spec.md`."
+- After writing the spec, tell the user: "Design Spec saved to `outputs/[name]-design-spec.md`."
 - Do not proceed past the Spec Approval Gate (Step 10) without explicit user approval
 - Do not research integration availability — that happens in the Build phase
 - Do not generate platform artifacts — that happens in the Build phase

--- a/.claude/skills/improve/SKILL.md
+++ b/.claude/skills/improve/SKILL.md
@@ -16,7 +16,7 @@ Evaluate and evolve running AI workflows. Review how a deployed workflow is perf
 
 ### 1. Load workflow context
 
-Read the Building Block Spec (including Evaluation Criteria), Run Guide, and original Test Results (baseline scores). Understand what was built, how it was designed to work, and what quality bar was established.
+Read the Design Spec (including Evaluation Criteria), Run Guide, and original Test Results (baseline scores). Understand what was built, how it was designed to work, and what quality bar was established.
 
 ### 2. Current state assessment
 

--- a/.claude/skills/run/SKILL.md
+++ b/.claude/skills/run/SKILL.md
@@ -22,11 +22,11 @@ Generate a Run Guide for deploying, executing, and testing an AI workflow. The R
 
 Determine which build path the user followed:
 
-- **Path 1 (Model-built):** The model generated platform artifacts during the Build phase. Look for generated artifacts in the working directory and load the Building Block Spec from `outputs/[workflow-name]-building-block-spec.md`.
-- **Path 2 (Manual build):** The user chose to build artifacts themselves using the spec as a guide. Load the Building Block Spec from `outputs/[workflow-name]-building-block-spec.md`.
-- **Path 3 (Guided-mode):** The model generated GUI instruction documents during the Build phase (for guided-mode platforms like Copilot Studio, Workspace Studio, ChatGPT Agent Mode). The `mode` field in the Building Block Spec indicates `guided`.
+- **Path 1 (Model-built):** The model generated platform artifacts during the Build phase. Look for generated artifacts in the working directory and load the Design Spec from `outputs/[workflow-name]-design-spec.md`.
+- **Path 2 (Manual build):** The user chose to build artifacts themselves using the spec as a guide. Load the Design Spec from `outputs/[workflow-name]-design-spec.md`.
+- **Path 3 (Guided-mode):** The model generated GUI instruction documents during the Build phase (for guided-mode platforms like Copilot Studio, Workspace Studio, ChatGPT Agent Mode). The `mode` field in the Design Spec indicates `guided`.
 
-If the user specifies a file path, use that. Otherwise, look for the most recent Building Block Spec in `outputs/` and check conversation context for which path was chosen.
+If the user specifies a file path, use that. Otherwise, look for the most recent Design Spec in `outputs/` and check conversation context for which path was chosen.
 
 If unclear, ask: "Did the model generate your workflow artifacts (Path 1), are you building them yourself from the spec (Path 2), or did the model produce GUI instruction documents for a guided-mode platform (Path 3)?"
 

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -13,7 +13,7 @@ Structured testing and evaluation of AI workflow artifacts. Walk the user throug
 
 ### 1. Load context
 
-Read the Building Block Spec (including Evaluation Criteria) to understand what was built, expected behavior, and how to evaluate. Identify the test scenarios and scoring dimensions defined during Design.
+Read the Design Spec (including Evaluation Criteria) to understand what was built, expected behavior, and how to evaluate. Identify the test scenarios and scoring dimensions defined during Design.
 
 ### 2. Quick smoke test
 

--- a/examples/content-calendar-planning/design-spec.md
+++ b/examples/content-calendar-planning/design-spec.md
@@ -1,4 +1,4 @@
-# Content Calendar Planning — AI Building Block Spec
+# Content Calendar Planning — Design Spec
 
 ## Execution Pattern
 

--- a/plugins/handsonai/.claude-plugin/plugin.json
+++ b/plugins/handsonai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "handsonai",
   "description": "Everything you need to design, build, and document AI workflows. The AI Workflow Framework as executable Claude Code skills, plus an AI registry and feature-spec toolkit.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": {
     "name": "James Gray"
   },

--- a/plugins/handsonai/README.md
+++ b/plugins/handsonai/README.md
@@ -25,7 +25,7 @@ The AI Workflow Framework as executable Claude Code skills, plus an AI registry 
 |-------|-------------|
 | `analyze` | Audit your workflows to find where AI creates the most value |
 | `deconstruct` | Break a workflow into structured steps using the 6-question framework |
-| `design` | Design the AI workflow architecture and produce an AI Building Block Spec |
+| `design` | Design the AI workflow architecture and produce a Design Spec |
 | `build` | Generate platform-appropriate artifacts from the approved spec |
 | `test` | Test workflow artifacts and evaluate output quality |
 | `run` | Generate a Run Guide for deploying and operating the workflow |

--- a/plugins/handsonai/agents/framework-agent.md
+++ b/plugins/handsonai/agents/framework-agent.md
@@ -25,7 +25,7 @@ You run seven skills sequentially, using files as handoffs between stages. Steps
 |------|-------|-------|--------|---------|
 | 1 (Analyze) | `analyze` | User interview | `ai-opportunity-report.md` | User picks candidate |
 | 2 (Deconstruct) | `deconstruct` | Candidate + interview | `[name]-definition.md` | Auto→Step 3 |
-| 3 (Design) | `design` | Workflow Definition | `[name]-building-block-spec.md` | Explicit approval gate |
+| 3 (Design) | `design` | Workflow Definition | `[name]-design-spec.md` | Explicit approval gate |
 | 4 (Build) | `build` | Approved spec | Platform artifacts | Auto→Step 5 |
 | 5 (Test) | `test` | Artifacts + spec | `[name]-test-results.md` | Ready OR loop to Build |
 | 6 (Run) | `run` | Tested artifacts + spec | `[name]-run-guide.md` | User follows guide |
@@ -65,25 +65,25 @@ Read the Workflow Definition and run the Design phase:
 6. Identify skill candidates with generation-ready detail
 7. Configure agents (when the mechanism calls for them)
 8. Define Evaluation Criteria — test scenarios and scoring dimensions for Step 5
-9. Generate the AI Building Block Spec (with "Integration Research Needed" section — availability research is deferred to Build)
+9. Generate the Design Spec (with "Integration Research Needed" section — availability research is deferred to Build)
 10. **Spec Approval Gate** — present the spec for explicit user approval. Do NOT proceed to Build without approval. Loop if changes are requested. After approval, prompt the user to exit plan mode.
 
 **Reads:** `outputs/[name]-definition.md`
-**Produces:** `outputs/[name]-building-block-spec.md`
+**Produces:** `outputs/[name]-design-spec.md`
 
 After the spec is approved, tell the user you're moving to Step 4 and proceed automatically.
 
 ### Step 4 — Build
 **Skill:** `build`
 
-Read the approved AI Building Block Spec and generate platform artifacts:
+Read the approved Design Spec and generate platform artifacts:
 1. **Build path choice** — offer "I'll build it" (model generates artifacts) or "I'll build it myself" (spec is the deliverable, skip to Run with construction guide)
 2. Present the mechanism-specific build path (only the steps that apply)
 3. Research integration availability via web search (deferred from Design)
 4. Generate platform artifacts (prompts, skills, agents, configs) — following agentskills.io format for skills and Claude Code subagent format for agents
 5. Write SOP to Notion (if available)
 
-**Reads:** `outputs/[name]-building-block-spec.md`
+**Reads:** `outputs/[name]-design-spec.md`
 **Produces:** Platform artifacts — prompts, skills, agents, configs (if model-built)
 
 After Build is complete, tell the user you're moving to Step 5 and proceed automatically.
@@ -92,7 +92,7 @@ After Build is complete, tell the user you're moving to Step 5 and proceed autom
 **Skill:** `test`
 
 Guide structured testing of the built workflow artifacts:
-1. Load the Building Block Spec (including Evaluation Criteria) and the built artifacts
+1. Load the Design Spec (including Evaluation Criteria) and the built artifacts
 2. Run a quick smoke test — one representative input, manual check
 3. Execute each test scenario from the Evaluation Criteria, scoring output on each dimension (1–5 scale)
 4. Test individual building blocks (skills, prompts) in isolation
@@ -100,7 +100,7 @@ Guide structured testing of the built workflow artifacts:
 6. Diagnose issues — map each problem to the specific building block to adjust
 7. Readiness decision — Ready (proceed to Step 6) or Not Ready (loop back to Step 4 with specific adjustments)
 
-**Reads:** `outputs/[name]-building-block-spec.md` + platform artifacts
+**Reads:** `outputs/[name]-design-spec.md` + platform artifacts
 **Produces:** `outputs/[name]-test-results.md`
 
 If ready, tell the user you're moving to Step 6 and proceed automatically. If not ready, return to Step 4 with the diagnosed issues.
@@ -112,7 +112,7 @@ Generate the Run Guide — two variants based on build path choice:
 - Model-built: setup instructions, first run, next steps
 - Manual build: construction guide with build sequence, format guidance, first run, next steps
 
-**Reads:** `outputs/[name]-building-block-spec.md` + platform artifacts + `outputs/[name]-test-results.md`
+**Reads:** `outputs/[name]-design-spec.md` + platform artifacts + `outputs/[name]-test-results.md`
 **Produces:** `outputs/[name]-run-guide.md`
 
 ### Step 7 — Improve
@@ -120,7 +120,7 @@ Generate the Run Guide — two variants based on build path choice:
 
 Evaluate a running workflow for quality, relevance, and evolution opportunities. This step is typically invoked in a separate session — weeks or months after initial deployment — not as part of the initial build flow.
 
-1. Load the Building Block Spec, Run Guide, and original Test Results (baseline scores)
+1. Load the Design Spec, Run Guide, and original Test Results (baseline scores)
 2. Interview the user about current performance and changing requirements
 3. Identify quality signals (increasing edits, new decision types, skipped steps)
 4. Assess whether the orchestration mechanism should graduate
@@ -128,7 +128,7 @@ Evaluate a running workflow for quality, relevance, and evolution opportunities.
 6. Review operationalization (for organizational workflows)
 7. Recommend: No changes / Tune / Redesign / Evolve
 
-**Reads:** `outputs/[name]-building-block-spec.md` + `outputs/[name]-run-guide.md` + `outputs/[name]-test-results.md`
+**Reads:** `outputs/[name]-design-spec.md` + `outputs/[name]-run-guide.md` + `outputs/[name]-test-results.md`
 **Produces:** `outputs/[name]-improvement-plan.md`
 
 ### Post-Build — Registry & SOP (if Notion available)
@@ -172,7 +172,7 @@ After Steps 1–6 are complete, present a summary:
 >
 > **Step 3 — Design:**
 >
-> 3. **AI Building Block Spec** — `outputs/[name]-building-block-spec.md`
+> 3. **Design Spec** — `outputs/[name]-design-spec.md`
 >
 > **Step 4 — Build:**
 >

--- a/plugins/handsonai/skills/build/SKILL.md
+++ b/plugins/handsonai/skills/build/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: build
 description: >
-  This skill should be used when the user has an approved AI Building Block Spec and wants to
+  This skill should be used when the user has an approved Design Spec and wants to
   build platform artifacts for their AI workflow. It offers a build path choice, researches
   integration availability, generates platform-appropriate artifacts (prompts, skills, agents, configs),
   This is Step 4 (Build) of the AI Workflow Framework.
@@ -10,7 +10,7 @@ user-invocable: true
 
 # Workflow Build
 
-Take an approved AI Building Block Spec and generate platform-appropriate artifacts: prompts, skills, agents, configs, and connectors.
+Take an approved Design Spec and generate platform-appropriate artifacts: prompts, skills, agents, configs, and connectors.
 
 **Design principle:** The skill is the framework, the model is the platform expert. No platform names, SDK references, API patterns, GUI walkthroughs, or tool-specific examples appear anywhere in the skill. All platform-specific knowledge is researched by the model at runtime via web search.
 
@@ -18,11 +18,11 @@ Take an approved AI Building Block Spec and generate platform-appropriate artifa
 
 ## Workflow
 
-Artifact generation begins only after the AI Building Block Spec has been approved in the Design phase.
+Artifact generation begins only after the Design Spec has been approved in the Design phase.
 
-#### Step 1 — Load Building Block Spec
+#### Step 1 — Load Design Spec
 
-Read the AI Building Block Spec from `outputs/[workflow-name]-building-block-spec.md`. If the user specifies a file path, use that. Otherwise, look for the most recent Building Block Spec in `outputs/`.
+Read the Design Spec from `outputs/[workflow-name]-design-spec.md`. If the user specifies a file path, use that. Otherwise, look for the most recent Design Spec in `outputs/`.
 
 Confirm you've loaded the spec by summarizing: workflow name, orchestration mechanism, involvement mode, number of steps, number of skill candidates, and number of agents.
 
@@ -84,7 +84,7 @@ After presenting the mechanism-specific build path, proceed to Step 3.5 to disco
 
 Before generating artifacts, discover what creation tools are available in this session. Skills are an open standard — they live in platform-specific directories but follow the same SKILL.md format everywhere.
 
-1. **Extract building block types** from the loaded Building Block Spec — list each type and count (e.g., "3 skills, 1 agent, 1 MCP server config").
+1. **Extract building block types** from the loaded Design Spec — list each type and count (e.g., "3 skills, 1 agent, 1 MCP server config").
 
 2. **Discover available creation skills** using two tiers:
 
@@ -148,7 +148,7 @@ Before generating artifacts, resolve platform-specific format requirements and i
 
 **Tier 2 — Integration Doc Resolver**
 
-For each integration listed in the Building Block Spec's "Integration Options" section, resolve platform-specific integration documentation:
+For each integration listed in the Design Spec's "Integration Options" section, resolve platform-specific integration documentation:
 
 1. **Read `integration-registries`** from the cached registry JSON. This section catalogs known sources for integration documentation (e.g., MCP registry, platform marketplaces, connector catalogs).
 
@@ -172,7 +172,7 @@ Before generating artifacts:
 
 #### Step 5 — Integration Research
 
-Read the "Integration Options" section from the loaded Building Block Spec. This section already identifies each integration, its category (built-in, available with setup, possible with code, manual), and source URLs discovered during the Design phase.
+Read the "Integration Options" section from the loaded Design Spec. This section already identifies each integration, its category (built-in, available with setup, possible with code, manual), and source URLs discovered during the Design phase.
 
 **Use the carried-forward URLs as starting points.** The Design phase's Integration Discovery already answered "what's available?" — the focus here is "how do I connect it on the user's platform?"
 
@@ -216,10 +216,10 @@ If playbook platform guides are available locally (e.g., `docs/platforms/claude/
   **If a creation skill was matched for this block type:**
 
   1. Invoke it via the Skill tool, passing:
-     - The building block's full spec from the Building Block Spec (name, purpose, inputs, outputs, decision logic, failure modes, which workflow steps it covers)
+     - The building block's full spec from the Design Spec (name, purpose, inputs, outputs, decision logic, failure modes, which workflow steps it covers)
      - The artifact format requirements resolved in Step 3.6 (or the fallback reference if Step 3.6 did not resolve a format)
      - Whether platform-specific extensions should be applied (based on Architecture Decisions)
-     - This context: "This building block spec comes from an approved AI Building Block Spec (AI Workflow Framework, Step 3 Design). The intent, inputs, outputs, decision logic, and failure modes are already defined. Use this as your starting context."
+     - This context: "This building block comes from an approved Design Spec (AI Workflow Framework, Step 3 Design). The intent, inputs, outputs, decision logic, and failure modes are already defined. Use this as your starting context."
   2. Let the creation skill run its full workflow. Do not skip or abbreviate any stage.
   3. After completion, move to the next building block. Later blocks may reference earlier ones.
 
@@ -237,11 +237,11 @@ After completing Build, tell the user: "To test the workflow, run the `test` ski
 
 ### Platform Artifacts
 
-Prompts, skills, agents, orchestration configs, and connector setups in whatever format is appropriate to the user's chosen platform. Generated by the model based on the Building Block Spec and Architecture Decisions. For code-mode platforms, these are source files; for guided-mode platforms, these are step-by-step GUI instruction documents. For building blocks with a matched creation skill (discovered at runtime in Step 3.5), artifacts are built by delegating to that skill's full workflow. For building blocks without a matched creation skill, artifacts are generated inline using the format resolved from the platform registry in Step 3.6 (falling back to `references/skill-spec.md` for skills, `references/agent-spec.md` for Claude Code agents, or web search for other platforms).
+Prompts, skills, agents, orchestration configs, and connector setups in whatever format is appropriate to the user's chosen platform. Generated by the model based on the Design Spec and Architecture Decisions. For code-mode platforms, these are source files; for guided-mode platforms, these are step-by-step GUI instruction documents. For building blocks with a matched creation skill (discovered at runtime in Step 3.5), artifacts are built by delegating to that skill's full workflow. For building blocks without a matched creation skill, artifacts are generated inline using the format resolved from the platform registry in Step 3.6 (falling back to `references/skill-spec.md` for skills, `references/agent-spec.md` for Claude Code agents, or web search for other platforms).
 
 ## Guidelines
 
 - Use plain language; avoid jargon unless the user introduced it
 - After generating platform artifacts, summarize what was produced and where each artifact was saved
-- Do not start Build without a loaded and approved Building Block Spec
+- Do not start Build without a loaded and approved Design Spec
 - Web search is required for integration research and platform documentation verification

--- a/plugins/handsonai/skills/design/SKILL.md
+++ b/plugins/handsonai/skills/design/SKILL.md
@@ -4,7 +4,7 @@ description: >
   This skill should be used when the user has a Workflow Definition and wants to design
   an AI workflow. It gathers architecture decisions, assesses workflow autonomy level,
   chooses an orchestration mechanism and involvement mode, classifies steps, maps building blocks,
-  identifies skill candidates, configures agents, and produces a Building Block Spec for approval.
+  identifies skill candidates, configures agents, and produces a Design Spec for approval.
   Supports both step-decomposed and outcome-driven Workflow Definitions.
   This is Step 3 (Design) of the AI Workflow Framework.
 user-invocable: true
@@ -12,7 +12,7 @@ user-invocable: true
 
 # Workflow Design
 
-Take a Workflow Definition and produce the Design deliverable: an AI Building Block Spec that captures architecture decisions, autonomy assessment, orchestration mechanism, per-step classifications (step-decomposed) or capability domain mapping (outcome-driven), skill candidates, and agent blueprints.
+Take a Workflow Definition and produce the Design deliverable: a Design Spec that captures architecture decisions, autonomy assessment, orchestration mechanism, per-step classifications (step-decomposed) or capability domain mapping (outcome-driven), skill candidates, and agent blueprints.
 
 **Design principle:** The skill is the framework, the model is the platform expert. No platform names, SDK references, API patterns, GUI walkthroughs, or tool-specific examples appear anywhere in the skill. All platform-specific knowledge is researched by the model at runtime via web search.
 
@@ -405,9 +405,9 @@ Then ask only the supplementary questions not already covered:
 - If test scenarios are missing: "Give me 3-5 real or realistic scenarios you'd run this on."
 - If minimum bar is missing: "What's your minimum bar? What quality level is acceptable vs. needs more work?"
 
-#### Step 9 — Generate AI Building Block Spec
+#### Step 9 — Generate Design Spec
 
-Write to `outputs/[workflow-name]-building-block-spec.md` using the template below. Every section is mandatory unless marked (optional). Do not add, remove, rename, or reorder sections.
+Write to `outputs/[workflow-name]-design-spec.md` using the template below. Every section is mandatory unless marked (optional). Do not add, remove, rename, or reorder sections.
 
 **Before writing, run the Build Skill Needs Checklist** (at the end of this step) to verify all required data has been captured.
 
@@ -416,7 +416,7 @@ Write to `outputs/[workflow-name]-building-block-spec.md` using the template bel
 **Template:**
 
 ```markdown
-# [Workflow Name] — AI Building Block Spec
+# [Workflow Name] — Design Spec
 
 ## Execution Pattern
 
@@ -615,9 +615,9 @@ Before saving the spec, verify every item. If any is missing, go back and add it
 
 **This is a hard gate. Do not proceed without explicit approval.**
 
-Present a summary of the Building Block Spec:
+Present a summary of the Design Spec:
 
-> "Here's the Building Block Spec summary:
+> "Here's the Design Spec summary:
 >
 > - **Autonomy:** [level] (for outcome-driven: Autonomous)
 > - **Mechanism:** [orchestration mechanism] ([involvement mode])
@@ -625,7 +625,7 @@ Present a summary of the Building Block Spec:
 > - **Integration options:** [count] tools with recommended integration approaches
 > - **Implementation order:** [brief summary]
 >
-> The full spec is saved to `outputs/[workflow-name]-building-block-spec.md`.
+> The full spec is saved to `outputs/[workflow-name]-design-spec.md`.
 >
 > **Do you approve this spec?** I won't generate any artifacts until you confirm. If you want changes, tell me what to adjust and I'll revise."
 
@@ -635,7 +635,7 @@ After the user approves, instruct them to **exit plan mode** if they entered it 
 
 > "Spec approved. **Exit plan mode now** (in Claude Code: `shift+tab` or `/plan`) so artifacts can be generated in the Build phase."
 >
-> "To build the workflow, run the `build` skill (Step 4) (or say *'Build the workflow from my Building Block Spec'*)."
+> "To build the workflow, run the `build` skill (Step 4) (or say *'Build the workflow from my Design Spec'*)."
 
 ### Outcome-Driven Processing Path
 
@@ -699,7 +699,7 @@ All other spec sections remain the same, except **Step Sequence and Dependencies
 
 ## Outputs
 
-### `outputs/[workflow-name]-building-block-spec.md` — AI Building Block Spec
+### `outputs/[workflow-name]-design-spec.md` — Design Spec
 
 Uses the mandatory template defined in Step 9. For step-decomposed definitions: Execution Pattern, Architecture Decisions, Scenario Summary, Step-by-Step Decomposition (with separate Orchestration/Integration/Intelligence columns), Autonomy Spectrum Summary, Skill Candidates (8 fields each), Agent Configuration (optional, with Skills and Trigger Examples), Step Sequence and Dependencies, Prerequisites, Context Inventory (with Location column), Data Readiness Summary, Integration Options (with Source URLs), Model Recommendation, Recommended Implementation Order, Where to Run, Evaluation Criteria (with test scenarios), Stakeholders (optional).
 
@@ -708,7 +708,7 @@ For outcome-driven definitions: Execution Pattern, Architecture Decisions, Scena
 ## Guidelines
 
 - Use plain language; avoid jargon unless the user introduced it
-- After writing the spec, tell the user: "AI Building Block Spec saved to `outputs/[name]-building-block-spec.md`."
+- After writing the spec, tell the user: "Design Spec saved to `outputs/[name]-design-spec.md`."
 - Do not proceed past the Spec Approval Gate (Step 10) without explicit user approval
 - Do not research integration availability — that happens in the Build phase
 - Do not generate platform artifacts — that happens in the Build phase

--- a/plugins/handsonai/skills/improve/SKILL.md
+++ b/plugins/handsonai/skills/improve/SKILL.md
@@ -16,7 +16,7 @@ Evaluate and evolve running AI workflows. Review how a deployed workflow is perf
 
 ### 1. Load workflow context
 
-Read the Building Block Spec (including Evaluation Criteria), Run Guide, and original Test Results (baseline scores). Understand what was built, how it was designed to work, and what quality bar was established.
+Read the Design Spec (including Evaluation Criteria), Run Guide, and original Test Results (baseline scores). Understand what was built, how it was designed to work, and what quality bar was established.
 
 ### 2. Current state assessment
 

--- a/plugins/handsonai/skills/naming-workflows/SKILL.md
+++ b/plugins/handsonai/skills/naming-workflows/SKILL.md
@@ -207,7 +207,7 @@ When user provides a workflow description:
 | Apps | multi-select | Notion, Web Search, Gmail, Slack, GitHub, etc. |
 | SOP | url | Link to SOP markdown file (populated by `writing-workflow-sops`) |
 | Workflow Definition | url | Link to workflow definition markdown file (populated by framework Deconstruct phase) |
-| Building Block Spec | url | Link to building block spec markdown file (populated by framework Build phase) |
+| Design Spec | url | Link to Design Spec markdown file (populated by framework Design phase) |
 | Assets Used | relation | Link to Assets database (optional) |
 
 ### Business Processes Database

--- a/plugins/handsonai/skills/run/SKILL.md
+++ b/plugins/handsonai/skills/run/SKILL.md
@@ -22,11 +22,11 @@ Generate a Run Guide for deploying, executing, and testing an AI workflow. The R
 
 Determine which build path the user followed:
 
-- **Path 1 (Model-built):** The model generated platform artifacts during the Build phase. Look for generated artifacts in the working directory and load the Building Block Spec from `outputs/[workflow-name]-building-block-spec.md`.
-- **Path 2 (Manual build):** The user chose to build artifacts themselves using the spec as a guide. Load the Building Block Spec from `outputs/[workflow-name]-building-block-spec.md`.
-- **Path 3 (Guided-mode):** The model generated GUI instruction documents during the Build phase (for guided-mode platforms like Copilot Studio, Workspace Studio, ChatGPT Agent Mode). The `mode` field in the Building Block Spec indicates `guided`.
+- **Path 1 (Model-built):** The model generated platform artifacts during the Build phase. Look for generated artifacts in the working directory and load the Design Spec from `outputs/[workflow-name]-design-spec.md`.
+- **Path 2 (Manual build):** The user chose to build artifacts themselves using the spec as a guide. Load the Design Spec from `outputs/[workflow-name]-design-spec.md`.
+- **Path 3 (Guided-mode):** The model generated GUI instruction documents during the Build phase (for guided-mode platforms like Copilot Studio, Workspace Studio, ChatGPT Agent Mode). The `mode` field in the Design Spec indicates `guided`.
 
-If the user specifies a file path, use that. Otherwise, look for the most recent Building Block Spec in `outputs/` and check conversation context for which path was chosen.
+If the user specifies a file path, use that. Otherwise, look for the most recent Design Spec in `outputs/` and check conversation context for which path was chosen.
 
 If unclear, ask: "Did the model generate your workflow artifacts (Path 1), are you building them yourself from the spec (Path 2), or did the model produce GUI instruction documents for a guided-mode platform (Path 3)?"
 

--- a/plugins/handsonai/skills/test/SKILL.md
+++ b/plugins/handsonai/skills/test/SKILL.md
@@ -13,7 +13,7 @@ Structured testing and evaluation of AI workflow artifacts. Walk the user throug
 
 ### 1. Load context
 
-Read the Building Block Spec (including Evaluation Criteria) to understand what was built, expected behavior, and how to evaluate. Identify the test scenarios and scoring dimensions defined during Design.
+Read the Design Spec (including Evaluation Criteria) to understand what was built, expected behavior, and how to evaluate. Identify the test scenarios and scoring dimensions defined during Design.
 
 ### 2. Quick smoke test
 

--- a/plugins/handsonai/skills/writing-process-guides/SKILL.md
+++ b/plugins/handsonai/skills/writing-process-guides/SKILL.md
@@ -21,7 +21,7 @@ Write comprehensive Business Process Guide documentation and save as markdown fi
 ## Process
 
 1. **Load process context** — Determine how the user is arriving:
-   - **From framework artifacts** (primary path): Read the Workflow Definitions for each component workflow (`outputs/<name>-definition.md`). If Building Block Specs and SOPs exist, read those too for sequencing, autonomy levels, and cross-references.
+   - **From framework artifacts** (primary path): Read the Workflow Definitions for each component workflow (`outputs/<name>-definition.md`). If Design Specs and SOPs exist, read those too for sequencing, autonomy levels, and cross-references.
    - **From Notion or another tracker** (if available): Fetch the business process record and its linked workflows for supplementary metadata (name, domain, description, linked workflows).
    - **From conversation**: If no artifacts exist, gather process details interactively (name, component workflows, sequence, triggers).
 2. **Gather strategic context** from user — frequency, timing, decision points between workflows, success criteria
@@ -87,7 +87,7 @@ For Notion users with the AI Registry template: update the "Guide" URL property 
 ## Interaction Pattern
 
 ### From framework artifacts (primary path)
-1. Read Workflow Definitions (and SOPs/Building Block Specs if they exist) for each component workflow
+1. Read Workflow Definitions (and SOPs/Design Specs if they exist) for each component workflow
 2. Gather strategic context from user (frequency, timing, decision points)
 3. Draft Process Guide and present for review
 4. Write markdown file after user approval

--- a/plugins/handsonai/skills/writing-workflow-sops/SKILL.md
+++ b/plugins/handsonai/skills/writing-workflow-sops/SKILL.md
@@ -51,10 +51,10 @@ An agent can orchestrate at any autonomy level. An agent that runs a fixed scrip
 ## Process
 
 1. **Load workflow context** — Determine how the user is arriving:
-   - **From framework artifacts** (primary path): Read the Workflow Definition (`outputs/<name>-definition.md`) and Building Block Spec (`outputs/<name>-building-block-spec.md`). Extract name, description, trigger, type, execution mode, autonomy level, refined steps, skill candidates, agent config, and failure modes.
+   - **From framework artifacts** (primary path): Read the Workflow Definition (`outputs/<name>-definition.md`) and Design Spec (`outputs/<name>-design-spec.md`). Extract name, description, trigger, type, execution mode, autonomy level, refined steps, skill candidates, agent config, and failure modes.
    - **From Notion or another tracker** (if available): Fetch the workflow record for supplementary metadata (name, description, type, trigger, apps, assets used).
    - **From conversation**: If no artifacts exist, gather workflow details interactively (name, purpose, trigger, type, steps, etc.)
-2. **Classify on both axes** — Determine execution mode (augmented / automated / manual) and autonomy level (deterministic / guided / autonomous / n/a). If loaded from a Building Block Spec, these are already defined — confirm with user rather than re-assessing from scratch. Autonomy level determines full vs. lightweight SOP template.
+2. **Classify on both axes** — Determine execution mode (augmented / automated / manual) and autonomy level (deterministic / guided / autonomous / n/a). If loaded from a Design Spec, these are already defined — confirm with user rather than re-assessing from scratch. Autonomy level determines full vs. lightweight SOP template.
 3. **Gather any missing details** — Adapted to autonomy level: for deterministic, confirm procedure steps; for guided/autonomous, confirm human checkpoints and inputs/outputs
 4. **Write SOP** using the appropriate template adapted for workflow type. Set `execution_mode` and `autonomy_level` in frontmatter, and include the taxonomy pair in the relevant section:
    - **Full SOPs** → add `**Execution Model:** <Mode> + <Level>` as the first line of the Automation Notes section
@@ -132,7 +132,7 @@ For Notion users with the AI Registry template: update the "SOP" URL property on
 ## Interaction Pattern
 
 ### From framework artifacts (primary path)
-1. Read the Workflow Definition and Building Block Spec from the `outputs/` folder
+1. Read the Workflow Definition and Design Spec from the `outputs/` folder
 2. Confirm classification (execution mode + autonomy level) with user
 3. Fill any gaps not covered by the artifacts
 4. Draft SOP using the appropriate template and present for review

--- a/public/assets/courses/builders/competitive-intelligence-workflow-definition.md
+++ b/public/assets/courses/builders/competitive-intelligence-workflow-definition.md
@@ -176,4 +176,4 @@ Changes applied to a naive "search → write a brief" version:
 
 ---
 
-**Workflow Definition complete. Ready for Session 9's live Design step — turning this into a Building Block Spec.**
+**Workflow Definition complete. Ready for Session 9's live Design step — turning this into a Design Spec.**

--- a/src/content/docs/ai-workflow-framework/build/index.mdx
+++ b/src/content/docs/ai-workflow-framework/build/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Step 4: Build"
-description: Generate platform-appropriate artifacts from your approved AI Building Block Spec — resolve context needs, build mechanism-specific components, and prepare your workflow for testing.
+description: Generate platform-appropriate artifacts from your approved Design Spec — resolve context needs, build mechanism-specific components, and prepare your workflow for testing.
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
@@ -11,7 +11,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 You've just finished [Design (Step 3)](../design/). You should have:
 
-- **AI Building Block Spec** (`[name]-building-block-spec.md`) — your approved blueprint with architecture approach, autonomy level, orchestration mechanism, step classifications, skill candidates, agent blueprints, and implementation order
+- **Design Spec** (`[name]-design-spec.md`) — your approved blueprint with architecture approach, autonomy level, orchestration mechanism, step classifications, skill candidates, agent blueprints, and implementation order
 
 If you're returning from [Test (Step 5)](../test/) to fix issues, you may also have test results telling you which building block needs adjustment.
 
@@ -44,22 +44,22 @@ The orchestration mechanism determines which steps you follow. Work through **on
 <Tabs>
   <TabItem label="Prompt">
 
-1. **Create context** — Build the context artifacts listed in your Building Block Spec's Context Inventory
-2. **Set up project workspace** (optional) — If the Building Block Spec's Where to Run recommends a project
+1. **Create context** — Build the context artifacts listed in your Design Spec's Context Inventory
+2. **Set up project workspace** (optional) — If the Design Spec's Where to Run recommends a project
 3. **Generate platform artifacts** — The model generates the prompt and any configuration needed for your platform
   </TabItem>
   <TabItem label="Skill-Powered Prompt">
 
-1. **Create context** — Build the context artifacts listed in your Building Block Spec's Context Inventory
-2. **Set up project workspace** (optional) — If the Building Block Spec's Where to Run recommends a project
-3. **Build skills** — Build skills for the steps tagged as skill candidates in your Building Block Spec. The model generates skills in the format appropriate to your platform.
+1. **Create context** — Build the context artifacts listed in your Design Spec's Context Inventory
+2. **Set up project workspace** (optional) — If the Design Spec's Where to Run recommends a project
+3. **Build skills** — Build skills for the steps tagged as skill candidates in your Design Spec. The model generates skills in the format appropriate to your platform.
 4. **Generate platform artifacts** — The model generates the prompt and skill configurations for your platform
   </TabItem>
   <TabItem label="Agent">
 
-1. **Create context** — Build the context artifacts listed in your Building Block Spec's Context Inventory
+1. **Create context** — Build the context artifacts listed in your Design Spec's Context Inventory
 2. **Build skills** — Build skills for tagged candidates
-3. **Connect tools** — Wire external tools from the Tools and Connectors section of your Building Block Spec
+3. **Connect tools** — Wire external tools from the Tools and Connectors section of your Design Spec
 4. **Generate platform artifacts** — The model generates agent configs (single or multi-agent), skills, and connectors for your platform
   </TabItem>
 </Tabs>
@@ -77,7 +77,7 @@ The model doesn't guess your platform's artifact format or available integration
 
 **Integration research:**
 
-1. **Integration Options from Design** — The Building Block Spec already identifies which integrations you need and includes source URLs discovered during Design's Integration Discovery (which itself used the curated tool catalog, integration registries, and web search).
+1. **Integration Options from Design** — The Design Spec already identifies which integrations you need and includes source URLs discovered during Design's Integration Discovery (which itself used the curated tool catalog, integration registries, and web search).
 2. **Platform-specific setup** — For each integration, the model researches how to connect it on your specific platform: installation steps, configuration, authentication, and prerequisites.
 3. **Integration registries** — The platform registry catalogs known sources for integration documentation (MCP registries, platform marketplaces, connector catalogs). The model checks these before falling back to web search.
 
@@ -127,7 +127,7 @@ The [Builder Tools Setup](../../builder-setup/) guide walks you through everythi
 | Context artifacts | Style guides, reference materials, and examples — formatted for AI consumption |
 | Tool connections | MCP connections and integrations configured on your platform |
 
-The Building Block Spec from Design is the design document — it captures *what* to build and *why*. The platform artifacts from Build are the implementation — generated by the model using your architecture decisions and current platform knowledge.
+The Design Spec from Design is the design document — it captures *what* to build and *why*. The platform artifacts from Build are the implementation — generated by the model using your architecture decisions and current platform knowledge.
 
 Many workflows stay at the prompt-plus-context level permanently — pasted into a chat whenever you need it. That's a feature, not a limitation.
 
@@ -138,10 +138,10 @@ This step is facilitated by the **`build`** AI Workflow Framework skill. See [Se
 **Start with this prompt:**
 
 ```
-Build the workflow from my approved AI Building Block Spec.
+Build the workflow from my approved Design Spec.
 ```
 
-Upload or reference your Building Block Spec file (`[workflow-name]-building-block-spec.md`) from the Design step when prompted. The skill resolves context needs, generates platform artifacts, and prepares the workflow for testing.
+Upload or reference your Design Spec file (`[workflow-name]-design-spec.md`) from the Design step when prompted. The skill resolves context needs, generates platform artifacts, and prepares the workflow for testing.
 
 ## Next Step
 

--- a/src/content/docs/ai-workflow-framework/design.md
+++ b/src/content/docs/ai-workflow-framework/design.md
@@ -1,6 +1,6 @@
 ---
 title: Design Your AI Workflow
-description: Gather architecture decisions, assess workflow autonomy level, choose an orchestration mechanism and involvement mode, classify steps on the autonomy spectrum, map AI building blocks, identify skill candidates, and document agent blueprints — producing a platform-agnostic AI Building Block Spec.
+description: Gather architecture decisions, assess workflow autonomy level, choose an orchestration mechanism and involvement mode, classify steps on the autonomy spectrum, map AI building blocks, identify skill candidates, and document agent blueprints — producing a platform-agnostic Design Spec.
 ---> **Part of:** [AI Workflow Framework](../)
 
 :::tip[New to the building blocks?]
@@ -32,7 +32,7 @@ This framework guides you through *which decisions to make* and *what building b
 | | |
 |---|---|
 | **What you'll do** | Upload your Workflow Definition, choose your architecture approach, confirm your platform, review the AI's autonomy assessment and orchestration mechanism recommendation, review step classifications, and adjust anything that doesn't look right |
-| **What you'll get** | An **AI Building Block Spec** — architecture approach with rationale, architecture decisions, autonomy level assessment, orchestration mechanism with involvement mode, per-step autonomy classifications, building block mapping, skill candidates, agent blueprints (when applicable), and a prioritized build sequence |
+| **What you'll get** | A **Design Spec** — architecture approach with rationale, architecture decisions, autonomy level assessment, orchestration mechanism with involvement mode, per-step autonomy classifications, building block mapping, skill candidates, agent blueprints (when applicable), and a prioritized build sequence |
 | **Time** | ~15–25 minutes (architecture questions + reviewing the AI's analysis) |
 
 ## Why This Matters
@@ -67,7 +67,7 @@ The model analyzes your workflow and recommends an approach based on these signa
 Most workflows start no-code. Code-first becomes the right choice when you need programmatic control, integration into existing systems, or production-grade deployment. The same three orchestration mechanisms (Prompt, Skill-Powered Prompt, Agent) apply to both approaches — the architecture approach determines *how* you implement them, not *what* you implement.
 
 :::tip[You can switch later]
-Many teams prototype no-code, validate the workflow works, then rebuild code-first for production. The AI Building Block Spec captures the design either way — only the Build step changes.
+Many teams prototype no-code, validate the workflow works, then rebuild code-first for production. The Design Spec captures the design either way — only the Build step changes.
 :::
 ## Architecture Decisions
 
@@ -229,7 +229,7 @@ When your Workflow Definition has `Definition Type: Outcome-Driven`, the Design 
 - **Evaluation criteria** are carried forward from the definition's Quality Criteria section rather than gathered from scratch
 - **Agent Configuration** becomes the primary section of the spec, with instructions drawn from the definition's Goal, Constraints, and Expected Outputs
 
-The output is the same AI Building Block Spec format, with Capability Domain Mapping replacing the Step-by-Step Decomposition table, and an Autonomy Statement replacing the Autonomy Spectrum Summary.
+The output is the same Design Spec format, with Capability Domain Mapping replacing the Step-by-Step Decomposition table, and an Autonomy Statement replacing the Autonomy Spectrum Summary.
 
 ## How to Use This
 
@@ -242,7 +242,7 @@ Design the AI workflow from my Workflow Definition.
 Assess the autonomy level, recommend an orchestration mechanism, and map building blocks.
 ```
 
-Upload or paste your Workflow Definition file (`[workflow-name]-definition.md`) from the Deconstruct step when prompted. The skill runs the Design analysis and produces an AI Building Block Spec.
+Upload or paste your Workflow Definition file (`[workflow-name]-definition.md`) from the Deconstruct step when prompted. The skill runs the Design analysis and produces a Design Spec.
 
 :::tip[If your AI tool doesn't support skills]
 Download the skill file from [GitHub](https://github.com/jamesgray-ai/handsonai-plugins/tree/main/plugins/handsonai/skills/design) and paste it into your system prompt or project instructions. Or use this page as a conversation guide — walk through each section in order with your AI tool.
@@ -257,7 +257,7 @@ The first part of Design is a back-and-forth conversation. The model scans your 
 
 **Phase 2: Plan the spec (plan mode)**
 
-Once the architecture decisions, autonomy level, and orchestration mechanism are locked in, the model has everything it needs to plan the full AI Building Block Spec. This is when you **activate plan mode** — the model shifts from asking you questions to planning: classifying each step on the autonomy spectrum, mapping building blocks, identifying skill candidates, and documenting agent blueprints.
+Once the architecture decisions, autonomy level, and orchestration mechanism are locked in, the model has everything it needs to plan the full Design Spec. This is when you **activate plan mode** — the model shifts from asking you questions to planning: classifying each step on the autonomy spectrum, mapping building blocks, identifying skill candidates, and documenting agent blueprints.
 
 **How to activate plan mode on your platform:**
 
@@ -266,13 +266,15 @@ Once the architecture decisions, autonomy level, and orchestration mechanism are
 | **Claude Code** | Press `Shift+Tab` twice, or type `/plan` |
 | **Cursor** | Select "Plan" in the composer mode |
 | **Codex CLI** | Run with the `--plan` flag |
-| **Other AI tools** | Ask the model: *"Switch to plan mode. Based on the architecture decisions, autonomy level, and orchestration mechanism we've agreed on, plan the full AI Building Block Spec — classify each step, map building blocks, identify skill candidates, and document agent blueprints."* |
+| **Other AI tools** | Ask the model: *"Switch to plan mode. Based on the architecture decisions, autonomy level, and orchestration mechanism we've agreed on, plan the full Design Spec — classify each step, map building blocks, identify skill candidates, and document agent blueprints."* |
 
-After the model produces the plan, **review and approve the AI Building Block Spec** before moving on. If anything needs adjustment — a step classification, a skill candidate, an agent blueprint — now is the time. Once you approve, the model transitions to [Build (Step 4)](../build/) and begins building.
+After the model produces the plan, **review and approve the Design Spec** before moving on. If anything needs adjustment — a step classification, a skill candidate, an agent blueprint — now is the time. Once you approve, the model transitions to [Build (Step 4)](../build/) and begins building.
 
 ## What This Produces
 
-The **AI Building Block Spec** contains:
+The Design Spec catalogs which AI building blocks each step uses — it's named after the step that produces it (Design), not the components it lists.
+
+The **Design Spec** contains:
 
 - **Architecture approach** — No-code or Code-first, with rationale and recommendation signals
 - **Autonomy level assessment** — Deterministic, Guided, or Autonomous, with rationale for where the whole workflow sits on the spectrum
@@ -290,4 +292,4 @@ The **AI Building Block Spec** contains:
 - **Tools and connectors** — external integrations required
 - **Implementation order** — quick wins → semi-autonomous → complex agent steps
 
-This AI Building Block Spec is the input for [Step 4: Build](../build/), where the model generates platform-appropriate artifacts (prompts, skills, agents, connectors) based on your orchestration mechanism and architecture decisions.
+This Design Spec is the input for [Step 4: Build](../build/), where the model generates platform-appropriate artifacts (prompts, skills, agents, connectors) based on your orchestration mechanism and architecture decisions.

--- a/src/content/docs/ai-workflow-framework/examples/content-calendar-planning.md
+++ b/src/content/docs/ai-workflow-framework/examples/content-calendar-planning.md
@@ -1,6 +1,6 @@
 ---
 title: "Example: Content Calendar Planning"
-description: A complete worked example showing the framework deliverables — Workflow Definition, AI Building Block Spec, and workflow prompt — for a real content calendar planning workflow.
+description: A complete worked example showing the framework deliverables — Workflow Definition, Design Spec, and workflow prompt — for a real content calendar planning workflow.
 ---This page walks through the complete output of running a real workflow through the [AI Workflow Framework](../..//). The workflow is **Content Calendar Planning** — a weekly process for planning and sequencing content across LinkedIn, Substack, X, and YouTube.
 
 The first four steps of the framework — Analyze, Deconstruct, Design, and Build — produced three key deliverables for this workflow. Each one is a detailed markdown document. This page summarizes what's in each and why it matters — then links to the full file on GitHub where you can read every table, every decision point, and every failure mode at full width.
@@ -28,11 +28,11 @@ The Workflow Definition is what [Deconstruct](../../deconstruct/) produces. What
 
 ---
 
-### 2. AI Building Block Spec (Step 3 — Design)
+### 2. Design Spec (Step 3 — Design)
 
-[GitHub View full Building Block Spec on GitHub](https://github.com/jamesgray-ai/handsonai/blob/main/examples/content-calendar-planning/building-block-spec.md)
+[GitHub View full Design Spec on GitHub](https://github.com/jamesgray-ai/handsonai/blob/main/examples/content-calendar-planning/design-spec.md)
 
-The AI Building Block Spec is what [Design](../../design/) produces from the Workflow Definition. It classifies each step on the autonomy spectrum, identifies which steps should become reusable skills, and recommends an implementation order.
+The Design Spec is what [Design](../../design/) produces from the Workflow Definition. It classifies each step on the autonomy spectrum, identifies which steps should become reusable skills, and recommends an implementation order.
 
 **What's inside:**
 
@@ -71,8 +71,8 @@ A few things to take away from this example:
 
 - **The expansion.** "I plan content on Sundays" became 10 steps across 4 phases, with decision logic, failure modes, and a dependency map. That expansion is what makes the workflow executable by AI.
 - **The autonomy spectrum.** Not every step needs AI autonomy. Steps 1, 2, 4, and 10 are deterministic (fixed data operations). Steps 5-8 are guided (AI proposes, human decides). Steps 3 and 9 are human-led. The framework helps you see this clearly.
-- **The build order.** The Building Block Spec doesn't just say "build everything." It recommends starting with a prompt (pure conversation, no infrastructure needed), then layering in skills incrementally. You get value from the first run.
-- **Platform-agnostic.** The Workflow Definition and Building Block Spec work with any AI tool. The skills and MCP connections are implementation details that vary by platform — but the underlying logic is the same everywhere.
+- **The build order.** The Design Spec doesn't just say "build everything." It recommends starting with a prompt (pure conversation, no infrastructure needed), then layering in skills incrementally. You get value from the first run.
+- **Platform-agnostic.** The Workflow Definition and Design Spec work with any AI tool. The skills and MCP connections are implementation details that vary by platform — but the underlying logic is the same everywhere.
 
 ---
 

--- a/src/content/docs/ai-workflow-framework/improve.md
+++ b/src/content/docs/ai-workflow-framework/improve.md
@@ -59,7 +59,7 @@ Over time, some workflows outgrow their orchestration mechanism. A prompt that s
 Graduation is not always the right answer. If the workflow works well at its current level, leave it. The goal is to match the mechanism to the workflow's actual needs — not to over-engineer.
 
 :::note[Graduation means going back to Design]
-When you graduate a workflow to a new mechanism, you are changing the architecture. Return to [Design (Step 3)](../design/) to reassess the orchestration mechanism, update the Building Block Spec, then proceed through Build and Test with the new architecture.
+When you graduate a workflow to a new mechanism, you are changing the architecture. Return to [Design (Step 3)](../design/) to reassess the orchestration mechanism, update the Design Spec, then proceed through Build and Test with the new architecture.
 :::
 ## For Organizations
 
@@ -78,7 +78,7 @@ Every improvement cycle ends with one of four outcomes:
 |---------|--------------|-----------|
 | **No changes needed** | Eval scores are stable, no quality signals, workflow fits its purpose | Record the result and set the next review date |
 | **Tune** | Specific building blocks need adjustment — context is outdated, a prompt needs refinement, a tool connection needs updating | Go to [Build (Step 4)](../build/), fix the identified issues, then [Test (Step 5)](../test/) |
-| **Redesign** | Architecture assumptions have changed — the workflow needs a different orchestration mechanism, new building blocks, or a fundamentally different approach | Go to [Design (Step 3)](../design/) and rework the Building Block Spec |
+| **Redesign** | Architecture assumptions have changed — the workflow needs a different orchestration mechanism, new building blocks, or a fundamentally different approach | Go to [Design (Step 3)](../design/) and rework the Design Spec |
 | **Evolve** | The workflow should graduate to a more capable orchestration mechanism (see [Graduation Assessment](#graduation-assessment)) | Go to [Design (Step 3)](../design/) and upgrade the mechanism |
 
 The Improve step completes the lifecycle loop. Every outcome either confirms the workflow is healthy or sends you back to an earlier step with a specific target — never a vague "make it better."
@@ -105,7 +105,7 @@ This step is facilitated by the **`improve`** AI Workflow Framework skill. See [
 Evaluate my running workflow and help me decide what to improve.
 ```
 
-The skill reads your Building Block Spec and previous test results, guides you through the regression evaluation and graduation assessment, and produces the Improvement Plan.
+The skill reads your Design Spec and previous test results, guides you through the regression evaluation and graduation assessment, and produces the Improvement Plan.
 
 ## Related
 

--- a/src/content/docs/ai-workflow-framework/index.md
+++ b/src/content/docs/ai-workflow-framework/index.md
@@ -79,7 +79,7 @@ Decide *how* the workflow should be built — before you build it.
 
 The Design step takes your Workflow Definition and produces a complete blueprint for your AI workflow. The skill confirms your platform, extracts tool integrations and constraints from your Workflow Definition, assesses the workflow's autonomy level (Deterministic, Guided, or Autonomous), recommends an orchestration mechanism (Prompt, Skill-Powered Prompt, or Agent) and involvement mode, classifies each step on the autonomy spectrum, maps AI building blocks, identifies skill candidates, and documents agent blueprints when needed. The spec must be approved before moving to Build.
 
-**Deliverable:** **AI Building Block Spec** (`outputs/[name]-building-block-spec.md`) — architecture decisions, autonomy assessment, orchestration mechanism, per-step classifications, skill candidates, agent blueprints, context inventory, and implementation order.
+**Deliverable:** **Design Spec** (`outputs/[name]-design-spec.md`) — architecture decisions, autonomy assessment, orchestration mechanism, per-step classifications, skill candidates, agent blueprints, context inventory, and implementation order.
 
 **Facilitated by the `design` skill.** See [Design Your AI Workflow](design/) for the full guide with autonomy assessment, orchestration mechanism decision flow, and output format.
 
@@ -101,7 +101,7 @@ The Build step starts with a **Prepare Context** phase — systematically resolv
 
 Structured testing against the evaluation criteria from Design.
 
-Your first run is a test, not a deployment. The Test step walks you through a quick smoke test (does it run at all?), then a full eval suite where you run each test scenario from the Building Block Spec and score the output on the quality dimensions defined during Design. You also test individual building blocks in isolation and establish a baseline for future comparison.
+Your first run is a test, not a deployment. The Test step walks you through a quick smoke test (does it run at all?), then a full eval suite where you run each test scenario from the Design Spec and score the output on the quality dimensions defined during Design. You also test individual building blocks in isolation and establish a baseline for future comparison.
 
 Most workflows need 2-4 iterations between Build and Test before they produce reliably good output. When something is off, the skill helps you diagnose which building block to fix and sends you back to Build with a clear target.
 

--- a/src/content/docs/ai-workflow-framework/run.md
+++ b/src/content/docs/ai-workflow-framework/run.md
@@ -138,7 +138,7 @@ This step is facilitated by the **`run`** AI Workflow Framework skill. See [Set 
 Generate a Run Guide for my workflow and help me deploy it.
 ```
 
-The skill reads your Building Block Spec and artifacts, generates the Run Guide, and walks you through choosing a run pattern and getting the workflow into production.
+The skill reads your Design Spec and artifacts, generates the Run Guide, and walks you through choosing a run pattern and getting the workflow into production.
 
 ## Next Step
 

--- a/src/content/docs/ai-workflow-framework/skills.mdx
+++ b/src/content/docs/ai-workflow-framework/skills.mdx
@@ -250,7 +250,7 @@ ChatGPT should activate the Analyze skill and begin a structured interview proce
 
 #### Option 2: OpenAI Codex in a Code Editor
 
-Use **OpenAI Codex** in a code editor like Cursor or VS Code. Codex uses your existing ChatGPT login (Plus, Pro, or any paid plan), supports skills natively, and **saves output files directly to your computer** — so when a skill creates a Workflow Definition or Building Block Spec, you get an actual file instead of text in a chat window.
+Use **OpenAI Codex** in a code editor like Cursor or VS Code. Codex uses your existing ChatGPT login (Plus, Pro, or any paid plan), supports skills natively, and **saves output files directly to your computer** — so when a skill creates a Workflow Definition or Design Spec, you get an actual file instead of text in a chat window.
 
 See the [**OpenAI Codex**](#openai-codex) section under Code Editors & Terminal below for setup instructions.
 
@@ -753,7 +753,7 @@ You can also invoke skills directly with slash commands like `/handsonai:analyze
 
 1. **Analyze** (`analyze`) — Audit your workflows, interview you about your work, and produce an opportunity report with structured candidates. If you already know which workflow to deconstruct, this step is brief.
 2. **Deconstruct** (`deconstruct`) — Interactive deep-dive that decomposes the workflow into refined steps using the 6-question framework. Produces the Workflow Definition.
-3. **Design** (`design`) — Gather architecture decisions, assess workflow autonomy level, choose an orchestration mechanism and involvement mode, classify steps, map building blocks, identify skill candidates, configure agents, and produce the AI Building Block Spec.
+3. **Design** (`design`) — Gather architecture decisions, assess workflow autonomy level, choose an orchestration mechanism and involvement mode, classify steps, map building blocks, identify skill candidates, configure agents, and produce the Design Spec.
 4. **Build** (`build`) — Resolve context needs and generate platform-appropriate artifacts (prompts, skills, agents, configs) based on the approved spec.
 5. **Test** (`test`) — Run structured evaluations against the criteria from Design, establish a quality baseline, and iterate with Build until the workflow is ready.
 6. **Run** (`run`) — Generate a Run Guide tailored to your platform and technical comfort level, choose a run pattern, and deploy.
@@ -783,7 +783,7 @@ Files are saved to `outputs/` using kebab-case workflow names (e.g., `outputs/le
 
 1. **Opportunity Report** — `ai-opportunity-report.md` — categorized opportunities with structured workflow candidates (if generated)
 2. **Workflow Definition** — `[name]-definition.md` — structured decomposition of every step
-3. **AI Building Block Spec** — `[name]-building-block-spec.md` — autonomy level, orchestration mechanism, per-step classifications, building block mapping, skill candidates, agent configs
+3. **Design Spec** — `[name]-design-spec.md` — autonomy level, orchestration mechanism, per-step classifications, building block mapping, skill candidates, agent configs
 4. **Platform Artifacts** — prompts, skills, agents, and configs generated for your platform
 5. **Run Guide** — `[name]-run-guide.md` — step-by-step setup and first-run instructions
 6. **Improvement Plan** — `[name]-improvement-plan.md` — eval results, quality signals, and recommended actions (when running Improve)
@@ -886,7 +886,7 @@ Design your AI implementation architecture.
 
 **Command:** `/handsonai:design`
 
-**What it does:** Takes a Workflow Definition and runs the Design phase: architecture decisions, autonomy assessment, orchestration mechanism with involvement mode, per-step classification, building block mapping, skill candidates, agent configuration. Produces an AI Building Block Spec for approval.
+**What it does:** Takes a Workflow Definition and runs the Design phase: architecture decisions, autonomy assessment, orchestration mechanism with involvement mode, per-step classification, building block mapping, skill candidates, agent configuration. Produces a Design Spec for approval.
 
 **When to use it:** Use this when you have a Workflow Definition (from the Deconstruct step) and want to design your AI workflow's architecture. The spec must be approved before moving to Build.
 
@@ -900,14 +900,14 @@ Design your AI implementation architecture.
 6. **Classify each step** — Per-step autonomy level, AI building blocks, tools, human review gates
 7. **Identify skill candidates** — Steps tagged for skill creation with generation-ready detail
 8. **Agent configuration** (when applicable) — Platform-agnostic agent blueprint
-9. **Generate AI Building Block Spec** — Complete design document
+9. **Generate Design Spec** — Complete design document
 10. **Spec Approval Gate** — Present the spec for approval. No artifacts are generated until you confirm.
 
 **Example prompts:**
 
     "Design the AI workflow from my Workflow Definition"
     → Reads the most recent Workflow Definition, runs Design,
-      produces the AI Building Block Spec for approval
+      produces the Design Spec for approval
 
     "Design the expense-reporting workflow"
     → Reads outputs/expense-reporting-definition.md, recommends
@@ -915,7 +915,7 @@ Design your AI implementation architecture.
 
 **What you'll get:**
 
-- **AI Building Block Spec** (`outputs/[name]-building-block-spec.md`) — architecture decisions, autonomy level, orchestration mechanism with involvement mode, step classifications, skill candidates, agent configs, implementation order
+- **Design Spec** (`outputs/[name]-design-spec.md`) — architecture decisions, autonomy level, orchestration mechanism with involvement mode, step classifications, skill candidates, agent configs, implementation order
 
 **Platform compatibility:** Claude Code &#10003; | Claude.ai &#10003;
 
@@ -931,13 +931,13 @@ Generate platform artifacts from your approved spec.
 
 **Command:** `/handsonai:build`
 
-**What it does:** Takes an approved AI Building Block Spec and generates platform-appropriate artifacts: prompts, skills, agents, configs, and connectors. Starts with a Prepare Context phase to resolve the context needs identified during Deconstruct and Design. Researches integration availability and resolves deferred platform decisions.
+**What it does:** Takes an approved Design Spec and generates platform-appropriate artifacts: prompts, skills, agents, configs, and connectors. Starts with a Prepare Context phase to resolve the context needs identified during Deconstruct and Design. Researches integration availability and resolves deferred platform decisions.
 
-**When to use it:** Use this when you have an approved AI Building Block Spec (from the Design step) and want to generate the actual building blocks for your platform. Also useful when re-platforming — run Build again with the same spec but a different platform target. If returning from Test with issues, Build helps you fix the specific building blocks that need adjustment.
+**When to use it:** Use this when you have an approved Design Spec (from the Design step) and want to generate the actual building blocks for your platform. Also useful when re-platforming — run Build again with the same spec but a different platform target. If returning from Test with issues, Build helps you fix the specific building blocks that need adjustment.
 
 **How it works:**
 
-1. **Load Building Block Spec** — The AI reads the approved spec from `outputs/`
+1. **Load Design Spec** — The AI reads the approved spec from `outputs/`
 2. **Prepare Context** — Resolve the Context Shopping List and Data Readiness Summary — find existing documents, create missing materials, format for AI consumption
 3. **Build path choice** — Choose "I'll build it" (model generates artifacts) or "I'll build it myself" (get a Construction Guide with build sequence and creation skill recommendations)
 4. **Mechanism-specific build path** — Only the steps relevant to your chosen orchestration mechanism
@@ -947,7 +947,7 @@ Generate platform artifacts from your approved spec.
 
 **Example prompts:**
 
-    "Build the workflow from my Building Block Spec"
+    "Build the workflow from my Design Spec"
     → Reads the most recent spec, researches integrations,
       generates all platform artifacts
 
@@ -978,9 +978,9 @@ Structured testing and quality evaluation.
 
 **How it works:**
 
-1. **Load artifacts and spec** — The AI reads your Building Block Spec (for evaluation criteria and test scenarios) and locates your platform artifacts
+1. **Load artifacts and spec** — The AI reads your Design Spec (for evaluation criteria and test scenarios) and locates your platform artifacts
 2. **Smoke test** — Run the workflow once with a realistic scenario. Check: does it run, does it produce output, is the output in the right format?
-3. **Full eval suite** — Run each test scenario from the Building Block Spec. Score each output on a 1-5 scale across the evaluation dimensions defined during Design.
+3. **Full eval suite** — Run each test scenario from the Design Spec. Score each output on a 1-5 scale across the evaluation dimensions defined during Design.
 4. **Building block evals** — Test individual components (skills, context, agents) in isolation to pinpoint weak links
 5. **Establish baseline** — Calculate average scores across all scenarios and dimensions. Record for future comparison.
 6. **Diagnose and fix** — Map problems to building blocks (generic output = context issue, skipped steps = prompt issue, etc.) and identify what to fix in Build
@@ -1018,7 +1018,7 @@ Deploy and operate your tested workflow.
 
 **How it works:**
 
-1. **Load spec and artifacts** — The AI reads your Building Block Spec and locates platform artifacts
+1. **Load spec and artifacts** — The AI reads your Design Spec and locates platform artifacts
 2. **Generate Run Guide** — Artifact inventory, setup steps, first production run instructions, and next steps
 3. **Run pattern selection** — Choose the right pattern: paste and run, run in a project, command an agent, code-first, or automate on schedule
 4. **Operationalization** (for organizational workflows) — Sharing, training, governance, and adoption monitoring guidance
@@ -1055,7 +1055,7 @@ Evaluate and evolve running workflows.
 
 **How it works:**
 
-1. **Load history** — The AI reads the Building Block Spec, previous test results, and baseline scores
+1. **Load history** — The AI reads the Design Spec, previous test results, and baseline scores
 2. **Quality signal review** — Discuss what prompted this improvement cycle. Which signals are you seeing?
 3. **Regression evaluation** — Re-run the eval suite from Test. Compare current scores to baseline. Identify dimensions where quality has degraded or improved.
 4. **Graduation assessment** — Should the orchestration mechanism evolve? Prompt to Skill-Powered Prompt, Skill-Powered Prompt to Agent, single agent to multi-agent? The AI assesses based on current pain points and workflow complexity.
@@ -1085,7 +1085,7 @@ These skills cover the full AI Workflow Framework. Here's the recommended path:
 
 1. **Analyze** — Run `analyze` to audit your workflows and identify where AI creates the most value
 2. **Deconstruct** — Pick your highest-impact candidate and run `deconstruct` (or use the `framework-agent` agent for the full end-to-end process)
-3. **Design** — Run `design` to produce your AI Building Block Spec
+3. **Design** — Run `design` to produce your Design Spec
 4. **Build** — Run `build` to resolve context needs and generate platform artifacts from the approved spec
 5. **Test** — Run `test` to evaluate output quality, establish a baseline, and iterate with Build until the workflow is ready
 6. **Run** — Run `run` to get a Run Guide, choose a run pattern, and deploy. See the [AI Workflow Examples](../../use-the-playbook/build/ai-workflow-examples/) plugin for working examples of real AI workflows.

--- a/src/content/docs/ai-workflow-framework/test.md
+++ b/src/content/docs/ai-workflow-framework/test.md
@@ -9,7 +9,7 @@ You've just finished [Build (Step 4)](../build/). You should have:
 
 - **Platform artifacts** — prompts, skills, agents, and configs generated for your platform
 - **Context artifacts** — style guides, reference materials, and examples
-- **AI Building Block Spec** (`[name]-building-block-spec.md`) — which includes the evaluation criteria and test scenarios defined during [Design](../design/)
+- **Design Spec** (`[name]-design-spec.md`) — which includes the evaluation criteria and test scenarios defined during [Design](../design/)
 
 Your first run is a test, not a deployment. The goal is to verify that the workflow produces good output before you share it with your team or use it on real work.
 
@@ -32,7 +32,7 @@ The first run is about confirming the workflow functions. Resist the urge to fin
 :::
 ## Structured Evaluation
 
-Once the smoke test passes, move to a full evaluation using the criteria defined during Design. Your AI Building Block Spec includes **evaluation dimensions** (the qualities you care about — accuracy, tone, completeness, specificity) and **test scenarios** (realistic inputs that exercise different parts of the workflow).
+Once the smoke test passes, move to a full evaluation using the criteria defined during Design. Your Design Spec includes **evaluation dimensions** (the qualities you care about — accuracy, tone, completeness, specificity) and **test scenarios** (realistic inputs that exercise different parts of the workflow).
 
 ### Run the Eval Suite
 
@@ -121,7 +121,7 @@ This step is facilitated by the **`test`** AI Workflow Framework skill. See [Set
 **Start with this prompt:**
 
 ```
-Test my workflow against the evaluation criteria in the Building Block Spec.
+Test my workflow against the evaluation criteria in the Design Spec.
 ```
 
 The skill guides you through the smoke test, eval suite, building block evals, baseline establishment, and diagnosis process.

--- a/src/content/docs/builder-setup/notion-registry-setup.md
+++ b/src/content/docs/builder-setup/notion-registry-setup.md
@@ -95,7 +95,7 @@ Agent skills are an open standard, and many companies are already working to ado
 | Database | Purpose | Key Fields |
 |----------|---------|------------|
 | **Business Processes** | High-level business functions and their domains | Domain, LOB, Description, Guide (URL) |
-| **Workflows** | Specific workflows within each process | Status, Execution Mode, Autonomy Level, Trigger, Process Outcome, SOP (URL), Workflow Definition (URL), Building Block Spec (URL) |
+| **Workflows** | Specific workflows within each process | Status, Execution Mode, Autonomy Level, Trigger, Process Outcome, SOP (URL), Workflow Definition (URL), Design Spec (URL) |
 | **AI Building Blocks** | Skills, prompts, agents, and other AI components | Asset Type, Platform, Status, Dependencies |
 | **Apps** | Connected applications and integrations | Type, Auth Type, Connection Status |
 

--- a/src/content/docs/courses/builders/week-5.md
+++ b/src/content/docs/courses/builders/week-5.md
@@ -14,7 +14,7 @@ Run the framework end-to-end yourself in Cowork (or Claude Code — same slash c
 **Starting point:** a pre-built workflow definition (download below).
 **Ending point:** a shipped skill + agent producing a brief on a real competitor.
 
-1. **`/design`** — Turn the definition into an approved Building Block Spec (plan mode, collaborative). See the [Design step docs](../../../ai-workflow-framework/design/).
+1. **`/design`** — Turn the definition into an approved Design Spec (plan mode, collaborative). See the [Design step docs](../../../ai-workflow-framework/design/).
 2. **`/build`** — Generate the `competitor-research` skill and `competitor-brief` agent from your spec. See the [Build step docs](../../../ai-workflow-framework/build/).
 3. **`/test`** — Validate the building blocks before trusting them with real input. See the [Test step docs](../../../ai-workflow-framework/test/).
 4. **`/run`** — Invoke the workflow on a real competitor; watch `knowledge/competitors/{name}.md` emerge. See the [Run step docs](../../../ai-workflow-framework/run/).

--- a/src/content/docs/llms-full.txt
+++ b/src/content/docs/llms-full.txt
@@ -30,11 +30,11 @@
 
 ### Step 3 — Design
 - URL: https://handsonai.info/ai-workflow-framework/design/
-- Summary: Assess the workflow's autonomy level, choose an orchestration mechanism (Prompt, Skill-Powered Prompt, Agent), classify each step on the autonomy spectrum, map to AI building blocks, identify skill candidates, and configure agents. Produces a platform-agnostic AI Building Block Spec.
+- Summary: Assess the workflow's autonomy level, choose an orchestration mechanism (Prompt, Skill-Powered Prompt, Agent), classify each step on the autonomy spectrum, map to AI building blocks, identify skill candidates, and configure agents. Produces a platform-agnostic Design Spec.
 
 ### Step 4 — Build
 - URL: https://handsonai.info/ai-workflow-framework/build/
-- Summary: Resolve context needs, then generate platform-appropriate artifacts (prompts, skills, agents, configs) from the approved Building Block Spec. Mechanism-specific build paths for Prompt, Skill-Powered Prompt, and Agent.
+- Summary: Resolve context needs, then generate platform-appropriate artifacts (prompts, skills, agents, configs) from the approved Design Spec. Mechanism-specific build paths for Prompt, Skill-Powered Prompt, and Agent.
 
 ### Step 5 — Test
 - URL: https://handsonai.info/ai-workflow-framework/test/

--- a/src/content/docs/use-the-playbook/build/handsonai.mdx
+++ b/src/content/docs/use-the-playbook/build/handsonai.mdx
@@ -55,7 +55,7 @@ Walks you through the full 7-step framework end-to-end. The agent calls the righ
 |---|---|---|
 | `analyze` | `/handsonai:analyze` | Audit your workflows (individual or organizational lens) to find where AI creates the most value |
 | `deconstruct` | `/handsonai:deconstruct` | Break a workflow into structured steps using the 6-question framework |
-| `design` | `/handsonai:design` | Design the AI workflow architecture and produce an AI Building Block Spec |
+| `design` | `/handsonai:design` | Design the AI workflow architecture and produce a Design Spec |
 | `build` | `/handsonai:build` | Generate platform-appropriate artifacts (prompts, skills, agents) from the approved spec |
 | `test` | `/handsonai:test` | Test workflow artifacts and evaluate output quality |
 | `run` | `/handsonai:run` | Generate a Run Guide for deploying and operating the workflow |

--- a/src/content/docs/use-the-playbook/build/index.md
+++ b/src/content/docs/use-the-playbook/build/index.md
@@ -29,7 +29,7 @@ The seven-step methodology for going from a workflow idea to a deployed AI syste
 | [`framework-agent`](handsonai/#framework-agent) agent | Walks you through the full 7-step framework end-to-end |
 | `analyze` skill | Audit your workflows to find where AI creates the most value |
 | `deconstruct` skill | Break a workflow into structured steps using the 6-question framework |
-| `design` skill | Design the AI workflow architecture and produce an AI Building Block Spec |
+| `design` skill | Design the AI workflow architecture and produce a Design Spec |
 | `build` skill | Generate platform-appropriate artifacts from the approved spec |
 | `test` skill | Test workflow artifacts and evaluate output quality |
 | `run` skill | Generate a Run Guide for deploying and operating the workflow |


### PR DESCRIPTION
## Summary

- Renames the Step 3 (Design) deliverable from **AI Building Block Spec** to **Design Spec** so the artifact name mirrors the step that produces it — matching how Step 2 (Deconstruct) produces a Workflow Definition.
- Disambiguates from the 11 AI building blocks (Model, Prompt, Context, etc.) that the spec itself catalogs.
- Updates output filename convention: `outputs/[name]-building-block-spec.md` → `outputs/[name]-design-spec.md`. Renames the existing example file accordingly.
- Bumps handsonai plugin: **3.0.0 → 3.0.1** (PATCH — in-place skill update). Sibling `handsonai-plugins` repo updated separately and pushed last per CLAUDE.md.
- Blog posts intentionally left unchanged (historical changelog entries).

## Test plan

- [x] `grep -rniE "building[- ]?blocks?[- ]spec"` → zero non-blog matches in both repos
- [x] `npm run build` → 201 pages, no broken links
- [x] `.claude/skills/*` and `plugins/handsonai/skills/*` parity verified
- [x] Article-grammar fix sweep ("an Design Spec" → "a Design Spec")
- [x] Bare "building blocks" (the 11 primitives) preserved in framework docs
- [ ] Spot-check rendered pages: `/ai-workflow-framework/design/`, `/ai-workflow-framework/build/`, `/ai-workflow-framework/examples/content-calendar-planning/`, `/use-the-playbook/build/handsonai/`
- [ ] After merge: reload `handsonai` plugin and run `/handsonai:design` to confirm description and produced filename use "Design Spec" / `design-spec.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)