### PR TITLE
fix(use-cases): exclude non-use-cases and style links to match site

### DIFF
--- a/src/components/UseCaseSearch.astro
+++ b/src/components/UseCaseSearch.astro
@@ -32,8 +32,15 @@ const isFlatUseCase = (entry: { id: string }) => {
 const isPublished = (entry: { data: { status?: string } }) =>
   entry.data.status !== 'draft';
 
+// Real worked use cases carry a `primitives` array in frontmatter.
+// This excludes the primitive landing pages, example-gallery, and any
+// other non-use-case content that happens to sit under /use-cases/.
+const isUseCase = (entry: { data: { primitives?: string[] } }) =>
+  Array.isArray(entry.data.primitives) && entry.data.primitives.length > 0;
+
 const useCases = allDocs
   .filter(isFlatUseCase)
+  .filter(isUseCase)
   .filter(isPublished)
   .sort((a, b) => {
     const aTime = a.data.published instanceof Date ? a.data.published.getTime() : 0;
@@ -235,6 +242,23 @@ const total = useCases.length;
   }
   .uc-row a {
     font-size: 1.05rem;
+    color: var(--sl-color-text-accent);
+    text-decoration: underline;
+    text-decoration-color: var(--sl-color-gray-4);
+    text-underline-offset: 2px;
+    transition: text-decoration-color 0.15s ease, background-color 0.15s ease;
+  }
+  .uc-row a:hover {
+    text-decoration-color: currentColor;
+  }
+  .uc-empty a {
+    color: var(--sl-color-text-accent);
+    text-decoration: underline;
+    text-decoration-color: var(--sl-color-gray-4);
+    text-underline-offset: 2px;
+  }
+  .uc-empty a:hover {
+    text-decoration-color: currentColor;
   }
   .uc-chips {
     display: inline-flex;


### PR DESCRIPTION
## Summary

Two issues on the new `/use-cases/` hub, both visible in light mode:

1. **Primitive landing pages + example-gallery appeared in the list as if they were worked use cases.** Astro treats `<primitive>/index.mdx` IDs the same as flat files, defeating the length-2 filter. Fixed by requiring a `primitives` array in frontmatter — only real use cases carry it.
2. **Links rendered default browser blue.** The `not-content` class strips Starlight's prose link styling. Added explicit `var(--sl-color-text-accent)` color + underline-on-hover to match `.sl-markdown-content a`.

## Test plan

- [x] `npm run build` reports "1 use cases" (only agentic-coding)
- [x] Rendered HTML contains exactly one `uc-item` in the list
- [ ] Visual: light mode — agentic-coding link is dark charcoal underline, not blue
- [ ] Visual: dark mode — link is neon
- [ ] Empty-state CTA link to Deconstruct also styled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)