### PR TITLE
feat: add Compose entry point to AI Workflow Framework

### DIFF
--- a/.claude/skills/deconstruct/SKILL.md
+++ b/.claude/skills/deconstruct/SKILL.md
@@ -3,15 +3,17 @@ name: deconstruct
 description: >
   This skill should be used when the user wants to deconstruct a workflow, break down a business
   process, define an outcome for an agent system, or deeply analyze a workflow's steps, decisions,
-  data flows, and failure modes. Interactively decomposes a workflow into a structured Workflow
-  Definition using either the 6-question framework (step-decomposed) or an outcome-driven interview
-  (for autonomous agent systems). This is Step 2 of the AI Workflow Framework.
+  data flows, and failure modes. Supports four entry paths: step-decomposed (6-question framework),
+  problem-first, outcome-driven (for autonomous agent systems), or Compose — a lean three-turn flow
+  that outputs an orchestration prompt directly when the user already has the skills/sub-agents in
+  place. The first three paths produce a structured Workflow Definition; Compose produces only an
+  orchestration prompt. This is Step 2 of the AI Workflow Framework.
 user-invocable: true
 ---
 
 # Workflow Deconstruction
 
-Interactively discover a business workflow and produce a structured Workflow Definition — either step-decomposed (using the 6-question framework) or outcome-driven (capturing goal, constraints, and capability domains for agent systems).
+Interactively discover a business workflow via one of four paths. The step-decomposed (6-question framework), problem-first, and outcome-driven paths all produce a structured Workflow Definition. The Compose path is the lean alternative: when the user already has the skills or sub-agents their workflow needs and can describe each step, Compose skips the deep dive and outputs an orchestration prompt directly in three turns — no Workflow Definition file.
 
 ## Workflow
 

--- a/.claude/skills/deconstruct/SKILL.md
+++ b/.claude/skills/deconstruct/SKILL.md
@@ -24,12 +24,94 @@ Interactively discover a business workflow and produce a structured Workflow Def
    > "How would you like to approach this?
    > (a) **Deconstruct a known process** — You can describe the steps and I'll interview you to surface hidden details
    > (b) **Start from a problem** — You know what's broken; I'll propose a workflow and we refine it together
-   > (c) **Define an outcome** — You know what you want produced but want an agent system to figure out the approach"
+   > (c) **Define an outcome** — You know what you want produced but want an agent system to figure out the approach
+   > (d) **Compose** — You already have skills and/or sub-agents and know the workflow; I'll write the orchestration prompt directly"
 
    **After the user chooses, gather scenario details based on their path:**
    - **Option (a)**: Ask about the business scenario, objective, high-level steps, and ownership. One question at a time. If no lens was established, determine it: individual tasks (one person's repetitive work) = Individual lens; multi-role or business-objective processes = Organizational lens. If not obvious from context, ask. Proceed to Step 2 (scope check) → Step 4 (deep dive with 6-question framework).
    - **Option (b)**: Ask the user to describe what's broken. Propose a candidate workflow for them to react to. Then recommend whether step-decomposed or outcome-driven fits better, with reasoning. User confirms or overrides — honor their choice either way. If step-decomposed, proceed to Step 2 → Step 4. If outcome-driven, proceed to Step 2 → Step 4-OD.
    - **Option (c)**: Ask the user to describe the outcome they want — what should the agent system produce, what triggers the need, and who consumes the output. One question at a time. Proceed to Step 2 (scope check) → Step 4-OD (outcome-driven interview).
+   - **Option (d) — Compose**: Proceed to the **Compose three-turn flow** (see Step 1c below). Do NOT call Step 2 (scope check) or Step 4 (deep dive); Compose handles its own lean intake inline and writes no Workflow Definition file.
+
+**Step 1c — Compose three-turn flow (only reached from Option d):**
+
+The Compose path is the **lean** path. No formal pre-flight, no Workflow Definition file, no `/design` invocation. The conversation captures what's needed, confirms it back, and outputs an orchestration prompt the student can run.
+
+**Turn 1 — Intake.** Ask the student for everything in one message:
+
+> "Tell me four things in one message:
+> 1. **Workflow name and outcome** — what does this workflow produce?
+> 2. **Where your components live** — Claude account (Claude.ai + Cowork), Claude Code, ChatGPT, or a mix?
+> 3. **The steps** — numbered, one line each.
+> 4. **Which component runs each step** — name and type (skill or sub-agent)."
+
+If the student answers Turn 1 incompletely, ask only for the missing pieces in Turn 2 — do not restart.
+
+**Turn 2 — Confirm + autonomy/involvement.** Restate what you heard in 5–8 lines: workflow name, hosting, steps, component-to-step mapping. Use ✓ when a component clearly fits its step; flag concerns inline (vague step, missing component, suspected mismatch) and ask for a quick fix.
+
+If the workflow looks more complex than the Compose path is built for — 8+ steps, no components for half the steps, "etc." in step descriptions, or 3+ decision points the student didn't surface — say so directly and offer to switch:
+
+> "This is more involved than the Compose path is built for — [specific reason]. The Known Process path (`/deconstruct` option a) will surface the gaps before they bite. Want to switch?"
+
+Then ask the two questions that actually shape the prompt:
+
+- *"Deterministic (fixed sequence, no AI judgment) or guided (the AI scores, evaluates, or adapts between steps)?"*
+- *"Augmented (AI pauses for your input at any point) or automated (runs straight through)?"*
+
+**Turn 3 — Output the orchestration prompt.** Generate the prompt in the standard shape below and return it as a code block the student can copy. Map the autonomy + involvement answers to one of four patterns:
+
+- **Deterministic, automated** — components fire in sequence, no pauses, no AI judgment.
+- **Deterministic, augmented** — same fixed sequence with a PAUSE for student review between named steps.
+- **Guided, augmented** — scoring/evaluation/adaptation between steps, with a PAUSE for steering.
+- **Guided, automated** — same decision logic, but the AI makes the bounded calls without pausing.
+
+**Standard output shape:**
+
+~~~markdown
+---
+workflow: <Workflow Name>
+outcome: <one-sentence outcome>
+autonomy: deterministic | guided
+involvement: augmented | automated
+components:
+  - name: <name>
+    type: skill       # used in step 1
+  - name: <name>
+    type: sub-agent   # used in step 2
+---
+
+# <Workflow Name>
+
+## Intent
+<one-paragraph "what this workflow does and when to run it">
+
+## Prompt
+<the orchestration prompt body>
+~~~
+
+**Prompt-body constraints — clarity, brevity, token efficiency:**
+
+- One instruction per line where possible. Imperative voice. No filler ("please", "kindly", "make sure to").
+- No re-explanation of what the components do — components have their own descriptions.
+- No preamble or commentary. Open with the first instruction, not "In this workflow, we will…".
+- PAUSE points are uppercase and unambiguous on their own line: `PAUSE — wait for me to confirm which insights to feature.`
+- Reuse the student's own wording for inputs, outputs, and decision criteria. Avoid synthesizing new jargon.
+- Inline tone or formatting guidance only when it changes the output (e.g., "narrative tone, not bullet-heavy"). Skip aesthetics.
+
+**Component verification, hosting-aware:**
+
+- **Claude Code (local files):** Read each named component's frontmatter (SKILL.md or agent file) under `.claude/skills/` and `.claude/agents/` (plus installed plugin caches). Confirm it exists, fits the step, and isn't an obvious mismatch. Mention an alternative only if you spot a clearly stronger match in the student's local inventory.
+- **Claude account, ChatGPT, or mix:** You cannot introspect. Trust the student's mapping. Ask for clarification only if a component name sounds wrong for the step it's assigned to. If the student doesn't remember a component's name, ask them to paste their available components from wherever they're hosted.
+
+**Saving the artifact:**
+
+Tell the student to save the orchestration prompt wherever they keep prompts:
+- Claude Code users: a `prompts/<workflow-name>.md` file in their project.
+- Everyone else: a Google Doc, Notion page, Claude account project file, ChatGPT saved prompt, or plain note.
+
+Do **not** write any file to `outputs/`. The Compose path produces conversation output only.
+
+**End of Compose flow.** Do not hand off to `/design`, `/build`, `/test`, or `/run`. The student tests the workflow by running the prompt.
 
 2. **Scope check — one trigger, one deliverable** — A workflow has exactly one trigger (what kicks it off) and one deliverable (the tangible output). Test for multiple workflows by checking:
    - **Triggers**: Multiple independent starting points? (e.g., "when a lead comes in" vs. "end of each week") → separate workflows

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -7,6 +7,7 @@ description: >
   identifies skill candidates, configures agents, and produces a Design Spec for approval.
   Supports both step-decomposed and outcome-driven Workflow Definitions.
   This is Step 3 (Design) of the AI Workflow Framework.
+  Note: the Compose entry point in /deconstruct (option d) handles its own lightweight design inline and bypasses this skill.
 user-invocable: true
 ---
 

--- a/plugins/handsonai/.claude-plugin/plugin.json
+++ b/plugins/handsonai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "handsonai",
   "description": "Everything you need to design, build, and document AI workflows. The AI Workflow Framework as executable Claude Code skills, plus an AI registry and feature-spec toolkit.",
-  "version": "3.1.0",
+  "version": "3.0.2",
   "author": {
     "name": "James Gray"
   },

--- a/plugins/handsonai/.claude-plugin/plugin.json
+++ b/plugins/handsonai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "handsonai",
   "description": "Everything you need to design, build, and document AI workflows. The AI Workflow Framework as executable Claude Code skills, plus an AI registry and feature-spec toolkit.",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "author": {
     "name": "James Gray"
   },

--- a/plugins/handsonai/skills/deconstruct/SKILL.md
+++ b/plugins/handsonai/skills/deconstruct/SKILL.md
@@ -3,15 +3,17 @@ name: deconstruct
 description: >
   This skill should be used when the user wants to deconstruct a workflow, break down a business
   process, define an outcome for an agent system, or deeply analyze a workflow's steps, decisions,
-  data flows, and failure modes. Interactively decomposes a workflow into a structured Workflow
-  Definition using either the 6-question framework (step-decomposed) or an outcome-driven interview
-  (for autonomous agent systems). This is Step 2 of the AI Workflow Framework.
+  data flows, and failure modes. Supports four entry paths: step-decomposed (6-question framework),
+  problem-first, outcome-driven (for autonomous agent systems), or Compose — a lean three-turn flow
+  that outputs an orchestration prompt directly when the user already has the skills/sub-agents in
+  place. The first three paths produce a structured Workflow Definition; Compose produces only an
+  orchestration prompt. This is Step 2 of the AI Workflow Framework.
 user-invocable: true
 ---
 
 # Workflow Deconstruction
 
-Interactively discover a business workflow and produce a structured Workflow Definition — either step-decomposed (using the 6-question framework) or outcome-driven (capturing goal, constraints, and capability domains for agent systems).
+Interactively discover a business workflow via one of four paths. The step-decomposed (6-question framework), problem-first, and outcome-driven paths all produce a structured Workflow Definition. The Compose path is the lean alternative: when the user already has the skills or sub-agents their workflow needs and can describe each step, Compose skips the deep dive and outputs an orchestration prompt directly in three turns — no Workflow Definition file.
 
 ## Workflow
 
@@ -24,12 +26,94 @@ Interactively discover a business workflow and produce a structured Workflow Def
    > "How would you like to approach this?
    > (a) **Deconstruct a known process** — You can describe the steps and I'll interview you to surface hidden details
    > (b) **Start from a problem** — You know what's broken; I'll propose a workflow and we refine it together
-   > (c) **Define an outcome** — You know what you want produced but want an agent system to figure out the approach"
+   > (c) **Define an outcome** — You know what you want produced but want an agent system to figure out the approach
+   > (d) **Compose** — You already have skills and/or sub-agents and know the workflow; I'll write the orchestration prompt directly"
 
    **After the user chooses, gather scenario details based on their path:**
    - **Option (a)**: Ask about the business scenario, objective, high-level steps, and ownership. One question at a time. If no lens was established, determine it: individual tasks (one person's repetitive work) = Individual lens; multi-role or business-objective processes = Organizational lens. If not obvious from context, ask. Proceed to Step 2 (scope check) → Step 4 (deep dive with 6-question framework).
    - **Option (b)**: Ask the user to describe what's broken. Propose a candidate workflow for them to react to. Then recommend whether step-decomposed or outcome-driven fits better, with reasoning. User confirms or overrides — honor their choice either way. If step-decomposed, proceed to Step 2 → Step 4. If outcome-driven, proceed to Step 2 → Step 4-OD.
    - **Option (c)**: Ask the user to describe the outcome they want — what should the agent system produce, what triggers the need, and who consumes the output. One question at a time. Proceed to Step 2 (scope check) → Step 4-OD (outcome-driven interview).
+   - **Option (d) — Compose**: Proceed to the **Compose three-turn flow** (see Step 1c below). Do NOT call Step 2 (scope check) or Step 4 (deep dive); Compose handles its own lean intake inline and writes no Workflow Definition file.
+
+**Step 1c — Compose three-turn flow (only reached from Option d):**
+
+The Compose path is the **lean** path. No formal pre-flight, no Workflow Definition file, no `/design` invocation. The conversation captures what's needed, confirms it back, and outputs an orchestration prompt the student can run.
+
+**Turn 1 — Intake.** Ask the student for everything in one message:
+
+> "Tell me four things in one message:
+> 1. **Workflow name and outcome** — what does this workflow produce?
+> 2. **Where your components live** — Claude account (Claude.ai + Cowork), Claude Code, ChatGPT, or a mix?
+> 3. **The steps** — numbered, one line each.
+> 4. **Which component runs each step** — name and type (skill or sub-agent)."
+
+If the student answers Turn 1 incompletely, ask only for the missing pieces in Turn 2 — do not restart.
+
+**Turn 2 — Confirm + autonomy/involvement.** Restate what you heard in 5–8 lines: workflow name, hosting, steps, component-to-step mapping. Use ✓ when a component clearly fits its step; flag concerns inline (vague step, missing component, suspected mismatch) and ask for a quick fix.
+
+If the workflow looks more complex than the Compose path is built for — 8+ steps, no components for half the steps, "etc." in step descriptions, or 3+ decision points the student didn't surface — say so directly and offer to switch:
+
+> "This is more involved than the Compose path is built for — [specific reason]. The Known Process path (`/deconstruct` option a) will surface the gaps before they bite. Want to switch?"
+
+Then ask the two questions that actually shape the prompt:
+
+- *"Deterministic (fixed sequence, no AI judgment) or guided (the AI scores, evaluates, or adapts between steps)?"*
+- *"Augmented (AI pauses for your input at any point) or automated (runs straight through)?"*
+
+**Turn 3 — Output the orchestration prompt.** Generate the prompt in the standard shape below and return it as a code block the student can copy. Map the autonomy + involvement answers to one of four patterns:
+
+- **Deterministic, automated** — components fire in sequence, no pauses, no AI judgment.
+- **Deterministic, augmented** — same fixed sequence with a PAUSE for student review between named steps.
+- **Guided, augmented** — scoring/evaluation/adaptation between steps, with a PAUSE for steering.
+- **Guided, automated** — same decision logic, but the AI makes the bounded calls without pausing.
+
+**Standard output shape:**
+
+~~~markdown
+---
+workflow: <Workflow Name>
+outcome: <one-sentence outcome>
+autonomy: deterministic | guided
+involvement: augmented | automated
+components:
+  - name: <name>
+    type: skill       # used in step 1
+  - name: <name>
+    type: sub-agent   # used in step 2
+---
+
+# <Workflow Name>
+
+## Intent
+<one-paragraph "what this workflow does and when to run it">
+
+## Prompt
+<the orchestration prompt body>
+~~~
+
+**Prompt-body constraints — clarity, brevity, token efficiency:**
+
+- One instruction per line where possible. Imperative voice. No filler ("please", "kindly", "make sure to").
+- No re-explanation of what the components do — components have their own descriptions.
+- No preamble or commentary. Open with the first instruction, not "In this workflow, we will…".
+- PAUSE points are uppercase and unambiguous on their own line: `PAUSE — wait for me to confirm which insights to feature.`
+- Reuse the student's own wording for inputs, outputs, and decision criteria. Avoid synthesizing new jargon.
+- Inline tone or formatting guidance only when it changes the output (e.g., "narrative tone, not bullet-heavy"). Skip aesthetics.
+
+**Component verification, hosting-aware:**
+
+- **Claude Code (local files):** Read each named component's frontmatter (SKILL.md or agent file) under `.claude/skills/` and `.claude/agents/` (plus installed plugin caches). Confirm it exists, fits the step, and isn't an obvious mismatch. Mention an alternative only if you spot a clearly stronger match in the student's local inventory.
+- **Claude account, ChatGPT, or mix:** You cannot introspect. Trust the student's mapping. Ask for clarification only if a component name sounds wrong for the step it's assigned to. If the student doesn't remember a component's name, ask them to paste their available components from wherever they're hosted.
+
+**Saving the artifact:**
+
+Tell the student to save the orchestration prompt wherever they keep prompts:
+- Claude Code users: a `prompts/<workflow-name>.md` file in their project.
+- Everyone else: a Google Doc, Notion page, Claude account project file, ChatGPT saved prompt, or plain note.
+
+Do **not** write any file to `outputs/`. The Compose path produces conversation output only.
+
+**End of Compose flow.** Do not hand off to `/design`, `/build`, `/test`, or `/run`. The student tests the workflow by running the prompt.
 
 2. **Scope check — one trigger, one deliverable** — A workflow has exactly one trigger (what kicks it off) and one deliverable (the tangible output). Test for multiple workflows by checking:
    - **Triggers**: Multiple independent starting points? (e.g., "when a lead comes in" vs. "end of each week") → separate workflows

--- a/plugins/handsonai/skills/design/SKILL.md
+++ b/plugins/handsonai/skills/design/SKILL.md
@@ -7,6 +7,7 @@ description: >
   identifies skill candidates, configures agents, and produces a Design Spec for approval.
   Supports both step-decomposed and outcome-driven Workflow Definitions.
   This is Step 3 (Design) of the AI Workflow Framework.
+  Note: the Compose entry point in /deconstruct (option d) handles its own lightweight design inline and bypasses this skill.
 user-invocable: true
 ---
 

--- a/src/content/docs/ai-workflow-framework/deconstruct/index.md
+++ b/src/content/docs/ai-workflow-framework/deconstruct/index.md
@@ -91,6 +91,46 @@ When you know what you want produced but don't want to prescribe how the AI gets
 
 From there, the model continues through constraints, quality criteria, capability domains, tools/data, and human gates — building an outcome-driven Workflow Definition without decomposing into fixed steps.
 
+### Compose (option d) — for clear workflows with components ready
+
+Compose is for one specific scenario: you already have reusable building blocks (skills, sub-agents, or both) covering your workflow's steps, **and** the workflow is straightforward enough to hold in your head.
+
+Both conditions must be true. If either is missing, the Known Process path (option a) is the right call.
+
+| Use Compose when | Use Known Process when |
+|---|---|
+| You already have a skill or sub-agent for each step | You'd need to build a new component for one or more steps |
+| You can describe each step in one clear sentence | Steps are vague, branching, or you're not sure they're complete |
+| Decision points (if any) are simple and few | Multiple decision points, scoring, or context-dependent routing |
+| You just need an orchestration prompt | You need a tested workflow with a documented spec |
+
+#### How Compose works
+
+A three-turn conversation inside `/deconstruct`:
+
+1. **Intake.** You answer four things in one message: workflow name + outcome, where your components live (Claude account, Claude Code, ChatGPT, or a mix), the steps, and which component runs each step.
+2. **Confirm + autonomy.** The AI restates what it heard, flags anything off (vague steps, missing components, hidden complexity), then asks two questions that shape the prompt: deterministic or guided? augmented or automated?
+3. **Output.** The AI writes the orchestration prompt in a standard shape — frontmatter (workflow name, outcome, autonomy, involvement, components) + Intent + Prompt body. You copy it, save it wherever you keep prompts, and run it.
+
+No Workflow Definition file, no Design Spec, no `/build` or `/test` invocation. The prompt is the artifact.
+
+#### Example: Weekly Competitive Intelligence Digest
+
+A student wants a workflow that pulls insights from 3 competitor blog posts, scores them by relevance, and produces a LinkedIn post summarizing the top 2.
+
+**Turn 1** — the student answers:
+
+- Workflow: Weekly Competitive Intelligence Digest. Output: a LinkedIn post drawing from the top 2 insights.
+- Components live in: Claude account.
+- Steps: (1) extract insights from each of 3 articles; (2) score insights 1–10 on relevance; (3) pick the top 2 and draft a LinkedIn post.
+- Components: `extracting-article-insights` (skill), `competitive-relevance-scorer` (skill), `drafting-linkedin-posts` (skill).
+
+**Turn 2** — the AI confirms back, notes that step 2's scoring makes this a *guided* workflow, and asks for autonomy + involvement. Student picks **guided, augmented** (pause after scoring so the student picks which insights make the post).
+
+**Turn 3** — the AI outputs an orchestration prompt with frontmatter, an Intent paragraph, and a Prompt body that chains the three skills with a PAUSE after scoring. The student copies the prompt into a Google Doc and runs it against the week's three articles.
+
+Three turns. One artifact. No file written to `outputs/`.
+
 ### Not sure which workflow to try?
 
 Browse the [AI Use Cases](../../use-cases/) section for inspiration — it organizes examples by type (content creation, research, coding, data analysis, ideation, and automation) with department-specific scenarios.

--- a/src/content/docs/ai-workflow-framework/design.md
+++ b/src/content/docs/ai-workflow-framework/design.md
@@ -6,6 +6,11 @@ description: Gather architecture decisions, assess workflow autonomy level, choo
 :::tip[New to the building blocks?]
 See the [Agentic Building Blocks](../../agentic-building-blocks/) reference for definitions, examples, and cross-platform comparisons of all blocks.
 :::
+
+:::note
+Coming from `/deconstruct` option (d) Compose? You're not here — Compose generates the orchestration prompt inline without invoking `/design`. See the [Compose section on the Deconstruct page](/ai-workflow-framework/deconstruct/#compose-option-d--for-clear-workflows-with-components-ready) for that path.
+:::
+
 ## What This Is
 
 The Design phase is where you decide *how* your workflow should be built — before you build it. You take the Workflow Definition from the [Deconstruct step](../deconstruct/) and make design decisions. The Design skill supports both **step-decomposed** and **outcome-driven** Workflow Definitions:

--- a/src/content/docs/ai-workflow-framework/index.md
+++ b/src/content/docs/ai-workflow-framework/index.md
@@ -55,6 +55,7 @@ How you enter depends on what you're starting with:
 - **You know the process.** You can describe the steps, decisions, and handoffs — the model interviews you to surface hidden details and capture it all in a structured format. This is the most common path for workflows you already do manually.
 - **You have a problem, not a process.** You know what's broken or slow, but there's no defined workflow yet. The model proposes a candidate workflow for you to react to, then decomposes it collaboratively.
 - **You know the outcome, not the process.** You know what you want produced but don't want to prescribe how — the model captures your goal, constraints, quality criteria, and what the agent system needs to be good at, producing an outcome-driven definition that feeds into agent-oriented design.
+- **Compose** — you already have skills and/or sub-agents and know the workflow; the framework writes the orchestration prompt directly inside `/deconstruct` (no Workflow Definition, no Design Spec, no `/build` — the prompt is the artifact).
 
 For the first two paths, the model uses the **six-question framework** to break down each step:
 


### PR DESCRIPTION
## Summary

Adds a fourth entry point ("Compose") to the AI Workflow Framework's `/deconstruct` skill. Compose is the lean path for students who already have reusable building blocks (skills, sub-agents, or both) and a clear workflow — three turns, no Workflow Definition file, no `/design` invocation, an orchestration prompt as the only artifact.

## What's changed

- `.claude/skills/deconstruct/SKILL.md` — option (d) Compose + three-turn flow inline
- `.claude/skills/design/SKILL.md` — description note that Compose bypasses it
- `src/content/docs/ai-workflow-framework/deconstruct/index.md` — new Compose section with when-to-use table and a Weekly Competitive Intelligence Digest worked example
- `src/content/docs/ai-workflow-framework/index.md` — Compose added to entry-point list
- `src/content/docs/ai-workflow-framework/design.md` — callout noting Compose bypasses `/design`
- `plugins/handsonai/.claude-plugin/plugin.json` — bumped 3.0.1 → 3.1.0

See the design spec in the business repo:
[docs/superpowers/specs/2026-05-16-compose-skills-entry-point-design.md](https://github.com/jamesgray-ai/business/blob/main/docs/superpowers/specs/2026-05-16-compose-skills-entry-point-design.md)

## Test plan

- [ ] Reload skills in Claude Code. Run \`/deconstruct\`, confirm 4 options.
- [ ] Pick option (d). Walk through the three-turn flow with the Weekly Competitive Intelligence example. Confirm the AI outputs an orchestration prompt with the standard frontmatter shape.
- [ ] Visit the deployed playbook site's Deconstruct page. Confirm the Compose section renders with the example.
- [ ] After merge, rebuild and redeploy the MCP server (npm run build:index && wrangler deploy in mcp-server/) so get_framework_step returns the four-option content.

## Release ops (post-merge)

1. Deploy playbook site (auto on merge to main, if configured)
2. Refresh MCP server content index
3. Cut a v3.1.0 GitHub release with notes (template in plan)
4. Optional: announce to course students / Substack

🤖 Generated with [Claude Code](https://claude.com/claude-code)