### PR TITLE
fix(use-cases): use neon for active primitive chip in both themes

### DIFF
--- a/src/components/UseCaseSearch.astro
+++ b/src/components/UseCaseSearch.astro
@@ -210,9 +210,12 @@ const total = useCases.length;
     border-color: var(--sl-color-accent);
   }
   .uc-filter-chip.is-active {
-    background: var(--sl-color-accent);
-    color: var(--sl-color-white);
-    border-color: var(--sl-color-accent);
+    background: #DDF222;
+    color: #1a1a18;
+    border-color: #DDF222;
+  }
+  .uc-filter-chip.is-active:hover {
+    border-color: #DDF222;
   }
   .use-case-list {
     list-style: none;


### PR DESCRIPTION
## Summary

- Active filter chip on `/use-cases/` used `var(--sl-color-accent)` which resolves to `#282828` in light mode — text became illegible (white-on-dark)
- Hardcode brand neon `#DDF222` background with `#1a1a18` text so the active state is readable and on-brand in both themes

## Test plan

- [x] `npm run build` passes
- [ ] Visual: toggle a primitive chip in light mode — should show neon with dark text
- [ ] Visual: same in dark mode — should look identical (neon doesn't change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)