### PR TITLE
refactor(framework): reshape Deconstruct as PRD, restructure Design Spec

### DIFF
--- a/.claude/agents/framework-agent.md
+++ b/.claude/agents/framework-agent.md
@@ -24,8 +24,8 @@ You run seven skills sequentially, using files as handoffs between stages. Steps
 | Step | Skill | Input | Output | Handoff |
 |------|-------|-------|--------|---------|
 | 1 (Analyze) | `analyze` | User interview | `ai-opportunity-report.md` | User picks candidate |
-| 2 (Deconstruct) | `deconstruct` | Candidate + interview | `[name]-definition.md` | Auto→Step 3 |
-| 3 (Design) | `design` | Workflow Definition | `[name]-design-spec.md` | Explicit approval gate |
+| 2 (Deconstruct) | `deconstruct` | Candidate + interview | `[name]-requirements.md` | Auto→Step 3 |
+| 3 (Design) | `design` | Workflow Requirements | `[name]-design-spec.md` | Explicit approval gate |
 | 4 (Build) | `build` | Approved spec | Platform artifacts | Auto→Step 5 |
 | 5 (Test) | `test` | Artifacts + spec | `[name]-test-results.md` | Ready OR loop to Build |
 | 6 (Run) | `run` | Tested artifacts + spec | `[name]-run-guide.md` | User follows guide |
@@ -49,14 +49,14 @@ During context probing, push beyond vague answers — identify the specific arti
 
 After naming is confirmed, register the workflow to the Notion Workflows database if the Notion MCP server is available. Use the confirmed metadata (name, description, outcome, trigger, type) with Status = "Under Development."
 
-**Produces:** `outputs/[name]-definition.md`
+**Produces:** `outputs/[name]-requirements.md`
 
-After the Workflow Definition is complete, tell the user you're moving to Step 3 and proceed automatically.
+After the Workflow Requirements is complete, tell the user you're moving to Step 3 and proceed automatically.
 
 ### Step 3 — Design
 **Skill:** `design`
 
-Read the Workflow Definition and run the Design phase:
+Read the Workflow Requirements and run the Design phase:
 1. Prompt the user to enter plan mode for collaborative design
 2. Gather architecture decisions (platform, tools, trigger)
 3. Assess workflow autonomy level (Deterministic → Guided → Autonomous)
@@ -64,11 +64,11 @@ Read the Workflow Definition and run the Design phase:
 5. Classify each step on the autonomy spectrum and map to AI building blocks
 6. Identify skill candidates with generation-ready detail
 7. Configure agents (when the mechanism calls for them)
-8. Define Evaluation Criteria — test scenarios and scoring dimensions for Step 5
-9. Generate the Design Spec (with "Integration Research Needed" section — availability research is deferred to Build)
+8. Confirm Evaluation Inputs — Acceptance Criteria and Example Scenarios are sourced from the Workflow Requirements; verify they're complete but do not re-collect
+9. Generate the Design Spec (references the Workflow Requirements; does not duplicate it)
 10. **Spec Approval Gate** — present the spec for explicit user approval. Do NOT proceed to Build without approval. Loop if changes are requested. After approval, prompt the user to exit plan mode.
 
-**Reads:** `outputs/[name]-definition.md`
+**Reads:** `outputs/[name]-requirements.md`
 **Produces:** `outputs/[name]-design-spec.md`
 
 After the spec is approved, tell the user you're moving to Step 4 and proceed automatically.
@@ -92,9 +92,9 @@ After Build is complete, tell the user you're moving to Step 5 and proceed autom
 **Skill:** `test`
 
 Guide structured testing of the built workflow artifacts:
-1. Load the Design Spec (including Evaluation Criteria) and the built artifacts
+1. Load the Workflow Requirements (for Acceptance Criteria + Example Scenarios), the Design Spec, and the built artifacts
 2. Run a quick smoke test — one representative input, manual check
-3. Execute each test scenario from the Evaluation Criteria, scoring output on each dimension (1–5 scale)
+3. Execute each Example Scenario from the Workflow Requirements, scoring output against the Acceptance Criteria dimensions (1–5 scale)
 4. Test individual building blocks (skills, prompts) in isolation
 5. Establish baseline scores as the reference point for future regression testing in Step 7
 6. Diagnose issues — map each problem to the specific building block to adjust
@@ -168,7 +168,7 @@ After Steps 1–6 are complete, present a summary:
 >
 > **Step 2 — Deconstruct:**
 >
-> 2. **Workflow Definition** — `outputs/[name]-definition.md`
+> 2. **Workflow Requirements** — `outputs/[name]-requirements.md`
 >
 > **Step 3 — Design:**
 >

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -4,6 +4,7 @@ description: >
   This skill should be used when the user has an approved Design Spec and wants to
   build platform artifacts for their AI workflow. It offers a build path choice, researches
   integration availability, generates platform-appropriate artifacts (prompts, skills, agents, configs),
+  and writes them to the right locations for the user's platform.
   This is Step 4 (Build) of the AI Workflow Framework.
 user-invocable: true
 ---
@@ -20,13 +21,20 @@ Take an approved Design Spec and generate platform-appropriate artifacts: prompt
 
 Artifact generation begins only after the Design Spec has been approved in the Design phase.
 
-#### Step 1 — Load Design Spec
+#### Step 1 — Load Design Spec and Workflow Requirements
 
 Read the Design Spec from `outputs/[workflow-name]-design-spec.md`. If the user specifies a file path, use that. Otherwise, look for the most recent Design Spec in `outputs/`.
 
-Confirm you've loaded the spec by summarizing: workflow name, orchestration mechanism, involvement mode, number of steps, number of skill candidates, and number of agents.
+**Parse the frontmatter first.** The spec opens with YAML frontmatter containing: `workflow`, `requirements_file`, `spec_version`, `definition_type`, `mechanism`, `involvement`, `platform`, `platform_mode`, `packaging`, and `counts`. Use these values to summarize the spec — no need to parse the body to get the headline numbers.
 
-Verify the spec contains an Architecture Decisions section and Integration Options section. If either is missing, inform the user: "This spec appears to predate the current format. Some sections are missing. I can either (a) proceed with what's available and ask questions as needed, or (b) you can regenerate the spec by running the Design skill again."
+**Also load the Workflow Requirements.** The Design Spec references the Workflow Requirements via its `requirements_file` frontmatter field (or the Source section if frontmatter is absent). Read that file too — it contains the per-step requirements, Context Inventory, Acceptance Criteria, Example Scenarios, and Human Gates that the Design Spec deliberately does NOT restate. Build needs both files together.
+
+Confirm you've loaded both by summarizing: workflow name, orchestration mechanism, involvement mode, packaging, counts (steps, skills, agents, integrations), and that the Workflow Requirements was loaded.
+
+**Spec version compatibility:**
+- `spec_version: 2.1` (current) → current format with three-layer grouping, Orchestrator Prompt Outline, and Self-Test Summary; proceed.
+- `spec_version: 2.0` → older format without layer grouping or Orchestrator Outline; proceed (Build's fallback derives the orchestrator from Workflow Requirements directly).
+- No frontmatter or older `spec_version` → spec predates the current format. Inform the user: "This spec is in an older format. Some fields (Packaging, Build Output column, Skill/Agent IDs, Deployment Plan, Orchestrator Prompt Outline) may be missing. I can either (a) proceed with what's available and ask questions as needed, or (b) you can regenerate the spec by running the Design skill again."
 
 #### Step 2 — Build Path Choice
 
@@ -193,7 +201,29 @@ If the Integration Options section is missing from the spec (older format), info
 
 #### Step 6 — Generate Platform Artifacts
 
-Based on the platform from Architecture Decisions. Resolve any deferred decisions now: ask about **shareability** (will team members run this?) to determine artifact format (file-based vs. code-based), and resolve the **specific platform offering** if not yet determined (e.g., Claude Code vs. Claude.ai, ADK vs. Gemini web). Infer **code comfort** from the specific offering (Claude Code = code-comfortable, ChatGPT = no-code).
+Based on the platform and packaging decisions from Architecture Decisions. Resolve the items in the spec's **Deferred to Build** section now:
+
+- **Specific platform offering** if not yet determined (e.g., "Claude" → Claude Code vs. Claude.ai vs. Cowork)
+- **Shareability** — file-based vs. code-based distribution; influences artifact format
+- **Exact model version per platform** — verify current model names via web search for the user's platform
+- **Integration setup specifics** — auth flow, region, plan tier per integration
+
+Use the spec's **Step-by-Step Decomposition Build Output column** (or **Capability Domain Mapping Build Output column** for outcome-driven) as your generation checklist. Each row tells you exactly what to produce:
+- `New skill: SN` → generate the skill defined in the matching Skill Candidates entry
+- `Use existing: [name]` → no generation needed; verify the skill exists and reference it
+- `New agent: AN` → generate the agent defined in the matching Agent Configuration entry
+- `Inline prompt → Workflow Requirements Step N` → fold this step's Goal/Inputs/Outputs/Rules from the Workflow Requirements into the main orchestrator prompt
+- `MCP server: [name]` → configure the connector using the Integration Options entry
+- `Human (no artifact)` → skip; no AI artifact for this step
+- `Handled by agent` (outcome-driven only) → no separate artifact; capability is covered by the agent's Instructions
+
+Apply the spec's **Packaging** decision to group the generated artifacts:
+- **Plugin** → assemble into a marketplace plugin directory structure (e.g., handsonai-plugins layout for Claude marketplace)
+- **Standalone Skill** → ship as a single uploadable artifact (zip for Claude.ai, single SKILL.md for code-mode platforms, single skill for ChatGPT)
+- **Workspace Agent** → bundle orchestration + skills + tools as a ChatGPT Workspace Agent (the current ChatGPT primitive; Custom GPTs are deprecated). Research current Workspace Agent creation flow via web search before generating.
+- **Loose Files** → write files to platform-appropriate paths; no distribution wrapper
+
+**When mechanism is `Prompt` or `Skill-Powered Prompt`:** read the spec's `Orchestrator Prompt Outline` section as the structural skeleton for the orchestrator prompt. The outline names which step invokes which skill, where PAUSE points sit, and what the user provides at each gate. Expand the outline into the full orchestrator prompt by pulling step content (Goal, Inputs, Outputs, Rules & Edge Cases) from the Workflow Requirements. If the section is absent (older spec or mechanism = Agent), fall back to deriving the orchestrator directly from Workflow Requirements Step Details + Human Gates.
 
 **a. Resolve platform documentation from the registry.** Use the platform doc URLs fetched in Platform Research (Step 3.6) from the registry's `platforms` section. These provide current, authoritative documentation for each building block's artifact format.
 
@@ -215,23 +245,29 @@ If playbook platform guides are available locally (e.g., `docs/platforms/claude/
 
   **If a creation skill was matched for this block type:**
 
-  1. Invoke it via the Skill tool, passing:
-     - The building block's full spec from the Design Spec (name, purpose, inputs, outputs, decision logic, failure modes, which workflow steps it covers)
+  1. Invoke it via the Skill tool, passing the building block's full spec from the Design Spec:
+     - **For skills (S1, S2, …):** all 12 fields from the Skill Candidates entry — ID, Name, Description, Purpose, Covers Steps/Domains, Inputs, Outputs, Decision Logic, Failure Modes, Required Tools, Depends On, Stateful?
+     - **For agents (A1, A2, …):** all 13 fields from the Agent Configuration entry — ID, Name, Description, Mission, Responsibilities, Output Format, Tone & Style, Constraints, Model, Memory Scope, Tools, Skills, Trigger Examples. If multi-agent, also pass the relevant Handoff Contracts and the Orchestration Pattern.
      - The artifact format requirements resolved in Step 3.6 (or the fallback reference if Step 3.6 did not resolve a format)
-     - Whether platform-specific extensions should be applied (based on Architecture Decisions)
-     - This context: "This building block comes from an approved Design Spec (AI Workflow Framework, Step 3 Design). The intent, inputs, outputs, decision logic, and failure modes are already defined. Use this as your starting context."
+     - Whether platform-specific extensions should be applied (based on Architecture Decisions and Packaging)
+     - This context: "This building block comes from an approved Design Spec (AI Workflow Framework, Step 3 Design). The intent, name, description, inputs, outputs, decision logic, and failure modes are already defined. Use this as your starting context."
   2. Let the creation skill run its full workflow. Do not skip or abbreviate any stage.
-  3. After completion, move to the next building block. Later blocks may reference earlier ones.
+  3. After completion, move to the next building block. Later blocks may reference earlier ones via their stable IDs.
 
   **If no creation skill was matched (inline generation):**
 
-  1. **For skills:** Use the artifact format from Step 3.6. If unavailable, fetch the agentskills.io specification (live from `https://agentskills.io/specification`, fallback to `references/skill-spec.md`). Generate the skill following that spec. Apply platform-specific extensions as documented for the target platform.
-  2. **For agents:** Use the artifact format from Step 3.6. If unavailable and on Claude Code, fall back to `references/agent-spec.md`. For other platforms, fall back to web search. Generate the agent following the resolved spec.
+  1. **For skills:** Use the artifact format from Step 3.6. If unavailable, fetch the agentskills.io specification (live from `https://agentskills.io/specification`, fallback to `references/skill-spec.md`). Generate the skill using the Skill Candidates entry — use the `Name` field as the directory name and the `Description` field verbatim in the SKILL.md frontmatter. Apply platform-specific extensions as documented for the target platform.
+  2. **For agents:** Use the artifact format from Step 3.6. If unavailable and on Claude Code, fall back to `references/agent-spec.md`. For other platforms, fall back to web search. Generate the agent using the Agent Configuration entry — use the `Name` as the filename, the `Description` field verbatim in the agent file frontmatter (and include the Trigger Examples as `<example>` blocks in the description), and the Mission, Responsibilities, Output Format, Tone & Style, and Constraints fields as the agent's system prompt body.
   3. **For other block types (MCP servers, hooks, commands, prompts):** Use the artifact format from Step 3.6. If unavailable, research the platform's current format via web search and generate accordingly.
 
 **f. Generate artifacts.** The skill provides the *specs* (what each building block should do, its inputs/outputs/instructions from the Design phase). The model provides the *implementation* (how to build it on the user's platform, using the verified specification and platform documentation as authoritative sources).
 
-After completing Build, tell the user: "To test the workflow, run the `test` skill (Step 5) (or say *'Test the workflow I built'*)."
+**g. Place and deploy each artifact per the Deployment Plan.** The Design Spec's Deployment Plan table specifies the target location and deployment steps for every artifact. For each generated artifact:
+1. Write the artifact to its target location from the Deployment Plan.
+2. Execute or document the deployment steps (e.g., "run `claude mcp add ...`", "upload zip via plugin marketplace", "create new GPT and paste instructions").
+3. If the target location requires user action (e.g., a manual GPT creation flow), produce a step-by-step guide tailored to the user's platform.
+
+After completing Build, summarize what was generated, where each artifact was placed, and any remaining manual deployment steps. Then tell the user: "To test the workflow, run the `test` skill (Step 5) (or say *'Test the workflow I built'*)."
 
 ## Outputs
 

--- a/.claude/skills/deconstruct/SKILL.md
+++ b/.claude/skills/deconstruct/SKILL.md
@@ -2,118 +2,51 @@
 name: deconstruct
 description: >
   This skill should be used when the user wants to deconstruct a workflow, break down a business
-  process, define an outcome for an agent system, or deeply analyze a workflow's steps, decisions,
-  data flows, and failure modes. Supports four entry paths: step-decomposed (6-question framework),
-  problem-first, outcome-driven (for autonomous agent systems), or Compose — a lean three-turn flow
-  that outputs an orchestration prompt directly when the user already has the skills/sub-agents in
-  place. The first three paths produce a structured Workflow Definition; Compose produces only an
-  orchestration prompt. This is Step 2 of the AI Workflow Framework.
+  process, capture requirements for an AI workflow, or define an outcome for an agent system.
+  Step 2 is the PRD for the workflow — it captures what the workflow must do, the rules it must
+  follow, and the edge cases it must handle, in clear requirements language suitable for the
+  Design step or any AI model to consume. Supports two paths: step-decomposed (you know how the
+  work gets done) and outcome-driven (you know what "done" looks like and want an agent system
+  to determine the path). Produces a structured Workflow Requirements document.
+  This is Step 2 of the AI Workflow Framework.
 user-invocable: true
 ---
 
 # Workflow Deconstruction
 
-Interactively discover a business workflow via one of four paths. The step-decomposed (6-question framework), problem-first, and outcome-driven paths all produce a structured Workflow Definition. The Compose path is the lean alternative: when the user already has the skills or sub-agents their workflow needs and can describe each step, Compose skips the deep dive and outputs an orchestration prompt directly in three turns — no Workflow Definition file.
+Step 2 is the **PRD for the workflow**. It captures *what* the workflow must do and the rules it must follow — not *how* AI building blocks will deliver it (that's Step 3, Design).
+
+The output is a **Workflow Requirements** document written in clear, concise requirements language. It must be self-contained enough that a reader who never saw this conversation — including the Design skill or any agent model — can act on it without re-interviewing the user.
+
+## The Two Paths
+
+Step 2 has **two paths**, mapped directly to the two ways students think about a workflow:
+
+| Path | When to use | Mental model |
+|------|-------------|--------------|
+| **Step-decomposed** | You can describe how the work gets done | "I know the steps" |
+| **Outcome-driven** | You know what "done" looks like but the path varies; you want an agent system to figure it out at runtime | "I know the outcome" |
+
+Both paths produce a Workflow Requirements document with the same shared shell — only the middle "what does the workflow do" block differs.
 
 ## Workflow
 
-1. **Scenario discovery** — Determine how the user is arriving and which path to take:
+1. **Scenario discovery** — Determine how the user is arriving and which path to take.
 
-   **From Analyze output**: If the user references an opportunity report, file path (e.g., `outputs/ai-opportunity-report.md`), or a specific workflow candidate from an Analyze session, read the Workflow Candidate Summary from the file. Present the available candidates and ask which one to deconstruct. Pre-populate scenario metadata (name, description, trigger, deliverable, autonomy, involvement) from the candidate fields. If the candidate includes a `Lens` field, carry it forward along with any `Business Objective`, `Stakeholders`, and `Success Metrics` fields. Confirm the pre-populated details with the user. Then choose the path: if the candidate's autonomy = Autonomous, suggest option (c) but still confirm. Otherwise present the three choices below.
+   **From Analyze output**: If the user references an opportunity report, file path (e.g., `outputs/ai-opportunity-report.md`), or a specific workflow candidate from an Analyze session, read the Workflow Candidate Summary from the file. Present the available candidates and ask which one to deconstruct. Pre-populate scenario metadata (name, description, trigger, deliverable, autonomy, involvement) from the candidate fields. If the candidate includes a `Lens` field, carry it forward along with any `Business Objective`, `Stakeholders`, and `Success Metrics` fields. Confirm the pre-populated details with the user. Then choose the path: if the candidate's autonomy = Autonomous, suggest outcome-driven but still confirm. Otherwise present the choice below.
 
-   **Cold entry (no Analyze output)**: Present three choices as the **first question**:
+   **Cold entry (no Analyze output)**: Ask one question:
 
-   > "How would you like to approach this?
-   > (a) **Deconstruct a known process** — You can describe the steps and I'll interview you to surface hidden details
-   > (b) **Start from a problem** — You know what's broken; I'll propose a workflow and we refine it together
-   > (c) **Define an outcome** — You know what you want produced but want an agent system to figure out the approach
-   > (d) **Compose** — You already have skills and/or sub-agents and know the workflow; I'll write the orchestration prompt directly"
+   > "Do you know the steps, or just the outcome?
+   > - **Step-decomposed** — You can describe how the work gets done. I'll interview you to refine the steps and surface decision rules and edge cases.
+   > - **Outcome-driven** — You know what "done" looks like but want an agent system to figure out the steps. I'll capture the outcome, inputs, acceptance criteria, and rules."
 
-   **After the user chooses, gather scenario details based on their path:**
-   - **Option (a)**: Ask about the business scenario, objective, high-level steps, and ownership. One question at a time. If no lens was established, determine it: individual tasks (one person's repetitive work) = Individual lens; multi-role or business-objective processes = Organizational lens. If not obvious from context, ask. Proceed to Step 2 (scope check) → Step 4 (deep dive with 6-question framework).
-   - **Option (b)**: Ask the user to describe what's broken. Propose a candidate workflow for them to react to. Then recommend whether step-decomposed or outcome-driven fits better, with reasoning. User confirms or overrides — honor their choice either way. If step-decomposed, proceed to Step 2 → Step 4. If outcome-driven, proceed to Step 2 → Step 4-OD.
-   - **Option (c)**: Ask the user to describe the outcome they want — what should the agent system produce, what triggers the need, and who consumes the output. One question at a time. Proceed to Step 2 (scope check) → Step 4-OD (outcome-driven interview).
-   - **Option (d) — Compose**: Proceed to the **Compose three-turn flow** (see Step 1c below). Do NOT call Step 2 (scope check) or Step 4 (deep dive); Compose handles its own lean intake inline and writes no Workflow Definition file.
+   **Problem-first handling (no separate path)**: If the user says they don't have a process *or* an outcome — just a problem ("People drop off during onboarding and I don't have a way to follow up") — propose a candidate workflow based on what they describe, then route into one of the two paths:
+   > "Here's a candidate workflow that would solve this: [outline]. Do you want to refine these steps with me (step-decomposed), or just describe the outcome and let an agent figure out the steps (outcome-driven)?"
 
-**Step 1c — Compose three-turn flow (only reached from Option d):**
-
-The Compose path is the **lean** path. No formal pre-flight, no Workflow Definition file, no `/design` invocation. The conversation captures what's needed, confirms it back, and outputs an orchestration prompt the student can run.
-
-**Turn 1 — Intake.** Ask the student for everything in one message:
-
-> "Tell me four things in one message:
-> 1. **Workflow name and outcome** — what does this workflow produce?
-> 2. **Where your components live** — Claude account (Claude.ai + Cowork), Claude Code, ChatGPT, or a mix?
-> 3. **The steps** — numbered, one line each.
-> 4. **Which component runs each step** — name and type (skill or sub-agent)."
-
-If the student answers Turn 1 incompletely, ask only for the missing pieces in Turn 2 — do not restart.
-
-**Turn 2 — Confirm + autonomy/involvement.** Restate what you heard in 5–8 lines: workflow name, hosting, steps, component-to-step mapping. Use ✓ when a component clearly fits its step; flag concerns inline (vague step, missing component, suspected mismatch) and ask for a quick fix.
-
-If the workflow looks more complex than the Compose path is built for — 8+ steps, no components for half the steps, "etc." in step descriptions, or 3+ decision points the student didn't surface — say so directly and offer to switch:
-
-> "This is more involved than the Compose path is built for — [specific reason]. The Known Process path (`/deconstruct` option a) will surface the gaps before they bite. Want to switch?"
-
-Then ask the two questions that actually shape the prompt:
-
-- *"Deterministic (fixed sequence, no AI judgment) or guided (the AI scores, evaluates, or adapts between steps)?"*
-- *"Augmented (AI pauses for your input at any point) or automated (runs straight through)?"*
-
-**Turn 3 — Output the orchestration prompt.** Generate the prompt in the standard shape below and return it as a code block the student can copy. Map the autonomy + involvement answers to one of four patterns:
-
-- **Deterministic, automated** — components fire in sequence, no pauses, no AI judgment.
-- **Deterministic, augmented** — same fixed sequence with a PAUSE for student review between named steps.
-- **Guided, augmented** — scoring/evaluation/adaptation between steps, with a PAUSE for steering.
-- **Guided, automated** — same decision logic, but the AI makes the bounded calls without pausing.
-
-**Standard output shape:**
-
-~~~markdown
----
-workflow: <Workflow Name>
-outcome: <one-sentence outcome>
-autonomy: deterministic | guided
-involvement: augmented | automated
-components:
-  - name: <name>
-    type: skill       # used in step 1
-  - name: <name>
-    type: sub-agent   # used in step 2
----
-
-# <Workflow Name>
-
-## Intent
-<one-paragraph "what this workflow does and when to run it">
-
-## Prompt
-<the orchestration prompt body>
-~~~
-
-**Prompt-body constraints — clarity, brevity, token efficiency:**
-
-- One instruction per line where possible. Imperative voice. No filler ("please", "kindly", "make sure to").
-- No re-explanation of what the components do — components have their own descriptions.
-- No preamble or commentary. Open with the first instruction, not "In this workflow, we will…".
-- PAUSE points are uppercase and unambiguous on their own line: `PAUSE — wait for me to confirm which insights to feature.`
-- Reuse the student's own wording for inputs, outputs, and decision criteria. Avoid synthesizing new jargon.
-- Inline tone or formatting guidance only when it changes the output (e.g., "narrative tone, not bullet-heavy"). Skip aesthetics.
-
-**Component verification, hosting-aware:**
-
-- **Claude Code (local files):** Read each named component's frontmatter (SKILL.md or agent file) under `.claude/skills/` and `.claude/agents/` (plus installed plugin caches). Confirm it exists, fits the step, and isn't an obvious mismatch. Mention an alternative only if you spot a clearly stronger match in the student's local inventory.
-- **Claude account, ChatGPT, or mix:** You cannot introspect. Trust the student's mapping. Ask for clarification only if a component name sounds wrong for the step it's assigned to. If the student doesn't remember a component's name, ask them to paste their available components from wherever they're hosted.
-
-**Saving the artifact:**
-
-Tell the student to save the orchestration prompt wherever they keep prompts:
-- Claude Code users: a `prompts/<workflow-name>.md` file in their project.
-- Everyone else: a Google Doc, Notion page, Claude account project file, ChatGPT saved prompt, or plain note.
-
-Do **not** write any file to `outputs/`. The Compose path produces conversation output only.
-
-**End of Compose flow.** Do not hand off to `/design`, `/build`, `/test`, or `/run`. The student tests the workflow by running the prompt.
+   **After the path is chosen, gather scenario details:**
+   - **Step-decomposed**: Ask about the business scenario, objective, high-level steps, and ownership. One question at a time. If no lens was established, determine it: individual tasks (one person's repetitive work) = Individual lens; multi-role or business-objective processes = Organizational lens. Ask only if not obvious from context. Proceed to Step 2 (scope check) → Step 4 (deep dive).
+   - **Outcome-driven**: Ask the user to describe the outcome — what should the agent system produce, what triggers the need, and who consumes the output. One question at a time. Proceed to Step 2 (scope check) → Step 4-OD (outcome-driven interview).
 
 2. **Scope check — one trigger, one deliverable** — A workflow has exactly one trigger (what kicks it off) and one deliverable (the tangible output). Test for multiple workflows by checking:
    - **Triggers**: Multiple independent starting points? (e.g., "when a lead comes in" vs. "end of each week") → separate workflows
@@ -121,11 +54,15 @@ Do **not** write any file to `outputs/`. The Compose path produces conversation 
    - **Timeframes**: Parts run on different schedules (daily vs. weekly), or significant waits between phases → likely separate workflows
    - **Step count**: Would this expand to 15+ refined steps? → may be multiple workflows
    - **Ownership boundary** (organizational lens): Does this process have a single accountable owner for the end-to-end outcome? If different people own different segments with no single owner, it may be multiple workflows.
-   If multiple workflows are detected: map out each one (working name, trigger, deliverable), present the breakdown, confirm boundaries with the user, and ask which to deconstruct first. Proceed with only the chosen workflow.
-3. **Name the workflow** — Present 2-3 name options following naming conventions (2-4 word noun phrase, Title Case). Confirm name, description, outcome, trigger, and type.
-4. **Deep dive** — Before probing the first step, briefly frame what "context" means: "As we go through each step, I'll ask about the *context* it needs. Context is any data or information the step requires to do its job — that includes databases and spreadsheets, but also documents, transcripts, emails, style guides, SOPs, or even knowledge that currently lives in someone's head. If the step needs it, it's context."
 
-   Work through each step using the 6-question framework:
+   If multiple workflows are detected: map out each one (working name, trigger, deliverable), present the breakdown, confirm boundaries with the user, and ask which to deconstruct first. Proceed with only the chosen workflow.
+
+3. **Name the workflow** — Present 2-3 name options following naming conventions (2-4 word noun phrase, Title Case). Confirm name, description, outcome, and trigger.
+
+4. **Deep dive (step-decomposed only)** — Before probing the first step, briefly frame what "context" means: "As we go through each step, I'll ask about the *context* it needs. Context is any data or information the step requires to do its job — that includes databases and spreadsheets, but also documents, transcripts, emails, style guides, SOPs, or even knowledge that currently lives in someone's head. If the step needs it, it's context."
+
+   Work through each step using the 6-question framework. These six dimensions are the **interview scaffold** — they shape what to ask, not how the spec is structured. Your job is to gather enough signal across all six to write the per-step requirements block (Goal / Inputs / Outputs / Rules & Edge Cases / Context Needed) in Step 10.
+
    - Discrete steps (is this actually multiple steps?)
    - Decision points (if/then branches, quality gates)
    - Data flows (inputs, outputs, sources, destinations)
@@ -137,10 +74,14 @@ Do **not** write any file to `outputs/`. The Compose path produces conversation 
      - Persistence: Does this context need to exist as a durable artifact that AI can access across workflow runs? If it's currently "in someone's head" or communicated verbally, flag that it needs to be externalized and stored somewhere AI-accessible.
      - Reorganization signal: If access, interpretability, or persistence is limited, flag that the context may need to be made more accessible or better organized — note this as a consideration for the Design step.
    - Role transitions (organizational lens with multiple stakeholders only) — Who performs this step? Does ownership change between steps? Are there handoff points?
+
    When probing context needs, push beyond vague answers — identify the specific artifact. For any step where AI is already being used, ask specifically for existing prompt instructions, project instructions, or system prompts — these contain workflow logic that must be included in the Baseline Prompt.
-5. **Propose and react** — After the first step of the deep dive, switch to propose-and-react: propose a hypothesis across all dimensions (including context readiness and role transitions for organizational workflows) and ask "What's right, what's wrong, what am I missing?" instead of asking each question individually. Include a context readiness hypothesis: "I think this context lives in [location] and is in [format] which AI can interpret. Is that right?"
-6. **Map sequence** — After all steps, identify sequential vs. parallel steps and the critical path.
-7. **Optimize for AI** (step-decomposed path only) — Now that the full process is mapped, step back and challenge it. The user described their *current* process — but an AI-powered version may not need every step. Present optimization recommendations for the user to react to. Look for:
+
+5. **Propose and react (step-decomposed only)** — After the first step of the deep dive, switch to propose-and-react: propose a hypothesis across all dimensions (including context readiness and role transitions for organizational workflows) and ask "What's right, what's wrong, what am I missing?" instead of asking each question individually. Include a context readiness hypothesis: "I think this context lives in [location] and is in [format] which AI can interpret. Is that right?"
+
+6. **Map sequence (step-decomposed only)** — After all steps, identify sequential vs. parallel steps and the critical path.
+
+7. **Optimize for AI (step-decomposed only)** — Now that the full process is mapped, step back and challenge it. The user described their *current* process — but an AI-powered version may not need every step. Present optimization recommendations for the user to react to. Look for:
    - **Eliminable steps** — Steps that exist only because a human was doing the work. Examples: manual data transfer between systems (an integration eliminates this), reformatting output from one step to match the input of the next (AI handles format natively), or "wait for X to be available" steps that become instant with API access.
    - **Collapsible steps** — Adjacent steps that AI can do in a single pass. Examples: separate "draft" and "format" steps, or "research" followed immediately by "summarize findings" — these are distinct for humans but one operation for AI.
    - **Parallelizable steps** — Steps that were sequential only because a human can do one thing at a time. If two steps have no data dependency, flag that AI can run them concurrently.
@@ -160,7 +101,7 @@ Do **not** write any file to `outputs/`. The Compose path produces conversation 
 
    Update the refined steps based on the user's confirmed optimizations. Renumber if steps were added, removed, or merged. If the user rejects all optimizations, that's fine — proceed with the original steps.
 
-8. **Validate the workflow** (step-decomposed path only) — Before consolidating context, walk through the refined workflow end-to-end and present a validation summary. This is the quality gate that catches gaps before the workflow moves to Design. Check for:
+8. **Validate the workflow (step-decomposed only)** — Before consolidating context, walk through the refined workflow end-to-end and present a validation summary. This is the quality gate that catches gaps before the workflow moves to Design. Check for:
    - **Completeness** — Are there gaps in the end-to-end flow? Steps where an output doesn't connect to the next step's input?
    - **Logic gaps** — Decision points without clear criteria? Steps that assume information not produced by a prior step?
    - **Edge cases** — Scenarios the user hasn't mentioned (empty inputs, unexpected formats, partial data, exception paths)?
@@ -178,100 +119,206 @@ Do **not** write any file to `outputs/`. The Compose path produces conversation 
 
    Update refined steps based on the user's responses. If no issues are found, say so and proceed.
 
-9. **Consolidate context** — Present a rolled-up "context shopping list" of every piece of context the workflow needs — documents, data, rules, examples, and any other knowledge from the user's domain that the model doesn't have.
-10. **Generate Workflow Definition** — Produce the structured Workflow Definition and write it to the output file.
+9. **Consolidate context** — Present a rolled-up "context inventory" of every piece of context the workflow needs — documents, data, rules, examples, and any other knowledge from the user's domain that the model doesn't have.
+
+   For step-decomposed workflows: assemble from per-step context needs gathered in Step 4. For outcome-driven workflows: assemble from the Inputs + Context Sources gathered in Step 4-OD.
+
+10. **Collect Acceptance Criteria and Example Scenarios (both paths)** — Before generating the Workflow Requirements, ask the user about acceptance criteria and example scenarios. These were previously collected during Design's Step 8b; capturing them here makes Step 2 a complete PRD and removes redundant questioning downstream.
+
+    Ask, one at a time:
+    1. "What does great output from this workflow look like? Describe what would make you say 'this is exactly right.'"
+    2. "Which dimensions matter most? For example: accuracy, completeness, tone, specificity, timeliness, format consistency."
+    3. "What's your minimum bar — what's acceptable vs. what needs more work?"
+    4. "Give me 3-5 real or realistic scenarios you'd run this on — different enough to test the workflow's range. For each, briefly describe the input and what you'd look for in the output."
+
+    For outcome-driven workflows, these answers also inform the Acceptance Criteria built up in Step 4-OD — fold them together rather than asking twice.
+
+11. **Generate Workflow Requirements** — Produce the structured Workflow Requirements document and write it to the output file. See the **Output** section below for the template, writing style, and machine-readability rules.
 
 ### Outcome-Driven Path (Step 4-OD)
 
-When the user selects option (c) or the problem-first funnel recommends outcome-driven, run this interview instead of the step-decomposed deep dive (Steps 4–9). The outcome-driven path handles context discovery internally (question 7), so it skips straight to Generate Workflow Definition (Step 10) after the interview. Same interview principles apply: one question at a time, propose-and-react after the first few answers, push beyond vague answers.
+When the user selects outcome-driven, run this interview instead of the step-decomposed deep dive (Steps 4–8). The outcome-driven path handles context discovery internally (question 7), so it skips straight to Step 9 (Consolidate Context) → Step 10 (Acceptance Criteria) → Step 11 (Generate) after the interview. Same interview principles apply: one question at a time, propose-and-react after the first few answers, push beyond vague answers.
 
-1. **Goal**: "What does a successful run produce? Describe the deliverable."
+1. **Outcome**: "What does a successful run produce? Describe the deliverable — format, structure, scope."
 2. **Inputs**: "What does the agent system receive to start? What triggers the work, and what materials does it have access to?"
-3. **Expected outputs**: "What format, structure, and detail level does the deliverable need? Describe or show what 'good' looks like."
-4. **Constraints**: "What boundaries or guardrails apply? Things the agent must always do, must never do, or limits on scope, sources, tone, length."
-5. **Quality criteria**: "How will you evaluate whether the output is good vs. bad? What dimensions matter — accuracy, completeness, tone, specificity, timeliness?" (These feed directly into the Test step.)
-6. **Capability domains**: "What does the agent system need to be good at? Not steps, but kinds of work — research, analysis, writing, data extraction, etc." After the first few answers, propose candidate domains from the goal/constraints and ask: "What's right, what's wrong, what am I missing?"
-7. **Tools and context sources**: "What external systems, data sources, documents, or reference materials should the agent system have access to?" Apply the same context readiness probing as the step-decomposed path:
+3. **Acceptance signals**: "What does the deliverable need to demonstrate to be considered 'good'? Examples or anti-examples are great here." (This feeds the Acceptance Criteria; Step 10 will sharpen it further.)
+4. **Rules & Constraints**: "What boundaries or guardrails apply? Things the agent must always do, must never do, or limits on scope, sources, tone, length."
+5. **Context & Data Sources**: "What external systems, data sources, documents, or reference materials should the agent system have access to?" Apply the same context readiness probing as the step-decomposed path:
    - Access: Where does this context live today? Is it in a system with programmatic access (database, cloud app, shared drive), or does it require manual steps (logging in, copy-pasting, reading from a screen)?
    - Interpretability: Is the context in a format AI can process?
    - Persistence: Does this context need to exist as a durable artifact that AI can access across workflow runs?
-8. **Human gates**: "Where should the agent system pause for human review? Or run end-to-end with final review only?"
-9. **Scope check**: Same one-trigger-one-deliverable test as Step 2 — confirm the outcome hasn't expanded into multiple workflows.
+6. **Human gates**: "Where should the agent system pause for human review? Or run end-to-end with final review only?"
+7. **Scope check**: Same one-trigger-one-deliverable test as Step 2 — confirm the outcome hasn't expanded into multiple workflows.
 
-After completing the interview, proceed directly to **Generate Workflow Definition** (Step 10) using the outcome-driven output format.
+**Do NOT ask about capability domains, agent count, model class, tools, or orchestration approach.** Those are Design decisions. Outcome-driven Deconstruct stays in "what" territory: outcome, inputs, acceptance criteria, rules, context, human gates.
+
+After completing the interview, proceed directly to Step 9 (Consolidate Context) → Step 10 (Acceptance Criteria) → Step 11 (Generate Workflow Requirements) using the outcome-driven output format.
 
 ## Output
 
-Write the Workflow Definition to `outputs/[workflow-name]-definition.md` where `[workflow-name]` is the kebab-case workflow name (e.g., `lead-qualification`).
+Write the Workflow Requirements to `outputs/[workflow-name]-requirements.md` where `[workflow-name]` is the kebab-case workflow name (e.g., `lead-qualification` → `outputs/lead-qualification-requirements.md`).
 
-The Workflow Definition uses a shared header with conditional sections depending on the definition type.
+### Writing-style rules (MUST follow)
 
-### Scenario Metadata (both formats)
-- Workflow name, description, outcome, trigger, type, business objective, current owner(s), lens (Individual/Organizational)
-- **Definition Type**: `Step-Decomposed` or `Outcome-Driven`
-- For organizational lens: stakeholders (roles/teams involved), success metrics (KPIs for measuring improvement)
+The output reads like a PRD, not an interview transcript. Enforce:
 
-### Step-Decomposed Sections (when Definition Type = Step-Decomposed)
+- **Requirements voice.** Every bullet is a statement of what must be true, not a description of what the user said. Prefer "The step accepts a list of prospect URLs" or "Output is a Markdown table with one row per prospect" over "The user mentioned they usually have a list of URLs."
+- **Active voice. Present tense.** "Validate the input against the rubric" — not "The input will then be validated."
+- **One requirement per line.** Use bulleted lists, not paragraphs, anywhere multiple discrete requirements appear.
+- **Concrete over abstract.** Name the artifact, the field, the threshold. "Reject submissions over 500 words" — not "Filter out long submissions."
+- **No interview residue.** Drop hedges ("I think", "sometimes", "usually"), narrative connectors ("then the user", "after that"), and meta-commentary about the conversation ("we discussed", "you mentioned").
+- **Self-contained.** A reader who never saw the deconstruct conversation can implement against the document.
 
-#### Refined Steps
-For each step: number, name, action, sub-steps, decision points, data in/out, context needs, failure modes
+### Machine-readability rules (MUST follow)
 
-#### Optimization Summary (produced by Step 7 — Optimize for AI; included if any optimizations were applied)
-Brief record of what changed from the original process and why:
-- Steps eliminated, collapsed, parallelized, or added
-- Rationale for each change
-- Any optimizations the user declined and why (preserves the reasoning for Design)
+So Design (and any agent model) can parse the document without re-asking:
 
-#### Step Sequence and Dependencies
-- Sequential steps, parallel steps, critical path, dependency map
-- Role swimlane (organizational lens with multiple roles) — a view showing which role owns each step
+- **Fixed section headings**, in fixed order — use the exact headings in the template; no synonyms, no reordering.
+- **Tables for any list of items with shared fields** (steps, context artifacts, example scenarios) — not prose.
+- **Canonical vocabulary** for enumerated values:
+  - Definition Type: `Step-Decomposed` or `Outcome-Driven`
+  - Lens: `Individual` or `Organizational`
+  - Context Status: `Exists` or `Needs Creation`
+  - AI Accessible: `Yes`, `Partial`, or `No`
+- **Stable IDs** — number steps `1, 2, 3, …`; ID context items `C1, C2, C3, …`; ID example scenarios `E1, E2, E3, …`. Downstream artifacts reference these IDs.
+- **Explicit Inputs and Outputs per step** — even when "obvious." Design uses these to build the data-flow without guessing.
 
-#### Context Shopping List
-For each artifact: name, description, used by steps, status (Exists/Needs Creation), key contents, AI Accessible? (Yes/Partial/No), readiness notes
+### Template — shared shell
 
-For items with `Status: Needs Creation`, the readiness notes should also capture where the artifact should be persisted — not just that it needs to be created, but that it needs a home AI can reach.
+```markdown
+# [Workflow Name] — Workflow Requirements
 
-For organizational workflows, also prompt for existing process documentation: SOPs, training guides, compliance requirements, SLAs.
+## Outcome
+[One paragraph: what a successful run produces, when it runs, who consumes the output.]
 
-### Outcome-Driven Sections (when Definition Type = Outcome-Driven)
+## Metadata
 
-#### Goal
-What a successful run produces — the deliverable described concretely.
+| Field | Value |
+|---|---|
+| Workflow Name | [name] |
+| Description | [short description] |
+| Trigger | [what kicks the workflow off] |
+| Owner | [person or role] |
+| Lens | Individual / Organizational |
+| Definition Type | Step-Decomposed / Outcome-Driven |
+| Business Objective | [why this workflow matters — optional but recommended] |
 
-#### Inputs
-What the agent system receives to start — trigger, data, materials.
+For organizational lens, also include:
+| Stakeholders | [roles/teams involved] |
+| Success Metrics | [KPIs for measuring improvement] |
 
-#### Expected Outputs
-Format, structure, quality expectations, and an example of what "good" looks like.
+---
 
-#### Constraints
-Boundaries, guardrails, must-do / must-not-do rules.
+[INSERT THE STEP-DECOMPOSED BLOCK OR THE OUTCOME-DRIVEN BLOCK HERE — see below]
 
-#### Quality Criteria
-Evaluation dimensions, what good vs. bad looks like, minimum bar. These feed directly into Step 5 (Test).
+---
 
-#### Capability Domains
-Table with columns: Domain Name, Description, Associated Tools/Data. Each domain represents a kind of work the agent system needs to be good at (e.g., research, analysis, writing, data extraction).
+## Context Inventory
 
-#### Tools and Context Sources
-External systems, reference materials, with context readiness assessment for each:
-- Access (direct AI access vs. human intervention needed)
-- Interpretability (structured / semi-structured / unstructured)
-- Persistence (durable artifact vs. needs externalization)
+| ID | Artifact | Used By | Status | AI Accessible | Location / Source | Key Contents |
+|---|---|---|---|---|---|---|
+| C1 | [name] | [Step IDs or "All"] | Exists / Needs Creation | Yes / Partial / No | [path, URL, system name, or "Create as [path]"] | [what's in it] |
 
-#### Human Gates
-Where human review is expected — checkpoints during execution, or final review only.
+Notes:
+- For items with `Status: Needs Creation`, the Location column captures where the artifact should be persisted — AI must be able to reach it.
+- For organizational workflows, include existing process documentation here: SOPs, training guides, compliance requirements, SLAs.
+
+## Acceptance Criteria
+
+### What good output looks like
+[Concrete description in plain language — what would make the user say "this is exactly right"?]
+
+### Dimensions that matter
+- [Dimension] — [what to evaluate]
+- [Dimension] — [what to evaluate]
+
+### Minimum bar
+[What's acceptable vs. what needs more work — in plain terms, not a numeric threshold.]
+
+## Example Scenarios
+
+| ID | Scenario | Input | What to look for in the output |
+|---|---|---|---|
+| E1 | [short name] | [description] | [what makes this output "good"] |
+| E2 | … | … | … |
+
+## Human Gates
+
+| Where | What requires human input |
+|---|---|
+| [step ID or phase] | [decision, approval, review] |
+
+If no human gates are required, write: "No human gates — the workflow runs end-to-end with final review only."
+
+## Optimization Notes (optional, step-decomposed only)
+[Brief record of what changed from the original process and why — only if optimizations were applied in Step 7. Include declined optimizations and the reasoning, since this preserves context for Design.]
+```
+
+### Step-Decomposed middle block
+
+Insert between the Metadata table and the Context Inventory:
+
+```markdown
+## Steps Overview
+
+1. [Step name] — [one-line summary]
+2. [Step name] — [one-line summary]
+3. …
+
+## Step Details
+
+### Step 1 — [Step Name]
+- **Goal:** [what this step achieves, one sentence]
+- **Inputs:** [data/context coming in — name the artifact or reference a Context Inventory ID]
+- **Outputs:** [what passes to the next step]
+- **Rules & Edge Cases:**
+  - [decision criterion or branch]
+  - [what to do when an input is missing, malformed, or empty]
+  - [quality threshold or exception path]
+- **Context Needed:** [list of Context Inventory IDs the step depends on, e.g., C1, C3]
+- **Role:** [who performs this step — organizational lens only]
+
+### Step 2 — [Step Name]
+… (same fields)
+
+## Sequence
+
+- **Sequential steps:** [list]
+- **Parallel steps:** [list with grouping, e.g., "Steps 2 and 3 run in parallel"]
+- **Critical path:** [longest dependency chain]
+- **Role swimlane** (organizational lens only): [brief view of which role owns each step]
+```
+
+### Outcome-Driven middle block
+
+Insert between the Metadata table and the Context Inventory (omit Steps Overview, Step Details, and Sequence — there is no fixed step sequence for outcome-driven workflows):
+
+```markdown
+## Inputs
+
+- [What the agent system receives to start — data, materials, references, access]
+- [One bullet per discrete input]
+
+## Rules & Constraints
+
+- **Must do:** [list]
+- **Must never do:** [list]
+- **Scope boundaries:** [what's in scope, what's out]
+- **Tone / format / length:** [if applicable]
+- **Source restrictions:** [if applicable]
+```
+
+The Outcome, Metadata, Context Inventory, Acceptance Criteria, Example Scenarios, and Human Gates sections from the shared shell still apply — outcome-driven uses the same shell, just a different middle.
 
 ## Guidelines
 
-- Ask one question at a time — never present a wall of questions
-- Probe for missing steps — most people undercount by 30-50%
-- Surface hidden assumptions ("How do you decide when X is good enough?")
-- Use plain language; avoid jargon unless the user introduced it
-- Push beyond vague context answers like "domain knowledge" — identify the specific artifact
+- Ask one question at a time — never present a wall of questions.
+- Probe for missing steps — most people undercount by 30-50%.
+- Surface hidden assumptions ("How do you decide when X is good enough?").
+- Use plain language; avoid jargon unless the user introduced it.
+- Push beyond vague context answers like "domain knowledge" — identify the specific artifact.
 - Surface the assumption that existing context — data, documents, transcripts, reference materials — will "just work" for AI. Most people underestimate the work required to make context AI-accessible, especially unstructured content like SOPs, style guides, meeting transcripts, and knowledge that lives in people's heads. Adopt a data strategist lens — help the user see where context reorganization, reformatting, or externalization is needed before they commit to a workflow design that depends on inaccessible context. Push beyond "it's in the CRM" or "I just know it" — ask what system it's in, what format it's in, and whether there's programmatic access or it requires manual steps. Leave specific integration mechanisms (MCP, API, SDK) to the Design step.
-- Stay in the "what" lane. Deconstruct defines the workflow, its context needs, and its failure modes. It does not prescribe how AI will access data, which tools to use, or what integrations to build — those are Design decisions (Step 3). If a technology concern surfaces, note it as a consideration for Design rather than resolving it here.
-- After writing the Workflow Definition file, tell the user: "Workflow Definition saved to `outputs/[name]-definition.md`. Ready for the `design` skill (Step 3)."
+- **Stay in the "what" lane.** Deconstruct defines the workflow, its context needs, its rules, and its acceptance criteria. It does not prescribe how AI will access data, which tools to use, what integrations to build, how many agents are needed, or which models to use — those are Design decisions (Step 3). Do not ask the user about capability domains, agent architecture, model class, or orchestration mechanism. If a technology concern surfaces, note it as a consideration for Design rather than resolving it here.
+- After writing the Workflow Requirements file, tell the user: "Workflow Requirements saved to `outputs/[name]-requirements.md`. Ready for the `design` skill (Step 3)."
 - If entering deconstruction without a prior analysis (direct workflow description), determine the lens by asking if not obvious from context.
-- For outcome-driven definitions, do not force step decomposition — the whole point is to capture what the agent system needs to know without prescribing execution steps.
-- When the problem-first funnel (option b) recommends outcome-driven, explain why: "This looks like a workflow where the agent system should determine its own approach. I'd recommend the outcome-driven path because [reasoning]."
+- For outcome-driven workflows, do not force step decomposition — the whole point is to capture what the agent system needs to know without prescribing execution steps.

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -1,19 +1,20 @@
 ---
 name: design
 description: >
-  This skill should be used when the user has a Workflow Definition and wants to design
+  This skill should be used when the user has a Workflow Requirements document and wants to design
   an AI workflow. It gathers architecture decisions, assesses workflow autonomy level,
   chooses an orchestration mechanism and involvement mode, classifies steps, maps building blocks,
   identifies skill candidates, configures agents, and produces a Design Spec for approval.
-  Supports both step-decomposed and outcome-driven Workflow Definitions.
+  Supports both step-decomposed and outcome-driven Workflow Requirements.
   This is Step 3 (Design) of the AI Workflow Framework.
-  Note: the Compose entry point in /deconstruct (option d) handles its own lightweight design inline and bypasses this skill.
 user-invocable: true
 ---
 
 # Workflow Design
 
-Take a Workflow Definition and produce the Design deliverable: a Design Spec that captures architecture decisions, autonomy assessment, orchestration mechanism, per-step classifications (step-decomposed) or capability domain mapping (outcome-driven), skill candidates, and agent blueprints.
+Take a Workflow Requirements document (produced by Step 2 — Deconstruct) and produce the Design deliverable: a Design Spec that captures architecture decisions, autonomy assessment, orchestration mechanism, per-step classifications (step-decomposed) or capability domain mapping (outcome-driven), skill candidates, and agent blueprints.
+
+**Source of truth:** The Workflow Requirements document is canonical. The Design Spec must NOT restate sections that already exist there (Outcome, Metadata, Context Inventory, Acceptance Criteria, Example Scenarios, Human Gates, Steps Overview). Instead, reference the Workflow Requirements file. The Design Spec adds *only* what Design produces: architecture decisions, per-step or per-domain building-block classifications, skill candidates, agent configurations, integration options, model recommendations, and implementation order.
 
 **Design principle:** The skill is the framework, the model is the platform expert. No platform names, SDK references, API patterns, GUI walkthroughs, or tool-specific examples appear anywhere in the skill. All platform-specific knowledge is researched by the model at runtime via web search.
 
@@ -29,25 +30,25 @@ The Design phase is collaborative — you plan the architecture together with th
 
 This is directive, not optional — plan mode is the preferred path for design collaboration.
 
-#### Step 1 — Load Workflow Definition
+#### Step 1 — Load Workflow Requirements
 
-Read the Workflow Definition from `outputs/[workflow-name]-definition.md`. If the user specifies a file path, use that. Otherwise, look for the most recent Workflow Definition in `outputs/`.
+Read the Workflow Requirements from `outputs/[workflow-name]-requirements.md`. If the user specifies a file path, use that. Otherwise, look for the most recent Workflow Requirements in `outputs/`.
 
-Read the `Definition Type` field from the Scenario Metadata. If `Outcome-Driven`, use the outcome-driven processing path for all subsequent steps (see **Outcome-Driven Processing Path** below). If `Step-Decomposed` (or no Definition Type field is present), use the standard step-decomposed path.
+Read the `Definition Type` field from the Metadata table. If `Outcome-Driven`, use the outcome-driven processing path for all subsequent steps (see **Outcome-Driven Processing Path** below). If `Step-Decomposed` (or no Definition Type field is present), use the standard step-decomposed path.
 
 #### Step 2 — Confirm Understanding
 
-For step-decomposed definitions: Summarize the workflow name, step count, and outcome. Ask the user to confirm before proceeding.
+For step-decomposed requirements: Summarize the workflow name, step count, and outcome (from the Outcome section of the Workflow Requirements). Ask the user to confirm before proceeding.
 
-For outcome-driven definitions: Summarize the workflow name, goal, capability domains, and constraints. Ask the user to confirm before proceeding.
+For outcome-driven requirements: Summarize the workflow name, outcome, and the headline rules and constraints (from the Outcome and Rules & Constraints sections). Ask the user to confirm before proceeding.
 
 #### Step 3 — Architecture Decisions
 
-Before assessing autonomy and orchestration, gather the information needed to make platform-aware recommendations. The approach: **one question, then extract everything else from the Workflow Definition.**
+Before assessing autonomy and orchestration, gather the information needed to make platform-aware recommendations. The approach: **one question, then extract everything else from the Workflow Requirements.**
 
 **a. One question: Platform**
 
-Platform is the only thing not already in the Workflow Definition. Determine the user's AI platform:
+Platform is the only thing not already in the Workflow Requirements. Determine the user's AI platform:
 - If stated in conversation or definition, confirm: "You mentioned [platform] — is that still correct?"
 - If not stated, ask. Let the user name their tool — do not present a fixed list.
 
@@ -56,15 +57,15 @@ Accept whatever level of specificity the user provides — "Claude Code", "Googl
 - **For Orchestration Mechanism:** The recommendation is driven by workflow characteristics first (tool use? autonomous decisions? multiple domains?). If the recommended mechanism requires capabilities the named platform might or might not support (e.g., recommending an agent when "Google Gemini" could mean the web app or ADK), ask a **motivated follow-up** in context.
 - **For Build:** The specific offering (Claude Code vs. Claude.ai, ADK vs. Gemini web) is resolved when generating artifacts in the Build phase — not during Design.
 
-**b. Extract everything else from the Workflow Definition**
+**b. Extract everything else from the Workflow Requirements**
 
-After confirming the platform, read the Workflow Definition and extract:
+After confirming the platform, read the Workflow Requirements and extract:
 
-- **Tool integrations** — from Data In, Context Needed, and Context Shopping List across all steps. Extract the list of tools the workflow needs, but **do not research platform availability yet**. That happens in Build. Simply list the tools identified.
+- **Tool integrations** — from per-step Inputs, Context Needed, and the Context Inventory. Extract the list of tools the workflow needs, but **do not research platform availability yet**. That happens in Build. Simply list the tools identified.
 
-- **Trigger/schedule** — from Scenario Metadata. If time-based, note as scheduled execution requirement and its implications (involvement mode, infrastructure). If manual, no action needed.
+- **Trigger/schedule** — from the Metadata table. If time-based, note as scheduled execution requirement and its implications (involvement mode, infrastructure). If manual, no action needed.
 
-- **Context readiness flags** — from the Context Shopping List's AI Accessible? and Readiness Notes columns. Summarize items flagged as "Partial" or "No" — these may be structured data, but also documents, transcripts, or reference materials that aren't AI-accessible. These inform step classification — a step that depends on inaccessible context may need:
+- **Context readiness flags** — from the Context Inventory's `AI Accessible` column. Summarize items flagged as `Partial` or `No` — these may be structured data, but also documents, transcripts, or reference materials that aren't AI-accessible. These inform step classification — a step that depends on inaccessible context may need:
   - A prerequisite human step prepended (e.g., "Export CRM data to CSV")
   - A different autonomy classification (Autonomous → Guided or Human, because a human must bridge the context gap)
   - An integration research priority flag for the Build phase (this tool connection is critical, not just nice-to-have)
@@ -77,7 +78,7 @@ After confirming the platform, read the Workflow Definition and extract:
 
 Present a single confirmation block:
 
-> "Here's what I found in your Workflow Definition:
+> "Here's what I found in your Workflow Requirements:
 > - **Platform:** [confirmed platform]
 > - **Tools needed:** [extracted list]
 > - **Trigger:** [extracted trigger] → [implications for involvement mode]
@@ -94,6 +95,8 @@ Present a single confirmation block:
 - Scheduled trigger + platform doesn't support unattended runs → flag infrastructure needed
 - State which extracted facts influenced the autonomy assessment and orchestration mechanism recommendation
 
+**Packaging is determined later, in Step 5.** Once the mechanism is selected, Step 5 proposes a Packaging value based on platform and mechanism (e.g., single skill → Standalone Skill; agent + skills on ChatGPT → Workspace Agent). Do not ask about Packaging during Step 3 — it depends on Step 5's mechanism decision.
+
 #### Step 4 — Autonomy Assessment
 
 Before choosing an orchestration mechanism, assess where the *whole workflow* sits on the autonomy spectrum. This is the same spectrum used for per-step classification (Step 6), applied at the workflow level.
@@ -107,6 +110,7 @@ Human ———— Deterministic ———————— Guided —————
 
 | Level | Signals | Orchestration implications |
 |-------|---------|--------------------------|
+| **Human** | Step requires human judgment, creativity, or physical action; AI cannot perform | No AI artifact — captured as Human step in the Decomposition table |
 | **Deterministic** | Steps always execute in the same order, no branching on output quality, failure = stop or retry same step | Prompt or skill-powered prompt likely sufficient |
 | **Guided** | Some steps involve bounded AI judgment, human steers at checkpoints, sequence is mostly fixed but with bounded flexibility | Skill-powered prompt or agent |
 | **Autonomous** | Executor backtracks, re-invokes based on feedback, adjusts approach on failure, human checkpoints can redirect flow | Agent required |
@@ -140,12 +144,15 @@ Single-agent vs. multi-agent is an architecture detail decided during Agent Conf
 
 Ask the user to confirm the mechanism, involvement mode, and platform sub-choice (if applicable).
 
-**Fast-track for complete definitions:** If the Workflow Definition + conversation context provide enough information to resolve ALL architecture dimensions, the autonomy level, AND the orchestration mechanism, present the entire Design analysis as a single confirmation block instead of stepping through questions one at a time.
+**Fast-track for complete Workflow Requirements:** If the Workflow Requirements + conversation context provide enough information to resolve ALL architecture dimensions, the autonomy level, AND the orchestration mechanism, present the entire Design analysis as a single confirmation block instead of stepping through questions one at a time.
 
-For step-decomposed definitions:
+**Packaging decision:** Before the Layer 1 confirmation, propose a Packaging value based on the platform and the workflow's shape (single skill → Standalone Skill; multiple related artifacts → Plugin; ChatGPT with agent + skills → Workspace Agent; ad-hoc files → Loose Files). The user confirms or overrides.
+
+For step-decomposed workflows:
 
 > "Based on your workflow definition, here's my design analysis:
 > - **Platform:** [platform] ([surface])
+> - **Packaging:** [packaging value] — [reason]
 > - **Autonomy level:** [level] — [brief rationale]
 > - **Orchestration mechanism:** [mechanism] ([involvement mode])
 > - **Tools needed:** [list — availability to be researched during Build]
@@ -155,10 +162,11 @@ For step-decomposed definitions:
 >
 > Does this look right, or would you like to adjust anything?"
 
-For outcome-driven definitions:
+For outcome-driven workflows:
 
 > "Based on your outcome-driven workflow definition, here's my design analysis:
 > - **Platform:** [platform] ([surface])
+> - **Packaging:** [packaging value] — [reason]
 > - **Autonomy level:** Autonomous (by definition — agent determines its own execution path)
 > - **Orchestration mechanism:** Agent ([involvement mode])
 > - **Tools needed:** [list — availability to be researched during Build]
@@ -169,6 +177,20 @@ For outcome-driven definitions:
 > Does this look right, or would you like to adjust anything?"
 
 Only drop into the question-by-question flow when genuinely missing information.
+
+**Layer 1 confirmation moment** (after Step 5, before moving to Step 6):
+
+The architecture work is complete. Before classifying each step, confirm the L1 decisions are right — catching strategic errors before investing in L2/L3 work:
+
+> "Architecture confirmed:
+> - **Platform:** [platform] ([surface])
+> - **Mechanism:** [mechanism] ([involvement mode])
+> - **Autonomy:** [level]
+> - **Packaging:** [packaging value]
+>
+> Moving to Layer 2 — Decomposition. I'll classify each step and identify which building blocks deliver each one. Confirm to proceed, or push back on any of the above."
+
+If the user pushes back, revise the relevant L1 decisions and re-confirm before proceeding. This is a lightweight confirmation, not a hard gate — but it's the cheapest moment to catch architecture mistakes.
 
 #### Step 6 — Classify Each Step
 
@@ -214,7 +236,7 @@ Each row captures one step. The Orchestration column shows the block from that l
 
 Additionally, for each step record the **autonomy level** and **role** (these appear in the full spec output but are omitted from the compact table above for readability).
 
-If a step's inputs include items flagged as "No" or "Partial" in the Context Shopping List, note this in the classification. A step classified as Autonomous but dependent on inaccessible data should be flagged: "Autonomy contingent on resolving data access for [item]."
+If a step's inputs include items flagged as "No" or "Partial" in the Context Inventory, note this in the classification. A step classified as Autonomous but dependent on inaccessible data should be flagged: "Autonomy contingent on resolving data access for [item]."
 
 Present the mapping as a clear table. Walk through reasoning for non-obvious classifications. Ask if the user wants to adjust anything.
 
@@ -286,6 +308,21 @@ For outcome-driven: `**[Tool] access needed (Domains: X, Y):**`
 >
 > *Recommendation: [block] for [rationale]*
 
+**Layer 2 confirmation moment** (after Step 6, before Skill Discovery and Component Blueprints):
+
+The decomposition is complete. Before generating detailed component blueprints (the most expensive work to redo), confirm the L2 decisions are right:
+
+> "Decomposition confirmed:
+> - **Steps requiring new skills:** [count] — [list step IDs and proposed skill names]
+> - **Steps using existing skills:** [count] — [list step IDs and existing skill names]
+> - **Steps as inline prompts:** [count] — [list step IDs]
+> - **Steps requiring agents:** [count] — [list]
+> - **Human-performed steps:** [count] — [list]
+>
+> Moving to Layer 3 — Component Blueprints. I'll write the field-level spec for each new skill and agent. Confirm to proceed, or push back on the decomposition."
+
+If the user pushes back, revise the L2 decomposition (and possibly L1 if the disagreement is architectural). Re-confirm before proceeding. Like the L1 confirmation, this is lightweight — not a hard gate — but it's the last cheap moment to catch decomposition mistakes before the detailed spec work.
+
 #### Step 6b — Skill Discovery
 
 For every step classified as needing a **Skill** in Step 6, search for existing skills before assuming one needs to be built.
@@ -331,7 +368,7 @@ For every step classified as needing a **Skill** in Step 6, search for existing 
 
 **Presentation format:**
 
-For each step (or capability domain, for outcome-driven definitions) that needs a skill, present candidates in a table:
+For each step (or capability domain, for outcome-driven workflows) that needs a skill, present candidates in a table:
 
 > **[Step 3 / Domain: Research] needs a skill: "Format coaching prep notes"**
 > | Source | Skill | Status |
@@ -349,75 +386,115 @@ If no suitable existing skill is found for a step, tag that step as **"build new
 
 For steps where Skill Discovery (Step 6b) found an existing skill, skip to the next step.
 
-This step only applies to steps tagged **"build new"** in Step 6b. Tag those steps that should become skills. For each skill candidate, document:
-- Purpose (one sentence)
-- Covers steps / domains (which step numbers or capability domains this skill spans)
-- Inputs (what data the skill receives)
-- Outputs (what the skill produces)
-- Decision logic (key rules, criteria, frameworks)
-- Failure modes (what happens when inputs are missing or unexpected)
-- Required tools (which integration blocks the skill needs at runtime — e.g., MCP: Notion)
-- Depends on (other skills or artifacts that must exist before this skill can function)
+This step only applies to steps tagged **"build new"** in Step 6b. Tag those steps that should become skills. For each skill candidate, gather all 12 fields. The complete field set is defined in the Skill Candidates template section in Step 9 — collect every field during the collaborative session so the spec is complete on first write:
+
+- **ID** — stable skill ID (S1, S2, …)
+- **Name** — lowercase-hyphenated, ≤64 chars, no consecutive hyphens; matches the skill directory name
+- **Description** — ≤1024 chars, MUST start with "This skill should be used when..." — verbatim text for the SKILL.md frontmatter; drives auto-activation
+- **Purpose** — one-sentence internal summary for the spec reader
+- **Covers Steps / Domains** — which step IDs (or capability domains) this skill spans
+- **Inputs** — what the skill receives
+- **Outputs** — what the skill produces
+- **Decision Logic** — key rules, criteria, evaluation frameworks
+- **Failure Modes** — condition → action, one per line
+- **Required Tools** — integration blocks the skill needs at runtime (e.g., MCP: Notion)
+- **Depends On** — other skill IDs (S2, S3) or artifacts that must exist first, or "None"
+- **Stateful?** — Yes / No, does the skill maintain state across invocations? Drives Memory building-block decisions.
 
 #### Step 8 — Agent Configuration
 
-(When orchestration mechanism is Agent.) For each agent the workflow needs, document:
+(When orchestration mechanism is Agent.) For each agent the workflow needs, gather all 13 fields. The complete field set is defined in the Agent Configuration template section in Step 9 — collect every field during the collaborative session so the spec is complete on first write:
 
-| Component | What to specify |
+| Field | What to specify |
 |-----------|----------------|
-| **Name** | Unique agent name |
-| **Purpose** | When this agent should be invoked (trigger conditions) |
-| **Instructions** | Mission, responsibilities, behavior, goals, tone & style, output format |
-| **Model** | Recommended capability tier: reasoning-heavy / fast / vision |
-| **Tools** | External tools the agent needs (from Integration Options) |
-| **Skills** | Which skill candidates this agent should have access to |
-| **Trigger Examples** | 2-3 example scenarios showing when/how the agent is invoked |
+| **ID** | Stable agent ID (A1, A2, …) |
+| **Name** | Unique agent name (lowercase-hyphenated, matches the agent filename without extension) |
+| **Description** | ≤1024 chars, MUST start with "Use this agent when..." — verbatim text for the agent file frontmatter; drives invocation |
+| **Mission** | One-sentence primary purpose |
+| **Responsibilities** | Bulleted list of what the agent does once invoked |
+| **Output Format** | Structured description of what the agent's output should look like |
+| **Tone & Style** | Voice and register (e.g., "concise, technical, no hedging") |
+| **Constraints** | Must-not-dos, scope boundaries, source restrictions |
+| **Model** | Capability tier: reasoning-heavy / fast / vision |
+| **Memory Scope** | user / project / local / none — cross-session learning scope |
+| **Tools** | External tools the agent needs (reference Integration Options entries by tool name) |
+| **Skills** | Skill IDs the agent has access to (S1, S2, …) |
+| **Trigger Examples** | 2-3 structured examples (context → user message → expected behavior → invocation) — Build uses these verbatim as `<example>` blocks in the description |
 
 The build skill maps these to platform-specific fields at runtime (e.g., "reasoning-heavy" → `opus` on Claude Code, trigger examples → `<example>` blocks).
 
-For multi-agent: orchestration pattern, agent handoffs, human review gates.
+For multi-agent: orchestration pattern, agent handoffs, human review gates — see the Multi-Agent Configuration section in the template.
 
-#### Step 8b — Evaluation Criteria
+#### Step 8b — Verify Evaluation Inputs
 
-Before generating the spec, gather evaluation criteria from the user. These feed directly into Step 5 (Test) where the workflow is evaluated against them, and Step 7 (Improve) where iteration decisions reference the quality bar established here.
+The Workflow Requirements already includes **Acceptance Criteria** (what good looks like, dimensions that matter, minimum bar) and **Example Scenarios** (3-5 representative inputs with what to look for) from the Deconstruct step. Do **not** ask the user to re-state these.
 
-**For step-decomposed definitions:**
+Confirm them briefly:
 
-Prompt the user:
+> "Your Workflow Requirements includes Acceptance Criteria and [N] Example Scenarios. These feed directly into Step 5 (Test). Anything to add or adjust before I generate the Design Spec?"
 
-> "Before generating the spec, I need to understand what good output looks like for this workflow. This feeds directly into Step 5 (Test) where you'll evaluate the workflow against these criteria."
+If the user adds or adjusts anything, update the Workflow Requirements file (not the Design Spec) — that file remains the canonical source of acceptance criteria and test scenarios. The Design Spec references them by file path; it does not duplicate them.
 
-Then ask these four questions, one at a time:
-
-1. "Describe what a great output from this workflow looks like — not format, but quality. What would make you say 'this is exactly right'?"
-2. "Which dimensions matter most? For example: accuracy, completeness, tone, specificity, timeliness, format consistency."
-3. "Give me 3-5 real or realistic scenarios you'd run this on — different enough to test the workflow's range. For each, briefly describe the input and what you'd look for in the output."
-4. "What's your minimum bar? What quality level is acceptable vs. needs more work?"
-
-Capture the answers for the Evaluation Criteria section of the spec.
-
-**For outcome-driven definitions:**
-
-The Workflow Definition already includes Quality Criteria from the Deconstruct interview. Carry these forward rather than asking from scratch:
-
-> "Your Workflow Definition includes these quality criteria: [list from definition]. These feed directly into Step 5 (Test). Anything to add or adjust?"
-
-Then ask only the supplementary questions not already covered:
-- If test scenarios are missing: "Give me 3-5 real or realistic scenarios you'd run this on."
-- If minimum bar is missing: "What's your minimum bar? What quality level is acceptable vs. needs more work?"
+If the Workflow Requirements is missing Acceptance Criteria or Example Scenarios entirely (which shouldn't happen if Deconstruct was run), pause and ask the user to run `/deconstruct` again or fill them in manually before continuing.
 
 #### Step 9 — Generate Design Spec
 
 Write to `outputs/[workflow-name]-design-spec.md` using the template below. Every section is mandatory unless marked (optional). Do not add, remove, rename, or reorder sections.
 
-**Before writing, run the Build Skill Needs Checklist** (at the end of this step) to verify all required data has been captured.
+**Generation order:**
+
+1. Generate all spec sections (frontmatter through Stakeholders) following the template.
+2. **Run the Build Skill Needs Checklist** (at the end of this step) to verify every required field is present and well-formed.
+3. **Write the Self-Test Summary section** as the final section of the spec. For each checklist item, mark ✓ (passed) or ⚠️ (issue — describe inline). This makes the verification visible to the user and to downstream consumers.
+4. If any checklist item failed (⚠️), fix the underlying section before writing the spec. The Self-Test Summary should ideally show all ✓ — but if a ⚠️ remains (e.g., a deliberate gap that the user accepted), it's surfaced honestly.
+
+**Conditional sections to generate:**
+- `Orchestrator Prompt Outline` — only when mechanism is `Prompt` or `Skill-Powered Prompt`. Omit for `Agent`.
+- `Agent Configuration` — only when mechanism is `Agent`. (Mandatory for outcome-driven.)
+- `Multi-Agent Configuration` — only when more than one agent is defined.
+- `Stakeholders` — only for Organizational lens.
 
 ---
 
 **Template:**
 
 ```markdown
+---
+workflow: [kebab-case name]
+requirements_file: outputs/[workflow-name]-requirements.md
+spec_version: 2.1
+definition_type: Step-Decomposed | Outcome-Driven
+mechanism: Prompt | Skill-Powered Prompt | Agent
+involvement: Augmented | Automated
+platform: [user's platform, e.g., Claude Code, Claude.ai, Cowork, Codex, ChatGPT, Gemini CLI]
+platform_mode: code | guided
+packaging: Plugin | Standalone Skill | Workspace Agent | Loose Files
+counts:
+  steps: [N]
+  skills: [N]
+  agents: [N]
+  integrations: [N]
+---
+
 # [Workflow Name] — Design Spec
+
+## Source
+
+**Workflow Requirements:** `outputs/[workflow-name]-requirements.md`
+
+This Design Spec consumes the Workflow Requirements as canonical input. Outcome, Metadata, Context Inventory, Acceptance Criteria, Example Scenarios, Human Gates, Steps Overview, and per-step requirements are defined there — not restated here. Read the Workflow Requirements alongside this spec when building.
+
+The spec is organized into three layers that build on each other:
+
+1. **Architecture (L1)** — strategic decisions: platform, mechanism, autonomy, packaging
+2. **Decomposition (L2)** — for each step (or capability domain), what AI building block delivers it
+3. **Component Blueprints (L3)** — field-level specs for each new skill and agent
+
+---
+
+## Layer 1 — Architecture
+
+*Strategic decisions that shape everything downstream.*
 
 ## Execution Pattern
 
@@ -432,107 +509,26 @@ Write to `outputs/[workflow-name]-design-spec.md` using the template below. Ever
 | Platform Mode | code / guided | [inferred from platform or confirmed] |
 | Orchestration | Prompt / Skill-Powered Prompt / Agent | [reason] |
 | Involvement | Augmented / Automated | [reason] |
-| Trigger | [trigger description] | [implications for involvement, infrastructure] |
+| Packaging | Plugin / Standalone Skill / Workspace Agent / Loose Files | [reason — determines how Build groups and ships artifacts] |
+| Trigger | [trigger description from Workflow Requirements] | [implications for involvement, infrastructure] |
 
-## Scenario Summary
+**Packaging values:**
+- **Plugin** — Multiple related artifacts shipped together (e.g., handsonai-plugins marketplace plugin, set of `.claude/` files distributed via marketplace).
+- **Standalone Skill** — A single skill, uploaded directly (e.g., zip uploaded to Claude.ai, single SKILL.md in `.claude/skills/`, Codex skill in `.agents/skills/`, ChatGPT skill).
+- **Workspace Agent** — A ChatGPT Workspace Agent that bundles orchestration + skills + tools as a unit. (Custom GPTs are deprecated; Workspace Agents are the current ChatGPT primitive.)
+- **Loose Files** — Individual files in a project directory, no distribution layer.
 
-| Field | Value |
-|---|---|
-| **Workflow Name** | [name] |
-| **Description** | [full description] |
-| **Outcome** | [what a successful run produces] |
-| **Trigger** | [when/how it starts] |
-| **Type** | Augmented / Automated |
-| **Business Process** | [functional category] |
-| **Owner** | [person or role] |
+## Autonomy Spectrum Summary
 
-## Step-by-Step Decomposition
+The workflow-level autonomy assessment and the rationale that drove it. (Per-step autonomy classifications appear in the Decomposition table below.)
 
-| Step | Name | Phase | Autonomy | Orchestration | Integration (use/build) | Intelligence | Skill Candidate? | Human Gate? |
-|------|------|-------|----------|---------------|------------------------|--------------|-------------------|-------------|
+For step-decomposed workflows: group steps by autonomy level. For each group, explain WHY those steps have that classification.
 
-Column definitions:
-- **Autonomy**: Human / Deterministic / Guided / Autonomous (canonical terms only)
-- **Orchestration**: Prompt / Skill / Agent
-- **Integration**: Block + tool + action tag (e.g., "MCP: Notion (use)") or "—" if none
-- **Intelligence**: Model class + context sources + memory flag (e.g., "Model: fast" or "Model: reasoning; Context: pillar-definitions")
-- **Skill Candidate?**: Skill name (if new), "Exists: [name]" (if pre-built), or "No"
-- **Human Gate?**: Yes / No
-
-### Autonomy Spectrum Summary
-
-Group steps by autonomy level. For each group, explain WHY those steps have that classification.
-
-## Skill Candidates
-
-For each skill candidate (steps tagged with a new skill name above):
-
-### [skill-name] (Step N)
-
-| Dimension | Detail |
-|---|---|
-| **Purpose** | [one sentence] |
-| **Covers Steps / Domains** | [list of step numbers, or capability domain names for outcome-driven] |
-| **Inputs** | [name (type, default)] |
-| **Outputs** | [what the skill produces] |
-| **Decision Logic** | [key rules, criteria, evaluation frameworks — multiline OK] |
-| **Failure Modes** | [condition → action, one per line] |
-| **Required Tools** | [block: tool (action) — e.g., MCP: Notion (use)] |
-| **Depends On** | [other skills or artifacts that must exist first, or "None"] |
-
-## Agent Configuration (optional — only when orchestration = Agent)
-
-For each agent:
-
-### [agent-name]
-
-| Component | Detail |
-|---|---|
-| **Name** | [lowercase-hyphenated] |
-| **Purpose** | [when this agent should be invoked] |
-| **Instructions** | [mission, responsibilities, behavior, goals, tone, output format] |
-| **Model** | [capability tier: reasoning-heavy / fast / vision] |
-| **Tools** | [external tools needed, from Integration Options] |
-| **Skills** | [skill candidates this agent should have access to] |
-| **Trigger Examples** | [2-3 scenarios: situation → user message → agent response] |
-
-For multi-agent: orchestration pattern, agent handoffs, human review gates.
-
-## Step Sequence and Dependencies
-
-\`\`\`
-[ASCII diagram showing parallel and sequential paths]
-\`\`\`
-
-**Parallel:** [which steps can run concurrently]
-**Sequential:** [which steps must run in order]
-**Critical path:** [longest dependency chain]
-
-## Prerequisites
-
-1. [Numbered list of requirements that must be in place before the workflow can run]
-
-## Context Inventory
-
-| # | Artifact | Type | Used By | Status | Location | Key Contents |
-|---|---|---|---|---|---|---|
-
-Column definitions:
-- **Type**: MCP Data Source / Context / External
-- **Status**: Exists / Create
-- **Location**: File path, URL, database name, or "Create as [path]" / "Create inline in prompt"
-
-## Data Readiness Summary
-
-Items NOT fully AI-accessible. If all items are accessible, state: "All context items are AI-accessible. No data readiness actions required."
-
-| Context Item | Current State | Required Action | Affects Steps |
-|---|---|---|---|
-| [item] | AI-Accessible / Partial / No | [action needed] | [step numbers] |
+For outcome-driven workflows: replace this section with an **Autonomy Statement** — a brief paragraph stating: "This is an outcome-driven workflow. Autonomy is Autonomous — the agent system determines its own execution path based on the Outcome, Inputs, Rules & Constraints, and Acceptance Criteria defined in the Workflow Requirements."
 
 ## Integration Options
 
-For each tool identified in the Integration column of the Step-by-Step Decomposition (or Capability Domain Mapping for outcome-driven):
+For each tool identified in the Decomposition table (or Capability Domain Mapping for outcome-driven):
 
 ### [Tool Name] (Steps N, M / Domains: X, Y)
 
@@ -552,46 +548,232 @@ For each tool identified in the Integration column of the Step-by-Step Decomposi
 
 ## Model Recommendation
 
-**Default:** [reasoning-heavy / fast / vision] — [rationale]
+**Default capability:** [reasoning-heavy / fast / vision] — [rationale]
 
 **Per-step overrides** (optional):
-- Steps N, M: [different model class] — [rationale]
+- Steps N, M: [different capability] — [rationale]
+
+**Per-platform mapping** (Build resolves at generation time):
+- Claude Code / Claude.ai / Cowork: `opus` (reasoning-heavy) / `sonnet` (balanced) / `haiku` (fast)
+- ChatGPT / Codex: `gpt-5` or `o3` (reasoning-heavy) / `gpt-4o` (balanced) / `gpt-4o-mini` (fast)
+- Gemini: `gemini-2.5-pro` (reasoning-heavy) / `gemini-2.5-flash` (fast)
+
+(These mappings are guidance; Build verifies current model names via web search before generating.)
+
+---
+
+## Layer 2 — Decomposition
+
+*For each step or capability domain, what AI building block delivers it. Layer 2 sections in order: Step-by-Step Decomposition (or Capability Domain Mapping for outcome-driven), Orchestrator Prompt Outline (conditional on mechanism), Data Readiness Summary, Recommended Implementation Order.*
+
+## Step-by-Step Decomposition
+
+Steps are defined in the Workflow Requirements. This table adds the building-block classification and the concrete Build output for each:
+
+| Step | Name (from Requirements) | Autonomy | Orchestration | Integration (use/build) | Intelligence | Build Output | Human Gate? |
+|------|------|----------|---------------|------------------------|--------------|--------------|-------------|
+
+Column definitions:
+- **Step**: Step ID from Workflow Requirements (e.g., Step 1, Step 2)
+- **Autonomy**: Human / Deterministic / Guided / Autonomous (canonical terms only)
+- **Orchestration**: Prompt / Skill / Agent
+- **Integration**: Block + tool + action tag (e.g., "MCP: Notion (use)") or "—" if none
+- **Intelligence**: Model class + context sources + memory flag (e.g., "Model: fast" or "Model: reasoning; Context: C2, C5")
+- **Build Output**: One of: `New skill: S1` (build a new skill, defined below) / `Use existing: [name]` (reference an existing skill) / `New agent: A1` (build a new agent, defined below) / `Inline prompt → Workflow Requirements Step N` (this step becomes a prompt block in the orchestrator, sourced from the named step's requirements) / `MCP server: [name]` (configure a connector) / `Human (no artifact)` (no AI artifact — human-performed)
+- **Human Gate?**: Yes / No (sourced from Workflow Requirements Human Gates table)
+
+## Orchestrator Prompt Outline
+
+*Include this section only when mechanism is `Prompt` or `Skill-Powered Prompt`. Omit for `Agent` (the agent IS the orchestrator — see Agent Configuration below).*
+
+The high-level shape of the orchestrator prompt the user runs to execute the workflow. This is not the full prompt text — it's the structural skeleton Build expands into the orchestrator. Build derives full step content from the Workflow Requirements' Step Details.
+
+```
+[Intro: one paragraph describing what this prompt does and when to run it]
+
+[Step 1 invocation]
+  - Source: Workflow Requirements Step 1
+  - Build Output: [from Decomposition table]
+  - User provides: [inputs from Workflow Requirements]
+  - Produces: [outputs from Workflow Requirements]
+
+[PAUSE for user review — sourced from Workflow Requirements Human Gates table]
+  - What user is reviewing: [describe]
+  - User decides: [decision criteria]
+
+[Step 2 invocation]
+  - ...
+
+[Final output: what the workflow delivers, format, where it goes]
+```
+
+Use the actual Step IDs and Build Output values. Mark PAUSE points where Human Gates apply. Indicate where the user provides input vs. where the workflow runs autonomously.
+
+## Data Readiness Summary
+
+Items in the Workflow Requirements' Context Inventory flagged as `Partial` or `No` for AI Accessible. If all items are `Yes`, state: "All context items are AI-accessible. No data readiness actions required."
+
+| Context ID | Current State | Required Action | Affects Steps |
+|---|---|---|---|
+| C1 | Partial / No | [action needed — e.g., "Export weekly to /data/foo.csv"] | [step numbers] |
 
 ## Recommended Implementation Order
 
+Build artifacts in this order. Dependencies within each tier follow the `Depends On` field of each skill.
+
 ### Quick Wins (implement first)
-1. **[name]** — [rationale]
+1. **[Artifact ID + name]** — [rationale]
 
 ### Core (implement second)
-1. **[name]** — [rationale]
+1. **[Artifact ID + name]** — [rationale]
 
 ### Future Enhancement (optional)
-1. **[name]** — [rationale]
+1. **[Artifact ID + name]** — [rationale]
 
-## Where to Run
+---
 
-**[Platform]** with [setup requirements]. [Recommendation for frequent use.]
+## Layer 3 — Component Blueprints
 
-## Evaluation Criteria
+*Field-level specs for each new skill, agent, and configuration. Build uses these to generate artifacts.*
 
-### What good output looks like
-[Concrete description in plain language — what would make you say "this is exactly right"?]
+## Skill Candidates
 
-### Quality dimensions
-[Which dimensions matter for this workflow — e.g., accuracy, completeness, tone, format, timeliness, specificity]
+For each Build Output tagged `New skill: SN` above:
 
-### Test scenarios
-[3-5 representative inputs that exercise the workflow's range — real or realistic examples]
+### S1 — [skill-name]
 
-| # | Scenario | Input description | What to look for |
-|---|----------|-------------------|------------------|
+| Field | Detail |
+|---|---|
+| **ID** | S1 |
+| **Name** | [lowercase-hyphenated, ≤64 chars, no consecutive hyphens; matches the skill directory name] |
+| **Description** | [≤1024 chars; MUST start with "This skill should be used when..." — this is the literal description that goes into the SKILL.md frontmatter and drives auto-activation on Claude.ai, Cowork, and code-mode platforms] |
+| **Purpose** | [one-sentence internal summary — for the Design Spec reader, not the skill description] |
+| **Covers Steps / Domains** | [list of Step IDs, or capability domain names for outcome-driven] |
+| **Inputs** | [name — description, one per line; "type" is the expected user-provided value description, not a strict type system] |
+| **Outputs** | [what the skill produces] |
+| **Decision Logic** | [key rules, criteria, evaluation frameworks — multiline OK] |
+| **Failure Modes** | [condition → action, one per line] |
+| **Required Tools** | [block: tool (action) — e.g., MCP: Notion (use)] |
+| **Depends On** | [other skill IDs (S2, S3) or artifacts that must exist first, or "None"] |
+| **Stateful?** | Yes / No — does the skill maintain state across invocations? Drives Memory building-block decisions. |
 
-### Minimum quality bar
-[What's acceptable vs. what needs iteration — in plain terms, not a numeric threshold]
+## Agent Configuration (mandatory when orchestration = Agent; otherwise omit)
+
+For each Build Output tagged `New agent: AN` above:
+
+### A1 — [agent-name]
+
+| Field | Detail |
+|---|---|
+| **ID** | A1 |
+| **Name** | [lowercase-hyphenated, matches the agent filename without extension] |
+| **Description** | [≤1024 chars; MUST start with "Use this agent when..." — this is the literal description that goes into the agent file frontmatter and drives invocation. Include 2-3 `<example>` blocks (see Trigger Examples field below) inline at the end.] |
+| **Mission** | [one-sentence primary purpose] |
+| **Responsibilities** | [bulleted list of what the agent does once invoked] |
+| **Output Format** | [structured description of what the agent's output should look like — sections, fields, format constraints] |
+| **Tone & Style** | [voice/register, e.g., "concise, technical, no hedging"] |
+| **Constraints** | [must-not-dos, scope boundaries, source restrictions] |
+| **Model** | [capability tier: reasoning-heavy / fast / vision] |
+| **Memory Scope** | user / project / local / none — controls cross-session learning (Claude Code agent format supports this; on other platforms, document the equivalent) |
+| **Tools** | [external tools needed — reference Integration Options entries by tool name] |
+| **Skills** | [Skill IDs the agent has access to — S1, S2, …] |
+| **Trigger Examples** | [2-3 structured examples, each: context → user message → expected agent behavior → invocation. Build uses these verbatim to construct the `<example>` blocks in the agent's description field.] |
+
+## Multi-Agent Configuration (only when more than one agent is defined)
+
+**Orchestration Pattern:** Supervisor (one agent delegates to others) / Pipeline (agents in sequence) / Parallel (agents run concurrently) / Network (agents call each other peer-to-peer)
+
+**Coordinator:** [Agent ID that coordinates, or "Pattern-based" if no single coordinator]
+
+**Handoff Contracts:**
+
+| From → To | Trigger | Data Passed | Format |
+|---|---|---|---|
+| A1 → A2 | [when A1 finishes / when condition X] | [what data passes] | [format / schema description] |
+
+**Aggregation Strategy:** [How results combine if parallel or network — last-writer-wins, merge, supervisor-decides, etc. Write "N/A" for Pipeline.]
+
+## Prerequisites
+
+1. [Numbered list of requirements that must be in place before the workflow can run — focus on platform setup, accounts, credentials, plugin installs. The Workflow Requirements covers content artifacts via its Context Inventory.]
+
+## Deployment Plan
+
+For each artifact produced, document where it lives and how it gets deployed:
+
+| Artifact | Target Location | Deployment Steps |
+|---|---|---|
+| S1 — `[name]` | [platform-specific path or destination] | [high-level steps; Build expands during artifact generation] |
+| A1 — `[name]` | [platform-specific path or destination] | [high-level steps] |
+| MCP: [tool] | [where the config lives] | [install/auth steps] |
+
+**Packaging note:** [How the artifacts ship together based on the Packaging decision — e.g., "All S1–S3 + A1 bundle into a plugin in the user's marketplace fork"; "Each skill uploaded individually to Claude.ai"; "All instructions consolidated into one GPT's instructions field"]
+
+**Recommended for frequent use:** [recommendation, e.g., "Save as Claude Project for one-click reuse"]
+
+---
+
+## Cross-Layer Sections
+
+*These sections apply across all three layers — handoff and metadata that doesn't belong to a single layer.*
+
+## Evaluation Inputs
+
+**Acceptance Criteria, Example Scenarios, and Human Gates are sourced from the Workflow Requirements file** (`outputs/[name]-requirements.md`). Do not duplicate them here. Step 5 (Test) reads them from that file directly.
+
+## Deferred to Build
+
+Decisions intentionally left for Build to resolve. Build should not need to re-ask the user about anything else in the spec.
+
+- [ ] Specific platform offering (if platform was given at ecosystem level, e.g., "Claude" vs Claude Code/Claude.ai/Cowork)
+- [ ] Shareability (file vs code distribution mode)
+- [ ] Exact model version per platform (mapping above is guidance; Build verifies current names)
+- [ ] Integration setup specifics (auth flow, region, plan tier)
 
 ## Stakeholders (optional — only for Organizational lens)
 
-[Role swimlane diagram and stakeholder details]
+[Role swimlane diagram and stakeholder details — sourced from Workflow Requirements Metadata.]
+
+## Self-Test Summary
+
+*Populated by the Design skill after running the Build Skill Needs Checklist. Each item marks ✓ (passed) or ⚠️ (issue — described inline). Lets users and downstream consumers see what was verified before approval.*
+
+### Structure
+- ✓ / ⚠️ Frontmatter present with all required fields (workflow, requirements_file, spec_version, definition_type, mechanism, involvement, platform, platform_mode, packaging, counts)
+- ✓ / ⚠️ Source section names Workflow Requirements file
+- ✓ / ⚠️ Architecture Decisions table complete (7 rows)
+- ✓ / ⚠️ Decomposition table complete with all step IDs from Workflow Requirements
+- ✓ / ⚠️ All Autonomy values use canonical terms (Human / Deterministic / Guided / Autonomous)
+- ✓ / ⚠️ All Integration column entries follow the `block: tool (use/build)` format
+- ✓ / ⚠️ All Build Output values use canonical forms (`New skill: SN` / `Use existing: [name]` / `New agent: AN` / `Inline prompt → Workflow Requirements Step N` / `MCP server: [name]` / `Human (no artifact)`)
+- ✓ / ⚠️ Packaging value uses a canonical form (`Plugin` / `Standalone Skill` / `Workspace Agent` / `Loose Files`)
+
+### Skill Candidates
+- ✓ / ⚠️ Every `New skill: SN` reference has a matching entry
+- ✓ / ⚠️ Every skill has all 12 fields
+- ✓ / ⚠️ Every skill Name conforms to format rules (lowercase-hyphen, ≤64 chars, no consecutive hyphens)
+- ✓ / ⚠️ Every skill Description starts with "This skill should be used when..." and is ≤1024 chars
+
+### Agent Configuration
+- ✓ / ⚠️ Every `New agent: AN` reference has a matching entry
+- ✓ / ⚠️ Every agent has all 13 fields
+- ✓ / ⚠️ Every agent Description starts with "Use this agent when..." and is ≤1024 chars
+- ✓ / ⚠️ Multi-Agent Configuration present when >1 agent defined
+
+### Cross-references
+- ✓ / ⚠️ Every tool in Integration column has a matching Integration Options entry with a Source URL
+- ✓ / ⚠️ Every skill `Depends On` reference points to a defined skill ID
+
+### Mechanism-specific
+- ✓ / ⚠️ Orchestrator Prompt Outline present (when mechanism is Prompt or Skill-Powered Prompt)
+- ✓ / ⚠️ Agent Configuration present (when mechanism is Agent)
+
+### Completeness
+- ✓ / ⚠️ Model Recommendation present with default capability and per-platform mapping
+- ✓ / ⚠️ Data Readiness Summary present (even if "all accessible")
+- ✓ / ⚠️ Deployment Plan present with target location, deployment steps, and Packaging note
+- ✓ / ⚠️ Evaluation Inputs present (pointer, not duplication)
+- ✓ / ⚠️ Deferred to Build present
 ```
 
 ---
@@ -600,17 +782,31 @@ For each tool identified in the Integration column of the Step-by-Step Decomposi
 
 Before saving the spec, verify every item. If any is missing, go back and add it:
 
-- [ ] `Architecture Decisions` table has Platform, Platform Mode, Orchestration, and Involvement rows
-- [ ] Every step in the decomposition table has separate Orchestration, Integration, and Intelligence columns (not collapsed into a single "Building Block(s)" column)
+- [ ] **Frontmatter** is present with workflow, requirements_file, spec_version, definition_type, mechanism, involvement, platform, platform_mode, packaging, and counts
+- [ ] **Source** section names the Workflow Requirements file path
+- [ ] `Architecture Decisions` table has Lens, Platform, Platform Mode, Orchestration, Involvement, Packaging, and Trigger rows
+- [ ] Every step in the decomposition table has separate Orchestration, Integration, Intelligence, and Build Output columns
+- [ ] Step IDs in the decomposition table match the Step IDs in the Workflow Requirements (Step 1, Step 2, …)
 - [ ] Every step uses canonical autonomy terms: Human / Deterministic / Guided / Autonomous
 - [ ] Every Integration column entry includes the block type, tool name, and use/build tag
-- [ ] Every skill candidate has all 8 fields: Purpose, Covers Steps, Inputs, Outputs, Decision Logic, Failure Modes, Required Tools, Depends On
-- [ ] Every "Exists" item in Context Inventory has a Location value
+- [ ] Every Build Output value is one of the canonical forms (`New skill: SN`, `Use existing: [name]`, `New agent: AN`, `Inline prompt → Workflow Requirements Step N`, `MCP server: [name]`, `Human (no artifact)`)
+- [ ] Every `New skill: SN` reference has a matching Skill Candidates entry with the SN ID
+- [ ] Every `New agent: AN` reference has a matching Agent Configuration entry with the AN ID
+- [ ] Every Skill Candidate has all 12 fields: ID, Name, Description, Purpose, Covers Steps, Inputs, Outputs, Decision Logic, Failure Modes, Required Tools, Depends On, Stateful?
+- [ ] Every Skill Candidate's Name conforms to format rules (lowercase-hyphen, ≤64 chars, no consecutive hyphens)
+- [ ] Every Skill Candidate's Description starts with "This skill should be used when..." and is ≤1024 chars
+- [ ] Every Agent Configuration has all 13 fields: ID, Name, Description, Mission, Responsibilities, Output Format, Tone & Style, Constraints, Model, Memory Scope, Tools, Skills, Trigger Examples
+- [ ] Every Agent Configuration's Description starts with "Use this agent when..." and is ≤1024 chars
+- [ ] If more than one agent is defined, Multi-Agent Configuration section is present with Orchestration Pattern, Coordinator, Handoff Contracts, and Aggregation Strategy
 - [ ] Every tool in the Integration column has a matching entry in Integration Options with at least one Source URL
-- [ ] Model Recommendation section is present with a default class
-- [ ] Data Readiness Summary is present (even if "all accessible")
-- [ ] Agent Configuration is present if orchestration = Agent (with Skills and Trigger Examples fields)
-- [ ] Evaluation Criteria section is present with at least 3 test scenarios
+- [ ] Model Recommendation section is present with a default capability and per-platform mapping
+- [ ] Data Readiness Summary is present (even if "all accessible") — references Context IDs from the Workflow Requirements
+- [ ] Deployment Plan is present with target location and deployment steps for each artifact, plus a Packaging note
+- [ ] Packaging value is one of the canonical forms (`Plugin`, `Standalone Skill`, `Workspace Agent`, `Loose Files`)
+- [ ] Orchestrator Prompt Outline section is present when mechanism is `Prompt` or `Skill-Powered Prompt` (omitted when mechanism is `Agent`)
+- [ ] Evaluation Inputs section is present, pointing to the Workflow Requirements file (do not duplicate Acceptance Criteria or Example Scenarios)
+- [ ] Deferred to Build section lists what Build will resolve at generation time
+- [ ] Self-Test Summary section is present at the end of the spec, with each item marked ✓ (passed) or ⚠️ (issue — described inline)
 
 #### Step 10 — Spec Approval Gate
 
@@ -640,15 +836,19 @@ After the user approves, instruct them to **exit plan mode** if they entered it 
 
 ### Outcome-Driven Processing Path
 
-When the Workflow Definition has `Definition Type: Outcome-Driven`, the following modifications apply to the standard workflow:
+When the Workflow Requirements has `Definition Type: Outcome-Driven`, the following modifications apply to the standard workflow:
 
-**Step 3 (Architecture Decisions):** Same as standard — extract tools from the Capability Domains and Tools/Data sections instead of from step data flows.
+**Step 3 (Architecture Decisions):** Same as standard, but the source sections differ. For outcome-driven Workflow Requirements, extract tools from the **Inputs**, **Rules & Constraints**, and **Context Inventory** sections (there are no per-step data flows to read from). Capability Domains do not exist in the Workflow Requirements — they are derived in Step 6.
 
 **Step 4 (Autonomy Assessment):** State as fact: "This is an outcome-driven workflow — autonomy is **Autonomous** by definition. The agent system determines its own execution path."
 
 **Step 5 (Orchestration Mechanism):** State as fact: "Orchestration is **Agent**." Still determine the involvement mode (Augmented/Automated) from the definition's Human Gates section and trigger type. Still ask the platform sub-choice if the platform has multiple agent offerings.
 
-**Step 6 (Classify Each Step) → Capability Domain Mapping:** Replace per-step classification with capability domain mapping. For each capability domain from the definition:
+**Step 6 (Classify Each Step) → Capability Domain Mapping:** Replace per-step classification with capability domain mapping.
+
+**Important:** Capability Domains are derived by Design — they are **not** captured in the Workflow Requirements (the Workflow Requirements stays in "what" territory; capability decomposition is "how"). Infer capability domains from the Workflow Requirements' Outcome, Inputs, Rules & Constraints, and Acceptance Criteria. Propose them to the user and confirm before mapping.
+
+For each derived capability domain:
 
 | Domain | Integration Needs | Intelligence Requirements | Reusable Skill? |
 |--------|-------------------|--------------------------|-----------------|
@@ -656,13 +856,13 @@ When the Workflow Definition has `Definition Type: Outcome-Driven`, the followin
 
 Same Integration Discovery and Skill Discovery processes apply, operating on capability domains instead of steps.
 
-**Step 7 (Skill Candidates):** Same — identify which capability domains should become skills.
+**Step 7 (Skill Candidates):** Same field structure — identify which capability domains should become skills. Each skill candidate uses the full 12-field Skill Candidate block (with Covers Domains in place of Covers Steps).
 
-**Step 8 (Agent Configuration):** This becomes the primary section. Agent Configuration is mandatory for outcome-driven definitions. Document the agent(s) with all standard fields, drawing instructions from the definition's Goal, Constraints, and Expected Outputs.
+**Step 8 (Agent Configuration):** This becomes the primary section. Agent Configuration is **mandatory** (not optional) for outcome-driven workflows. Document the agent(s) with all 13 standard fields, drawing Description, Mission, Responsibilities, Output Format, and Constraints from the Workflow Requirements' Outcome, Rules & Constraints, and Acceptance Criteria.
 
-**Step 8b (Evaluation Criteria):** Carry forward from the definition's Quality Criteria — see above.
+**Step 8b (Verify Evaluation Inputs):** Same as step-decomposed — confirm Acceptance Criteria and Example Scenarios in the Workflow Requirements are complete; do not duplicate.
 
-**Step 9 (Generate Spec):** Use the modified template sections below. The spec uses the same filename pattern. Conditional sections replace Step-by-Step Decomposition with Capability Domain Mapping, and Autonomy Spectrum Summary with a brief Autonomous statement.
+**Step 9 (Generate Spec):** Use the modified template sections below. The spec uses the same filename pattern and same frontmatter shape (with `definition_type: Outcome-Driven`). The Step-by-Step Decomposition section is replaced with Capability Domain Mapping; the Autonomy Spectrum Summary becomes a brief Autonomous statement; Build Output is captured per domain rather than per step.
 
 **Outcome-driven spec template modifications:**
 
@@ -671,45 +871,53 @@ Replace the `## Step-by-Step Decomposition` section with:
 ```markdown
 ## Capability Domain Mapping
 
-| Domain | Description | Integration (use/build) | Intelligence | Reusable Skill? |
-|--------|-------------|------------------------|--------------|-----------------|
+(Capability domains are derived by Design from the Workflow Requirements' Outcome, Inputs, Rules, and Acceptance Criteria. They are not present in the Workflow Requirements.)
+
+| Domain | Description | Integration (use/build) | Intelligence | Build Output |
+|--------|-------------|------------------------|--------------|--------------|
+
+**Build Output values:** Same canonical forms as the step-decomposed table (`New skill: SN`, `Use existing: [name]`, `New agent: AN`, etc.). For outcome-driven workflows, expect most domains to map to either `New skill: SN` (if the agent should delegate to a reusable skill) or `Handled by agent` (if the agent handles the domain inline with its own instructions).
 
 ### Autonomy Statement
 
-This is an outcome-driven workflow. Autonomy is Autonomous — the agent system determines its own execution path based on the goal, inputs, and constraints.
+This is an outcome-driven workflow. Autonomy is Autonomous — the agent system determines its own execution path based on the Outcome, Inputs, Rules & Constraints, and Acceptance Criteria defined in the Workflow Requirements.
 ```
 
-Replace the `## Skill Candidates` section header with capability-domain-based skill candidates (same field structure, keyed by domain instead of step number).
-
-The `## Agent Configuration` section is **mandatory** (not optional) for outcome-driven specs.
-
-All other spec sections remain the same, except **Step Sequence and Dependencies** is omitted for outcome-driven specs — the agent determines its own execution path, so there is no fixed step sequence to document.
+Skill Candidates use the same 12-field block (with `Covers Domains` instead of `Covers Steps`). Agent Configuration is **mandatory** for outcome-driven specs.
 
 **Build Skill Needs Checklist modifications for outcome-driven:**
-- [ ] `Architecture Decisions` table has Platform, Platform Mode, Orchestration (Agent), and Involvement rows
-- [ ] Capability Domain Mapping table is present with Integration and Intelligence columns
-- [ ] Every Integration column entry includes block type, tool name, and use/build tag
-- [ ] Every skill candidate has all 8 fields: Purpose, Covers Steps / Domains, Inputs, Outputs, Decision Logic, Failure Modes, Required Tools, Depends On
-- [ ] Every "Exists" item in Context Inventory has a Location value
-- [ ] Every tool in the Integration column has a matching entry in Integration Options with at least one Source URL
-- [ ] Model Recommendation section is present with a default class
-- [ ] Data Readiness Summary is present (even if "all accessible")
-- [ ] Agent Configuration is present with Skills and Trigger Examples fields
-- [ ] Evaluation Criteria section is present with at least 3 test scenarios
-- [ ] Quality criteria carried forward from Workflow Definition
+
+Use the full step-decomposed checklist with these substitutions:
+- Replace "Step-by-Step Decomposition" with "Capability Domain Mapping"
+- Replace "Step IDs match Workflow Requirements Step IDs" with "Capability Domains are derived from Workflow Requirements (not restated from a section that doesn't exist there)"
+- Replace "Inline prompt → Workflow Requirements Step N" Build Output value with "Handled by agent"
+- Agent Configuration is mandatory (not optional)
+
+All other checklist items apply unchanged.
 
 ## Outputs
 
 ### `outputs/[workflow-name]-design-spec.md` — Design Spec
 
-Uses the mandatory template defined in Step 9. For step-decomposed definitions: Execution Pattern, Architecture Decisions, Scenario Summary, Step-by-Step Decomposition (with separate Orchestration/Integration/Intelligence columns), Autonomy Spectrum Summary, Skill Candidates (8 fields each), Agent Configuration (optional, with Skills and Trigger Examples), Step Sequence and Dependencies, Prerequisites, Context Inventory (with Location column), Data Readiness Summary, Integration Options (with Source URLs), Model Recommendation, Recommended Implementation Order, Where to Run, Evaluation Criteria (with test scenarios), Stakeholders (optional).
+Uses the mandatory template defined in Step 9. The Design Spec **references** the Workflow Requirements as canonical source — it does not restate Outcome, Metadata, Context Inventory, Acceptance Criteria, Example Scenarios, Human Gates, Steps Overview, or per-step requirements.
 
-For outcome-driven definitions: Execution Pattern, Architecture Decisions, Scenario Summary, Capability Domain Mapping (with Integration/Intelligence columns), Autonomy Statement, Skill Candidates (8 fields each, keyed by domain), Agent Configuration (mandatory, with Skills and Trigger Examples), Prerequisites, Context Inventory, Data Readiness Summary, Integration Options, Model Recommendation, Recommended Implementation Order, Where to Run, Evaluation Criteria (with test scenarios carried forward from definition), Stakeholders (optional).
+The spec opens with YAML frontmatter (workflow, requirements_file, spec_version, definition_type, mechanism, involvement, platform, platform_mode, packaging, counts) so Build and downstream skills can summarize the spec without parsing prose.
+
+The spec is organized into three layered groups:
+
+- **Layer 1 — Architecture:** Execution Pattern, Architecture Decisions (with Packaging), Autonomy Spectrum Summary, Integration Options (with Source URLs), Model Recommendation (with per-platform mapping)
+- **Layer 2 — Decomposition:** Step-by-Step Decomposition (with Build Output column) — or Capability Domain Mapping for outcome-driven — Orchestrator Prompt Outline (when mechanism is Prompt or Skill-Powered Prompt), Data Readiness Summary, Recommended Implementation Order
+- **Layer 3 — Component Blueprints:** Skill Candidates (12 fields each), Agent Configuration (optional, mandatory for outcome-driven; 13 fields each), Multi-Agent Configuration (when applicable), Prerequisites, Deployment Plan
+
+**Cross-layer sections:** Evaluation Inputs (pointer to Workflow Requirements), Deferred to Build, Stakeholders (optional), Self-Test Summary (results of the Build Skill Needs Checklist).
+
+For outcome-driven workflows: Step-by-Step Decomposition is replaced by Capability Domain Mapping; Autonomy Spectrum Summary is replaced by an Autonomy Statement; Orchestrator Prompt Outline is omitted (the agent IS the orchestrator); Agent Configuration is mandatory.
 
 ## Guidelines
 
 - Use plain language; avoid jargon unless the user introduced it
-- After writing the spec, tell the user: "Design Spec saved to `outputs/[name]-design-spec.md`."
+- After writing the spec, tell the user: "Design Spec saved to `outputs/[name]-design-spec.md`. Read it alongside the Workflow Requirements at `outputs/[name]-requirements.md`."
 - Do not proceed past the Spec Approval Gate (Step 10) without explicit user approval
 - Do not research integration availability — that happens in the Build phase
 - Do not generate platform artifacts — that happens in the Build phase
+- Do not restate Workflow Requirements content in the Design Spec — reference the file

--- a/examples/content-calendar-planning/workflow-requirements.md
+++ b/examples/content-calendar-planning/workflow-requirements.md
@@ -1,4 +1,6 @@
-# Content Calendar Planning — Workflow Definition
+# Content Calendar Planning — Workflow Requirements
+
+> **Note:** This example was produced under the older Workflow Definition format. The body below uses Scenario Metadata, Refined Steps (sub-steps / decision points / data in / data out / failure modes per step), and a Context Shopping List. The current PRD-style Workflow Requirements format uses Outcome, Metadata, Steps Overview, per-step Goal·Inputs·Outputs·Rules & Edge Cases·Context, Context Inventory, Acceptance Criteria, Example Scenarios, and Human Gates. This example will be regenerated to match the current format in a follow-up.
 
 ## Scenario Metadata
 

--- a/plugins/handsonai/.claude-plugin/plugin.json
+++ b/plugins/handsonai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "handsonai",
   "description": "Everything you need to design, build, and document AI workflows. The AI Workflow Framework as executable Claude Code skills, plus an AI registry and feature-spec toolkit.",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "author": {
     "name": "James Gray"
   },

--- a/plugins/handsonai/agents/framework-agent.md
+++ b/plugins/handsonai/agents/framework-agent.md
@@ -24,8 +24,8 @@ You run seven skills sequentially, using files as handoffs between stages. Steps
 | Step | Skill | Input | Output | Handoff |
 |------|-------|-------|--------|---------|
 | 1 (Analyze) | `analyze` | User interview | `ai-opportunity-report.md` | User picks candidate |
-| 2 (Deconstruct) | `deconstruct` | Candidate + interview | `[name]-definition.md` | Auto→Step 3 |
-| 3 (Design) | `design` | Workflow Definition | `[name]-design-spec.md` | Explicit approval gate |
+| 2 (Deconstruct) | `deconstruct` | Candidate + interview | `[name]-requirements.md` | Auto→Step 3 |
+| 3 (Design) | `design` | Workflow Requirements | `[name]-design-spec.md` | Explicit approval gate |
 | 4 (Build) | `build` | Approved spec | Platform artifacts | Auto→Step 5 |
 | 5 (Test) | `test` | Artifacts + spec | `[name]-test-results.md` | Ready OR loop to Build |
 | 6 (Run) | `run` | Tested artifacts + spec | `[name]-run-guide.md` | User follows guide |
@@ -49,14 +49,14 @@ During context probing, push beyond vague answers — identify the specific arti
 
 After naming is confirmed, register the workflow to the Notion Workflows database if the Notion MCP server is available. Use the confirmed metadata (name, description, outcome, trigger, type) with Status = "Under Development."
 
-**Produces:** `outputs/[name]-definition.md`
+**Produces:** `outputs/[name]-requirements.md`
 
-After the Workflow Definition is complete, tell the user you're moving to Step 3 and proceed automatically.
+After the Workflow Requirements is complete, tell the user you're moving to Step 3 and proceed automatically.
 
 ### Step 3 — Design
 **Skill:** `design`
 
-Read the Workflow Definition and run the Design phase:
+Read the Workflow Requirements and run the Design phase:
 1. Prompt the user to enter plan mode for collaborative design
 2. Gather architecture decisions (platform, tools, trigger)
 3. Assess workflow autonomy level (Deterministic → Guided → Autonomous)
@@ -64,11 +64,11 @@ Read the Workflow Definition and run the Design phase:
 5. Classify each step on the autonomy spectrum and map to AI building blocks
 6. Identify skill candidates with generation-ready detail
 7. Configure agents (when the mechanism calls for them)
-8. Define Evaluation Criteria — test scenarios and scoring dimensions for Step 5
-9. Generate the Design Spec (with "Integration Research Needed" section — availability research is deferred to Build)
+8. Confirm Evaluation Inputs — Acceptance Criteria and Example Scenarios are sourced from the Workflow Requirements; verify they're complete but do not re-collect
+9. Generate the Design Spec (references the Workflow Requirements; does not duplicate it)
 10. **Spec Approval Gate** — present the spec for explicit user approval. Do NOT proceed to Build without approval. Loop if changes are requested. After approval, prompt the user to exit plan mode.
 
-**Reads:** `outputs/[name]-definition.md`
+**Reads:** `outputs/[name]-requirements.md`
 **Produces:** `outputs/[name]-design-spec.md`
 
 After the spec is approved, tell the user you're moving to Step 4 and proceed automatically.
@@ -92,9 +92,9 @@ After Build is complete, tell the user you're moving to Step 5 and proceed autom
 **Skill:** `test`
 
 Guide structured testing of the built workflow artifacts:
-1. Load the Design Spec (including Evaluation Criteria) and the built artifacts
+1. Load the Workflow Requirements (for Acceptance Criteria + Example Scenarios), the Design Spec, and the built artifacts
 2. Run a quick smoke test — one representative input, manual check
-3. Execute each test scenario from the Evaluation Criteria, scoring output on each dimension (1–5 scale)
+3. Execute each Example Scenario from the Workflow Requirements, scoring output against the Acceptance Criteria dimensions (1–5 scale)
 4. Test individual building blocks (skills, prompts) in isolation
 5. Establish baseline scores as the reference point for future regression testing in Step 7
 6. Diagnose issues — map each problem to the specific building block to adjust
@@ -168,7 +168,7 @@ After Steps 1–6 are complete, present a summary:
 >
 > **Step 2 — Deconstruct:**
 >
-> 2. **Workflow Definition** — `outputs/[name]-definition.md`
+> 2. **Workflow Requirements** — `outputs/[name]-requirements.md`
 >
 > **Step 3 — Design:**
 >

--- a/plugins/handsonai/skills/build/SKILL.md
+++ b/plugins/handsonai/skills/build/SKILL.md
@@ -4,6 +4,7 @@ description: >
   This skill should be used when the user has an approved Design Spec and wants to
   build platform artifacts for their AI workflow. It offers a build path choice, researches
   integration availability, generates platform-appropriate artifacts (prompts, skills, agents, configs),
+  and writes them to the right locations for the user's platform.
   This is Step 4 (Build) of the AI Workflow Framework.
 user-invocable: true
 ---
@@ -20,13 +21,20 @@ Take an approved Design Spec and generate platform-appropriate artifacts: prompt
 
 Artifact generation begins only after the Design Spec has been approved in the Design phase.
 
-#### Step 1 — Load Design Spec
+#### Step 1 — Load Design Spec and Workflow Requirements
 
 Read the Design Spec from `outputs/[workflow-name]-design-spec.md`. If the user specifies a file path, use that. Otherwise, look for the most recent Design Spec in `outputs/`.
 
-Confirm you've loaded the spec by summarizing: workflow name, orchestration mechanism, involvement mode, number of steps, number of skill candidates, and number of agents.
+**Parse the frontmatter first.** The spec opens with YAML frontmatter containing: `workflow`, `requirements_file`, `spec_version`, `definition_type`, `mechanism`, `involvement`, `platform`, `platform_mode`, `packaging`, and `counts`. Use these values to summarize the spec — no need to parse the body to get the headline numbers.
 
-Verify the spec contains an Architecture Decisions section and Integration Options section. If either is missing, inform the user: "This spec appears to predate the current format. Some sections are missing. I can either (a) proceed with what's available and ask questions as needed, or (b) you can regenerate the spec by running the Design skill again."
+**Also load the Workflow Requirements.** The Design Spec references the Workflow Requirements via its `requirements_file` frontmatter field (or the Source section if frontmatter is absent). Read that file too — it contains the per-step requirements, Context Inventory, Acceptance Criteria, Example Scenarios, and Human Gates that the Design Spec deliberately does NOT restate. Build needs both files together.
+
+Confirm you've loaded both by summarizing: workflow name, orchestration mechanism, involvement mode, packaging, counts (steps, skills, agents, integrations), and that the Workflow Requirements was loaded.
+
+**Spec version compatibility:**
+- `spec_version: 2.1` (current) → current format with three-layer grouping, Orchestrator Prompt Outline, and Self-Test Summary; proceed.
+- `spec_version: 2.0` → older format without layer grouping or Orchestrator Outline; proceed (Build's fallback derives the orchestrator from Workflow Requirements directly).
+- No frontmatter or older `spec_version` → spec predates the current format. Inform the user: "This spec is in an older format. Some fields (Packaging, Build Output column, Skill/Agent IDs, Deployment Plan, Orchestrator Prompt Outline) may be missing. I can either (a) proceed with what's available and ask questions as needed, or (b) you can regenerate the spec by running the Design skill again."
 
 #### Step 2 — Build Path Choice
 
@@ -193,7 +201,29 @@ If the Integration Options section is missing from the spec (older format), info
 
 #### Step 6 — Generate Platform Artifacts
 
-Based on the platform from Architecture Decisions. Resolve any deferred decisions now: ask about **shareability** (will team members run this?) to determine artifact format (file-based vs. code-based), and resolve the **specific platform offering** if not yet determined (e.g., Claude Code vs. Claude.ai, ADK vs. Gemini web). Infer **code comfort** from the specific offering (Claude Code = code-comfortable, ChatGPT = no-code).
+Based on the platform and packaging decisions from Architecture Decisions. Resolve the items in the spec's **Deferred to Build** section now:
+
+- **Specific platform offering** if not yet determined (e.g., "Claude" → Claude Code vs. Claude.ai vs. Cowork)
+- **Shareability** — file-based vs. code-based distribution; influences artifact format
+- **Exact model version per platform** — verify current model names via web search for the user's platform
+- **Integration setup specifics** — auth flow, region, plan tier per integration
+
+Use the spec's **Step-by-Step Decomposition Build Output column** (or **Capability Domain Mapping Build Output column** for outcome-driven) as your generation checklist. Each row tells you exactly what to produce:
+- `New skill: SN` → generate the skill defined in the matching Skill Candidates entry
+- `Use existing: [name]` → no generation needed; verify the skill exists and reference it
+- `New agent: AN` → generate the agent defined in the matching Agent Configuration entry
+- `Inline prompt → Workflow Requirements Step N` → fold this step's Goal/Inputs/Outputs/Rules from the Workflow Requirements into the main orchestrator prompt
+- `MCP server: [name]` → configure the connector using the Integration Options entry
+- `Human (no artifact)` → skip; no AI artifact for this step
+- `Handled by agent` (outcome-driven only) → no separate artifact; capability is covered by the agent's Instructions
+
+Apply the spec's **Packaging** decision to group the generated artifacts:
+- **Plugin** → assemble into a marketplace plugin directory structure (e.g., handsonai-plugins layout for Claude marketplace)
+- **Standalone Skill** → ship as a single uploadable artifact (zip for Claude.ai, single SKILL.md for code-mode platforms, single skill for ChatGPT)
+- **Workspace Agent** → bundle orchestration + skills + tools as a ChatGPT Workspace Agent (the current ChatGPT primitive; Custom GPTs are deprecated). Research current Workspace Agent creation flow via web search before generating.
+- **Loose Files** → write files to platform-appropriate paths; no distribution wrapper
+
+**When mechanism is `Prompt` or `Skill-Powered Prompt`:** read the spec's `Orchestrator Prompt Outline` section as the structural skeleton for the orchestrator prompt. The outline names which step invokes which skill, where PAUSE points sit, and what the user provides at each gate. Expand the outline into the full orchestrator prompt by pulling step content (Goal, Inputs, Outputs, Rules & Edge Cases) from the Workflow Requirements. If the section is absent (older spec or mechanism = Agent), fall back to deriving the orchestrator directly from Workflow Requirements Step Details + Human Gates.
 
 **a. Resolve platform documentation from the registry.** Use the platform doc URLs fetched in Platform Research (Step 3.6) from the registry's `platforms` section. These provide current, authoritative documentation for each building block's artifact format.
 
@@ -215,23 +245,29 @@ If playbook platform guides are available locally (e.g., `docs/platforms/claude/
 
   **If a creation skill was matched for this block type:**
 
-  1. Invoke it via the Skill tool, passing:
-     - The building block's full spec from the Design Spec (name, purpose, inputs, outputs, decision logic, failure modes, which workflow steps it covers)
+  1. Invoke it via the Skill tool, passing the building block's full spec from the Design Spec:
+     - **For skills (S1, S2, …):** all 12 fields from the Skill Candidates entry — ID, Name, Description, Purpose, Covers Steps/Domains, Inputs, Outputs, Decision Logic, Failure Modes, Required Tools, Depends On, Stateful?
+     - **For agents (A1, A2, …):** all 13 fields from the Agent Configuration entry — ID, Name, Description, Mission, Responsibilities, Output Format, Tone & Style, Constraints, Model, Memory Scope, Tools, Skills, Trigger Examples. If multi-agent, also pass the relevant Handoff Contracts and the Orchestration Pattern.
      - The artifact format requirements resolved in Step 3.6 (or the fallback reference if Step 3.6 did not resolve a format)
-     - Whether platform-specific extensions should be applied (based on Architecture Decisions)
-     - This context: "This building block comes from an approved Design Spec (AI Workflow Framework, Step 3 Design). The intent, inputs, outputs, decision logic, and failure modes are already defined. Use this as your starting context."
+     - Whether platform-specific extensions should be applied (based on Architecture Decisions and Packaging)
+     - This context: "This building block comes from an approved Design Spec (AI Workflow Framework, Step 3 Design). The intent, name, description, inputs, outputs, decision logic, and failure modes are already defined. Use this as your starting context."
   2. Let the creation skill run its full workflow. Do not skip or abbreviate any stage.
-  3. After completion, move to the next building block. Later blocks may reference earlier ones.
+  3. After completion, move to the next building block. Later blocks may reference earlier ones via their stable IDs.
 
   **If no creation skill was matched (inline generation):**
 
-  1. **For skills:** Use the artifact format from Step 3.6. If unavailable, fetch the agentskills.io specification (live from `https://agentskills.io/specification`, fallback to `references/skill-spec.md`). Generate the skill following that spec. Apply platform-specific extensions as documented for the target platform.
-  2. **For agents:** Use the artifact format from Step 3.6. If unavailable and on Claude Code, fall back to `references/agent-spec.md`. For other platforms, fall back to web search. Generate the agent following the resolved spec.
+  1. **For skills:** Use the artifact format from Step 3.6. If unavailable, fetch the agentskills.io specification (live from `https://agentskills.io/specification`, fallback to `references/skill-spec.md`). Generate the skill using the Skill Candidates entry — use the `Name` field as the directory name and the `Description` field verbatim in the SKILL.md frontmatter. Apply platform-specific extensions as documented for the target platform.
+  2. **For agents:** Use the artifact format from Step 3.6. If unavailable and on Claude Code, fall back to `references/agent-spec.md`. For other platforms, fall back to web search. Generate the agent using the Agent Configuration entry — use the `Name` as the filename, the `Description` field verbatim in the agent file frontmatter (and include the Trigger Examples as `<example>` blocks in the description), and the Mission, Responsibilities, Output Format, Tone & Style, and Constraints fields as the agent's system prompt body.
   3. **For other block types (MCP servers, hooks, commands, prompts):** Use the artifact format from Step 3.6. If unavailable, research the platform's current format via web search and generate accordingly.
 
 **f. Generate artifacts.** The skill provides the *specs* (what each building block should do, its inputs/outputs/instructions from the Design phase). The model provides the *implementation* (how to build it on the user's platform, using the verified specification and platform documentation as authoritative sources).
 
-After completing Build, tell the user: "To test the workflow, run the `test` skill (Step 5) (or say *'Test the workflow I built'*)."
+**g. Place and deploy each artifact per the Deployment Plan.** The Design Spec's Deployment Plan table specifies the target location and deployment steps for every artifact. For each generated artifact:
+1. Write the artifact to its target location from the Deployment Plan.
+2. Execute or document the deployment steps (e.g., "run `claude mcp add ...`", "upload zip via plugin marketplace", "create new GPT and paste instructions").
+3. If the target location requires user action (e.g., a manual GPT creation flow), produce a step-by-step guide tailored to the user's platform.
+
+After completing Build, summarize what was generated, where each artifact was placed, and any remaining manual deployment steps. Then tell the user: "To test the workflow, run the `test` skill (Step 5) (or say *'Test the workflow I built'*)."
 
 ## Outputs
 

--- a/plugins/handsonai/skills/deconstruct/SKILL.md
+++ b/plugins/handsonai/skills/deconstruct/SKILL.md
@@ -2,118 +2,51 @@
 name: deconstruct
 description: >
   This skill should be used when the user wants to deconstruct a workflow, break down a business
-  process, define an outcome for an agent system, or deeply analyze a workflow's steps, decisions,
-  data flows, and failure modes. Supports four entry paths: step-decomposed (6-question framework),
-  problem-first, outcome-driven (for autonomous agent systems), or Compose — a lean three-turn flow
-  that outputs an orchestration prompt directly when the user already has the skills/sub-agents in
-  place. The first three paths produce a structured Workflow Definition; Compose produces only an
-  orchestration prompt. This is Step 2 of the AI Workflow Framework.
+  process, capture requirements for an AI workflow, or define an outcome for an agent system.
+  Step 2 is the PRD for the workflow — it captures what the workflow must do, the rules it must
+  follow, and the edge cases it must handle, in clear requirements language suitable for the
+  Design step or any AI model to consume. Supports two paths: step-decomposed (you know how the
+  work gets done) and outcome-driven (you know what "done" looks like and want an agent system
+  to determine the path). Produces a structured Workflow Requirements document.
+  This is Step 2 of the AI Workflow Framework.
 user-invocable: true
 ---
 
 # Workflow Deconstruction
 
-Interactively discover a business workflow via one of four paths. The step-decomposed (6-question framework), problem-first, and outcome-driven paths all produce a structured Workflow Definition. The Compose path is the lean alternative: when the user already has the skills or sub-agents their workflow needs and can describe each step, Compose skips the deep dive and outputs an orchestration prompt directly in three turns — no Workflow Definition file.
+Step 2 is the **PRD for the workflow**. It captures *what* the workflow must do and the rules it must follow — not *how* AI building blocks will deliver it (that's Step 3, Design).
+
+The output is a **Workflow Requirements** document written in clear, concise requirements language. It must be self-contained enough that a reader who never saw this conversation — including the Design skill or any agent model — can act on it without re-interviewing the user.
+
+## The Two Paths
+
+Step 2 has **two paths**, mapped directly to the two ways students think about a workflow:
+
+| Path | When to use | Mental model |
+|------|-------------|--------------|
+| **Step-decomposed** | You can describe how the work gets done | "I know the steps" |
+| **Outcome-driven** | You know what "done" looks like but the path varies; you want an agent system to figure it out at runtime | "I know the outcome" |
+
+Both paths produce a Workflow Requirements document with the same shared shell — only the middle "what does the workflow do" block differs.
 
 ## Workflow
 
-1. **Scenario discovery** — Determine how the user is arriving and which path to take:
+1. **Scenario discovery** — Determine how the user is arriving and which path to take.
 
-   **From Analyze output**: If the user references an opportunity report, file path (e.g., `outputs/ai-opportunity-report.md`), or a specific workflow candidate from an Analyze session, read the Workflow Candidate Summary from the file. Present the available candidates and ask which one to deconstruct. Pre-populate scenario metadata (name, description, trigger, deliverable, autonomy, involvement) from the candidate fields. If the candidate includes a `Lens` field, carry it forward along with any `Business Objective`, `Stakeholders`, and `Success Metrics` fields. Confirm the pre-populated details with the user. Then choose the path: if the candidate's autonomy = Autonomous, suggest option (c) but still confirm. Otherwise present the three choices below.
+   **From Analyze output**: If the user references an opportunity report, file path (e.g., `outputs/ai-opportunity-report.md`), or a specific workflow candidate from an Analyze session, read the Workflow Candidate Summary from the file. Present the available candidates and ask which one to deconstruct. Pre-populate scenario metadata (name, description, trigger, deliverable, autonomy, involvement) from the candidate fields. If the candidate includes a `Lens` field, carry it forward along with any `Business Objective`, `Stakeholders`, and `Success Metrics` fields. Confirm the pre-populated details with the user. Then choose the path: if the candidate's autonomy = Autonomous, suggest outcome-driven but still confirm. Otherwise present the choice below.
 
-   **Cold entry (no Analyze output)**: Present three choices as the **first question**:
+   **Cold entry (no Analyze output)**: Ask one question:
 
-   > "How would you like to approach this?
-   > (a) **Deconstruct a known process** — You can describe the steps and I'll interview you to surface hidden details
-   > (b) **Start from a problem** — You know what's broken; I'll propose a workflow and we refine it together
-   > (c) **Define an outcome** — You know what you want produced but want an agent system to figure out the approach
-   > (d) **Compose** — You already have skills and/or sub-agents and know the workflow; I'll write the orchestration prompt directly"
+   > "Do you know the steps, or just the outcome?
+   > - **Step-decomposed** — You can describe how the work gets done. I'll interview you to refine the steps and surface decision rules and edge cases.
+   > - **Outcome-driven** — You know what "done" looks like but want an agent system to figure out the steps. I'll capture the outcome, inputs, acceptance criteria, and rules."
 
-   **After the user chooses, gather scenario details based on their path:**
-   - **Option (a)**: Ask about the business scenario, objective, high-level steps, and ownership. One question at a time. If no lens was established, determine it: individual tasks (one person's repetitive work) = Individual lens; multi-role or business-objective processes = Organizational lens. If not obvious from context, ask. Proceed to Step 2 (scope check) → Step 4 (deep dive with 6-question framework).
-   - **Option (b)**: Ask the user to describe what's broken. Propose a candidate workflow for them to react to. Then recommend whether step-decomposed or outcome-driven fits better, with reasoning. User confirms or overrides — honor their choice either way. If step-decomposed, proceed to Step 2 → Step 4. If outcome-driven, proceed to Step 2 → Step 4-OD.
-   - **Option (c)**: Ask the user to describe the outcome they want — what should the agent system produce, what triggers the need, and who consumes the output. One question at a time. Proceed to Step 2 (scope check) → Step 4-OD (outcome-driven interview).
-   - **Option (d) — Compose**: Proceed to the **Compose three-turn flow** (see Step 1c below). Do NOT call Step 2 (scope check) or Step 4 (deep dive); Compose handles its own lean intake inline and writes no Workflow Definition file.
+   **Problem-first handling (no separate path)**: If the user says they don't have a process *or* an outcome — just a problem ("People drop off during onboarding and I don't have a way to follow up") — propose a candidate workflow based on what they describe, then route into one of the two paths:
+   > "Here's a candidate workflow that would solve this: [outline]. Do you want to refine these steps with me (step-decomposed), or just describe the outcome and let an agent figure out the steps (outcome-driven)?"
 
-**Step 1c — Compose three-turn flow (only reached from Option d):**
-
-The Compose path is the **lean** path. No formal pre-flight, no Workflow Definition file, no `/design` invocation. The conversation captures what's needed, confirms it back, and outputs an orchestration prompt the student can run.
-
-**Turn 1 — Intake.** Ask the student for everything in one message:
-
-> "Tell me four things in one message:
-> 1. **Workflow name and outcome** — what does this workflow produce?
-> 2. **Where your components live** — Claude account (Claude.ai + Cowork), Claude Code, ChatGPT, or a mix?
-> 3. **The steps** — numbered, one line each.
-> 4. **Which component runs each step** — name and type (skill or sub-agent)."
-
-If the student answers Turn 1 incompletely, ask only for the missing pieces in Turn 2 — do not restart.
-
-**Turn 2 — Confirm + autonomy/involvement.** Restate what you heard in 5–8 lines: workflow name, hosting, steps, component-to-step mapping. Use ✓ when a component clearly fits its step; flag concerns inline (vague step, missing component, suspected mismatch) and ask for a quick fix.
-
-If the workflow looks more complex than the Compose path is built for — 8+ steps, no components for half the steps, "etc." in step descriptions, or 3+ decision points the student didn't surface — say so directly and offer to switch:
-
-> "This is more involved than the Compose path is built for — [specific reason]. The Known Process path (`/deconstruct` option a) will surface the gaps before they bite. Want to switch?"
-
-Then ask the two questions that actually shape the prompt:
-
-- *"Deterministic (fixed sequence, no AI judgment) or guided (the AI scores, evaluates, or adapts between steps)?"*
-- *"Augmented (AI pauses for your input at any point) or automated (runs straight through)?"*
-
-**Turn 3 — Output the orchestration prompt.** Generate the prompt in the standard shape below and return it as a code block the student can copy. Map the autonomy + involvement answers to one of four patterns:
-
-- **Deterministic, automated** — components fire in sequence, no pauses, no AI judgment.
-- **Deterministic, augmented** — same fixed sequence with a PAUSE for student review between named steps.
-- **Guided, augmented** — scoring/evaluation/adaptation between steps, with a PAUSE for steering.
-- **Guided, automated** — same decision logic, but the AI makes the bounded calls without pausing.
-
-**Standard output shape:**
-
-~~~markdown
----
-workflow: <Workflow Name>
-outcome: <one-sentence outcome>
-autonomy: deterministic | guided
-involvement: augmented | automated
-components:
-  - name: <name>
-    type: skill       # used in step 1
-  - name: <name>
-    type: sub-agent   # used in step 2
----
-
-# <Workflow Name>
-
-## Intent
-<one-paragraph "what this workflow does and when to run it">
-
-## Prompt
-<the orchestration prompt body>
-~~~
-
-**Prompt-body constraints — clarity, brevity, token efficiency:**
-
-- One instruction per line where possible. Imperative voice. No filler ("please", "kindly", "make sure to").
-- No re-explanation of what the components do — components have their own descriptions.
-- No preamble or commentary. Open with the first instruction, not "In this workflow, we will…".
-- PAUSE points are uppercase and unambiguous on their own line: `PAUSE — wait for me to confirm which insights to feature.`
-- Reuse the student's own wording for inputs, outputs, and decision criteria. Avoid synthesizing new jargon.
-- Inline tone or formatting guidance only when it changes the output (e.g., "narrative tone, not bullet-heavy"). Skip aesthetics.
-
-**Component verification, hosting-aware:**
-
-- **Claude Code (local files):** Read each named component's frontmatter (SKILL.md or agent file) under `.claude/skills/` and `.claude/agents/` (plus installed plugin caches). Confirm it exists, fits the step, and isn't an obvious mismatch. Mention an alternative only if you spot a clearly stronger match in the student's local inventory.
-- **Claude account, ChatGPT, or mix:** You cannot introspect. Trust the student's mapping. Ask for clarification only if a component name sounds wrong for the step it's assigned to. If the student doesn't remember a component's name, ask them to paste their available components from wherever they're hosted.
-
-**Saving the artifact:**
-
-Tell the student to save the orchestration prompt wherever they keep prompts:
-- Claude Code users: a `prompts/<workflow-name>.md` file in their project.
-- Everyone else: a Google Doc, Notion page, Claude account project file, ChatGPT saved prompt, or plain note.
-
-Do **not** write any file to `outputs/`. The Compose path produces conversation output only.
-
-**End of Compose flow.** Do not hand off to `/design`, `/build`, `/test`, or `/run`. The student tests the workflow by running the prompt.
+   **After the path is chosen, gather scenario details:**
+   - **Step-decomposed**: Ask about the business scenario, objective, high-level steps, and ownership. One question at a time. If no lens was established, determine it: individual tasks (one person's repetitive work) = Individual lens; multi-role or business-objective processes = Organizational lens. Ask only if not obvious from context. Proceed to Step 2 (scope check) → Step 4 (deep dive).
+   - **Outcome-driven**: Ask the user to describe the outcome — what should the agent system produce, what triggers the need, and who consumes the output. One question at a time. Proceed to Step 2 (scope check) → Step 4-OD (outcome-driven interview).
 
 2. **Scope check — one trigger, one deliverable** — A workflow has exactly one trigger (what kicks it off) and one deliverable (the tangible output). Test for multiple workflows by checking:
    - **Triggers**: Multiple independent starting points? (e.g., "when a lead comes in" vs. "end of each week") → separate workflows
@@ -121,11 +54,15 @@ Do **not** write any file to `outputs/`. The Compose path produces conversation 
    - **Timeframes**: Parts run on different schedules (daily vs. weekly), or significant waits between phases → likely separate workflows
    - **Step count**: Would this expand to 15+ refined steps? → may be multiple workflows
    - **Ownership boundary** (organizational lens): Does this process have a single accountable owner for the end-to-end outcome? If different people own different segments with no single owner, it may be multiple workflows.
-   If multiple workflows are detected: map out each one (working name, trigger, deliverable), present the breakdown, confirm boundaries with the user, and ask which to deconstruct first. Proceed with only the chosen workflow.
-3. **Name the workflow** — Present 2-3 name options following naming conventions (2-4 word noun phrase, Title Case). Confirm name, description, outcome, trigger, and type.
-4. **Deep dive** — Before probing the first step, briefly frame what "context" means: "As we go through each step, I'll ask about the *context* it needs. Context is any data or information the step requires to do its job — that includes databases and spreadsheets, but also documents, transcripts, emails, style guides, SOPs, or even knowledge that currently lives in someone's head. If the step needs it, it's context."
 
-   Work through each step using the 6-question framework:
+   If multiple workflows are detected: map out each one (working name, trigger, deliverable), present the breakdown, confirm boundaries with the user, and ask which to deconstruct first. Proceed with only the chosen workflow.
+
+3. **Name the workflow** — Present 2-3 name options following naming conventions (2-4 word noun phrase, Title Case). Confirm name, description, outcome, and trigger.
+
+4. **Deep dive (step-decomposed only)** — Before probing the first step, briefly frame what "context" means: "As we go through each step, I'll ask about the *context* it needs. Context is any data or information the step requires to do its job — that includes databases and spreadsheets, but also documents, transcripts, emails, style guides, SOPs, or even knowledge that currently lives in someone's head. If the step needs it, it's context."
+
+   Work through each step using the 6-question framework. These six dimensions are the **interview scaffold** — they shape what to ask, not how the spec is structured. Your job is to gather enough signal across all six to write the per-step requirements block (Goal / Inputs / Outputs / Rules & Edge Cases / Context Needed) in Step 10.
+
    - Discrete steps (is this actually multiple steps?)
    - Decision points (if/then branches, quality gates)
    - Data flows (inputs, outputs, sources, destinations)
@@ -137,10 +74,14 @@ Do **not** write any file to `outputs/`. The Compose path produces conversation 
      - Persistence: Does this context need to exist as a durable artifact that AI can access across workflow runs? If it's currently "in someone's head" or communicated verbally, flag that it needs to be externalized and stored somewhere AI-accessible.
      - Reorganization signal: If access, interpretability, or persistence is limited, flag that the context may need to be made more accessible or better organized — note this as a consideration for the Design step.
    - Role transitions (organizational lens with multiple stakeholders only) — Who performs this step? Does ownership change between steps? Are there handoff points?
+
    When probing context needs, push beyond vague answers — identify the specific artifact. For any step where AI is already being used, ask specifically for existing prompt instructions, project instructions, or system prompts — these contain workflow logic that must be included in the Baseline Prompt.
-5. **Propose and react** — After the first step of the deep dive, switch to propose-and-react: propose a hypothesis across all dimensions (including context readiness and role transitions for organizational workflows) and ask "What's right, what's wrong, what am I missing?" instead of asking each question individually. Include a context readiness hypothesis: "I think this context lives in [location] and is in [format] which AI can interpret. Is that right?"
-6. **Map sequence** — After all steps, identify sequential vs. parallel steps and the critical path.
-7. **Optimize for AI** (step-decomposed path only) — Now that the full process is mapped, step back and challenge it. The user described their *current* process — but an AI-powered version may not need every step. Present optimization recommendations for the user to react to. Look for:
+
+5. **Propose and react (step-decomposed only)** — After the first step of the deep dive, switch to propose-and-react: propose a hypothesis across all dimensions (including context readiness and role transitions for organizational workflows) and ask "What's right, what's wrong, what am I missing?" instead of asking each question individually. Include a context readiness hypothesis: "I think this context lives in [location] and is in [format] which AI can interpret. Is that right?"
+
+6. **Map sequence (step-decomposed only)** — After all steps, identify sequential vs. parallel steps and the critical path.
+
+7. **Optimize for AI (step-decomposed only)** — Now that the full process is mapped, step back and challenge it. The user described their *current* process — but an AI-powered version may not need every step. Present optimization recommendations for the user to react to. Look for:
    - **Eliminable steps** — Steps that exist only because a human was doing the work. Examples: manual data transfer between systems (an integration eliminates this), reformatting output from one step to match the input of the next (AI handles format natively), or "wait for X to be available" steps that become instant with API access.
    - **Collapsible steps** — Adjacent steps that AI can do in a single pass. Examples: separate "draft" and "format" steps, or "research" followed immediately by "summarize findings" — these are distinct for humans but one operation for AI.
    - **Parallelizable steps** — Steps that were sequential only because a human can do one thing at a time. If two steps have no data dependency, flag that AI can run them concurrently.
@@ -160,7 +101,7 @@ Do **not** write any file to `outputs/`. The Compose path produces conversation 
 
    Update the refined steps based on the user's confirmed optimizations. Renumber if steps were added, removed, or merged. If the user rejects all optimizations, that's fine — proceed with the original steps.
 
-8. **Validate the workflow** (step-decomposed path only) — Before consolidating context, walk through the refined workflow end-to-end and present a validation summary. This is the quality gate that catches gaps before the workflow moves to Design. Check for:
+8. **Validate the workflow (step-decomposed only)** — Before consolidating context, walk through the refined workflow end-to-end and present a validation summary. This is the quality gate that catches gaps before the workflow moves to Design. Check for:
    - **Completeness** — Are there gaps in the end-to-end flow? Steps where an output doesn't connect to the next step's input?
    - **Logic gaps** — Decision points without clear criteria? Steps that assume information not produced by a prior step?
    - **Edge cases** — Scenarios the user hasn't mentioned (empty inputs, unexpected formats, partial data, exception paths)?
@@ -178,100 +119,206 @@ Do **not** write any file to `outputs/`. The Compose path produces conversation 
 
    Update refined steps based on the user's responses. If no issues are found, say so and proceed.
 
-9. **Consolidate context** — Present a rolled-up "context shopping list" of every piece of context the workflow needs — documents, data, rules, examples, and any other knowledge from the user's domain that the model doesn't have.
-10. **Generate Workflow Definition** — Produce the structured Workflow Definition and write it to the output file.
+9. **Consolidate context** — Present a rolled-up "context inventory" of every piece of context the workflow needs — documents, data, rules, examples, and any other knowledge from the user's domain that the model doesn't have.
+
+   For step-decomposed workflows: assemble from per-step context needs gathered in Step 4. For outcome-driven workflows: assemble from the Inputs + Context Sources gathered in Step 4-OD.
+
+10. **Collect Acceptance Criteria and Example Scenarios (both paths)** — Before generating the Workflow Requirements, ask the user about acceptance criteria and example scenarios. These were previously collected during Design's Step 8b; capturing them here makes Step 2 a complete PRD and removes redundant questioning downstream.
+
+    Ask, one at a time:
+    1. "What does great output from this workflow look like? Describe what would make you say 'this is exactly right.'"
+    2. "Which dimensions matter most? For example: accuracy, completeness, tone, specificity, timeliness, format consistency."
+    3. "What's your minimum bar — what's acceptable vs. what needs more work?"
+    4. "Give me 3-5 real or realistic scenarios you'd run this on — different enough to test the workflow's range. For each, briefly describe the input and what you'd look for in the output."
+
+    For outcome-driven workflows, these answers also inform the Acceptance Criteria built up in Step 4-OD — fold them together rather than asking twice.
+
+11. **Generate Workflow Requirements** — Produce the structured Workflow Requirements document and write it to the output file. See the **Output** section below for the template, writing style, and machine-readability rules.
 
 ### Outcome-Driven Path (Step 4-OD)
 
-When the user selects option (c) or the problem-first funnel recommends outcome-driven, run this interview instead of the step-decomposed deep dive (Steps 4–9). The outcome-driven path handles context discovery internally (question 7), so it skips straight to Generate Workflow Definition (Step 10) after the interview. Same interview principles apply: one question at a time, propose-and-react after the first few answers, push beyond vague answers.
+When the user selects outcome-driven, run this interview instead of the step-decomposed deep dive (Steps 4–8). The outcome-driven path handles context discovery internally (question 7), so it skips straight to Step 9 (Consolidate Context) → Step 10 (Acceptance Criteria) → Step 11 (Generate) after the interview. Same interview principles apply: one question at a time, propose-and-react after the first few answers, push beyond vague answers.
 
-1. **Goal**: "What does a successful run produce? Describe the deliverable."
+1. **Outcome**: "What does a successful run produce? Describe the deliverable — format, structure, scope."
 2. **Inputs**: "What does the agent system receive to start? What triggers the work, and what materials does it have access to?"
-3. **Expected outputs**: "What format, structure, and detail level does the deliverable need? Describe or show what 'good' looks like."
-4. **Constraints**: "What boundaries or guardrails apply? Things the agent must always do, must never do, or limits on scope, sources, tone, length."
-5. **Quality criteria**: "How will you evaluate whether the output is good vs. bad? What dimensions matter — accuracy, completeness, tone, specificity, timeliness?" (These feed directly into the Test step.)
-6. **Capability domains**: "What does the agent system need to be good at? Not steps, but kinds of work — research, analysis, writing, data extraction, etc." After the first few answers, propose candidate domains from the goal/constraints and ask: "What's right, what's wrong, what am I missing?"
-7. **Tools and context sources**: "What external systems, data sources, documents, or reference materials should the agent system have access to?" Apply the same context readiness probing as the step-decomposed path:
+3. **Acceptance signals**: "What does the deliverable need to demonstrate to be considered 'good'? Examples or anti-examples are great here." (This feeds the Acceptance Criteria; Step 10 will sharpen it further.)
+4. **Rules & Constraints**: "What boundaries or guardrails apply? Things the agent must always do, must never do, or limits on scope, sources, tone, length."
+5. **Context & Data Sources**: "What external systems, data sources, documents, or reference materials should the agent system have access to?" Apply the same context readiness probing as the step-decomposed path:
    - Access: Where does this context live today? Is it in a system with programmatic access (database, cloud app, shared drive), or does it require manual steps (logging in, copy-pasting, reading from a screen)?
    - Interpretability: Is the context in a format AI can process?
    - Persistence: Does this context need to exist as a durable artifact that AI can access across workflow runs?
-8. **Human gates**: "Where should the agent system pause for human review? Or run end-to-end with final review only?"
-9. **Scope check**: Same one-trigger-one-deliverable test as Step 2 — confirm the outcome hasn't expanded into multiple workflows.
+6. **Human gates**: "Where should the agent system pause for human review? Or run end-to-end with final review only?"
+7. **Scope check**: Same one-trigger-one-deliverable test as Step 2 — confirm the outcome hasn't expanded into multiple workflows.
 
-After completing the interview, proceed directly to **Generate Workflow Definition** (Step 10) using the outcome-driven output format.
+**Do NOT ask about capability domains, agent count, model class, tools, or orchestration approach.** Those are Design decisions. Outcome-driven Deconstruct stays in "what" territory: outcome, inputs, acceptance criteria, rules, context, human gates.
+
+After completing the interview, proceed directly to Step 9 (Consolidate Context) → Step 10 (Acceptance Criteria) → Step 11 (Generate Workflow Requirements) using the outcome-driven output format.
 
 ## Output
 
-Write the Workflow Definition to `outputs/[workflow-name]-definition.md` where `[workflow-name]` is the kebab-case workflow name (e.g., `lead-qualification`).
+Write the Workflow Requirements to `outputs/[workflow-name]-requirements.md` where `[workflow-name]` is the kebab-case workflow name (e.g., `lead-qualification` → `outputs/lead-qualification-requirements.md`).
 
-The Workflow Definition uses a shared header with conditional sections depending on the definition type.
+### Writing-style rules (MUST follow)
 
-### Scenario Metadata (both formats)
-- Workflow name, description, outcome, trigger, type, business objective, current owner(s), lens (Individual/Organizational)
-- **Definition Type**: `Step-Decomposed` or `Outcome-Driven`
-- For organizational lens: stakeholders (roles/teams involved), success metrics (KPIs for measuring improvement)
+The output reads like a PRD, not an interview transcript. Enforce:
 
-### Step-Decomposed Sections (when Definition Type = Step-Decomposed)
+- **Requirements voice.** Every bullet is a statement of what must be true, not a description of what the user said. Prefer "The step accepts a list of prospect URLs" or "Output is a Markdown table with one row per prospect" over "The user mentioned they usually have a list of URLs."
+- **Active voice. Present tense.** "Validate the input against the rubric" — not "The input will then be validated."
+- **One requirement per line.** Use bulleted lists, not paragraphs, anywhere multiple discrete requirements appear.
+- **Concrete over abstract.** Name the artifact, the field, the threshold. "Reject submissions over 500 words" — not "Filter out long submissions."
+- **No interview residue.** Drop hedges ("I think", "sometimes", "usually"), narrative connectors ("then the user", "after that"), and meta-commentary about the conversation ("we discussed", "you mentioned").
+- **Self-contained.** A reader who never saw the deconstruct conversation can implement against the document.
 
-#### Refined Steps
-For each step: number, name, action, sub-steps, decision points, data in/out, context needs, failure modes
+### Machine-readability rules (MUST follow)
 
-#### Optimization Summary (produced by Step 7 — Optimize for AI; included if any optimizations were applied)
-Brief record of what changed from the original process and why:
-- Steps eliminated, collapsed, parallelized, or added
-- Rationale for each change
-- Any optimizations the user declined and why (preserves the reasoning for Design)
+So Design (and any agent model) can parse the document without re-asking:
 
-#### Step Sequence and Dependencies
-- Sequential steps, parallel steps, critical path, dependency map
-- Role swimlane (organizational lens with multiple roles) — a view showing which role owns each step
+- **Fixed section headings**, in fixed order — use the exact headings in the template; no synonyms, no reordering.
+- **Tables for any list of items with shared fields** (steps, context artifacts, example scenarios) — not prose.
+- **Canonical vocabulary** for enumerated values:
+  - Definition Type: `Step-Decomposed` or `Outcome-Driven`
+  - Lens: `Individual` or `Organizational`
+  - Context Status: `Exists` or `Needs Creation`
+  - AI Accessible: `Yes`, `Partial`, or `No`
+- **Stable IDs** — number steps `1, 2, 3, …`; ID context items `C1, C2, C3, …`; ID example scenarios `E1, E2, E3, …`. Downstream artifacts reference these IDs.
+- **Explicit Inputs and Outputs per step** — even when "obvious." Design uses these to build the data-flow without guessing.
 
-#### Context Shopping List
-For each artifact: name, description, used by steps, status (Exists/Needs Creation), key contents, AI Accessible? (Yes/Partial/No), readiness notes
+### Template — shared shell
 
-For items with `Status: Needs Creation`, the readiness notes should also capture where the artifact should be persisted — not just that it needs to be created, but that it needs a home AI can reach.
+```markdown
+# [Workflow Name] — Workflow Requirements
 
-For organizational workflows, also prompt for existing process documentation: SOPs, training guides, compliance requirements, SLAs.
+## Outcome
+[One paragraph: what a successful run produces, when it runs, who consumes the output.]
 
-### Outcome-Driven Sections (when Definition Type = Outcome-Driven)
+## Metadata
 
-#### Goal
-What a successful run produces — the deliverable described concretely.
+| Field | Value |
+|---|---|
+| Workflow Name | [name] |
+| Description | [short description] |
+| Trigger | [what kicks the workflow off] |
+| Owner | [person or role] |
+| Lens | Individual / Organizational |
+| Definition Type | Step-Decomposed / Outcome-Driven |
+| Business Objective | [why this workflow matters — optional but recommended] |
 
-#### Inputs
-What the agent system receives to start — trigger, data, materials.
+For organizational lens, also include:
+| Stakeholders | [roles/teams involved] |
+| Success Metrics | [KPIs for measuring improvement] |
 
-#### Expected Outputs
-Format, structure, quality expectations, and an example of what "good" looks like.
+---
 
-#### Constraints
-Boundaries, guardrails, must-do / must-not-do rules.
+[INSERT THE STEP-DECOMPOSED BLOCK OR THE OUTCOME-DRIVEN BLOCK HERE — see below]
 
-#### Quality Criteria
-Evaluation dimensions, what good vs. bad looks like, minimum bar. These feed directly into Step 5 (Test).
+---
 
-#### Capability Domains
-Table with columns: Domain Name, Description, Associated Tools/Data. Each domain represents a kind of work the agent system needs to be good at (e.g., research, analysis, writing, data extraction).
+## Context Inventory
 
-#### Tools and Context Sources
-External systems, reference materials, with context readiness assessment for each:
-- Access (direct AI access vs. human intervention needed)
-- Interpretability (structured / semi-structured / unstructured)
-- Persistence (durable artifact vs. needs externalization)
+| ID | Artifact | Used By | Status | AI Accessible | Location / Source | Key Contents |
+|---|---|---|---|---|---|---|
+| C1 | [name] | [Step IDs or "All"] | Exists / Needs Creation | Yes / Partial / No | [path, URL, system name, or "Create as [path]"] | [what's in it] |
 
-#### Human Gates
-Where human review is expected — checkpoints during execution, or final review only.
+Notes:
+- For items with `Status: Needs Creation`, the Location column captures where the artifact should be persisted — AI must be able to reach it.
+- For organizational workflows, include existing process documentation here: SOPs, training guides, compliance requirements, SLAs.
+
+## Acceptance Criteria
+
+### What good output looks like
+[Concrete description in plain language — what would make the user say "this is exactly right"?]
+
+### Dimensions that matter
+- [Dimension] — [what to evaluate]
+- [Dimension] — [what to evaluate]
+
+### Minimum bar
+[What's acceptable vs. what needs more work — in plain terms, not a numeric threshold.]
+
+## Example Scenarios
+
+| ID | Scenario | Input | What to look for in the output |
+|---|---|---|---|
+| E1 | [short name] | [description] | [what makes this output "good"] |
+| E2 | … | … | … |
+
+## Human Gates
+
+| Where | What requires human input |
+|---|---|
+| [step ID or phase] | [decision, approval, review] |
+
+If no human gates are required, write: "No human gates — the workflow runs end-to-end with final review only."
+
+## Optimization Notes (optional, step-decomposed only)
+[Brief record of what changed from the original process and why — only if optimizations were applied in Step 7. Include declined optimizations and the reasoning, since this preserves context for Design.]
+```
+
+### Step-Decomposed middle block
+
+Insert between the Metadata table and the Context Inventory:
+
+```markdown
+## Steps Overview
+
+1. [Step name] — [one-line summary]
+2. [Step name] — [one-line summary]
+3. …
+
+## Step Details
+
+### Step 1 — [Step Name]
+- **Goal:** [what this step achieves, one sentence]
+- **Inputs:** [data/context coming in — name the artifact or reference a Context Inventory ID]
+- **Outputs:** [what passes to the next step]
+- **Rules & Edge Cases:**
+  - [decision criterion or branch]
+  - [what to do when an input is missing, malformed, or empty]
+  - [quality threshold or exception path]
+- **Context Needed:** [list of Context Inventory IDs the step depends on, e.g., C1, C3]
+- **Role:** [who performs this step — organizational lens only]
+
+### Step 2 — [Step Name]
+… (same fields)
+
+## Sequence
+
+- **Sequential steps:** [list]
+- **Parallel steps:** [list with grouping, e.g., "Steps 2 and 3 run in parallel"]
+- **Critical path:** [longest dependency chain]
+- **Role swimlane** (organizational lens only): [brief view of which role owns each step]
+```
+
+### Outcome-Driven middle block
+
+Insert between the Metadata table and the Context Inventory (omit Steps Overview, Step Details, and Sequence — there is no fixed step sequence for outcome-driven workflows):
+
+```markdown
+## Inputs
+
+- [What the agent system receives to start — data, materials, references, access]
+- [One bullet per discrete input]
+
+## Rules & Constraints
+
+- **Must do:** [list]
+- **Must never do:** [list]
+- **Scope boundaries:** [what's in scope, what's out]
+- **Tone / format / length:** [if applicable]
+- **Source restrictions:** [if applicable]
+```
+
+The Outcome, Metadata, Context Inventory, Acceptance Criteria, Example Scenarios, and Human Gates sections from the shared shell still apply — outcome-driven uses the same shell, just a different middle.
 
 ## Guidelines
 
-- Ask one question at a time — never present a wall of questions
-- Probe for missing steps — most people undercount by 30-50%
-- Surface hidden assumptions ("How do you decide when X is good enough?")
-- Use plain language; avoid jargon unless the user introduced it
-- Push beyond vague context answers like "domain knowledge" — identify the specific artifact
+- Ask one question at a time — never present a wall of questions.
+- Probe for missing steps — most people undercount by 30-50%.
+- Surface hidden assumptions ("How do you decide when X is good enough?").
+- Use plain language; avoid jargon unless the user introduced it.
+- Push beyond vague context answers like "domain knowledge" — identify the specific artifact.
 - Surface the assumption that existing context — data, documents, transcripts, reference materials — will "just work" for AI. Most people underestimate the work required to make context AI-accessible, especially unstructured content like SOPs, style guides, meeting transcripts, and knowledge that lives in people's heads. Adopt a data strategist lens — help the user see where context reorganization, reformatting, or externalization is needed before they commit to a workflow design that depends on inaccessible context. Push beyond "it's in the CRM" or "I just know it" — ask what system it's in, what format it's in, and whether there's programmatic access or it requires manual steps. Leave specific integration mechanisms (MCP, API, SDK) to the Design step.
-- Stay in the "what" lane. Deconstruct defines the workflow, its context needs, and its failure modes. It does not prescribe how AI will access data, which tools to use, or what integrations to build — those are Design decisions (Step 3). If a technology concern surfaces, note it as a consideration for Design rather than resolving it here.
-- After writing the Workflow Definition file, tell the user: "Workflow Definition saved to `outputs/[name]-definition.md`. Ready for the `design` skill (Step 3)."
+- **Stay in the "what" lane.** Deconstruct defines the workflow, its context needs, its rules, and its acceptance criteria. It does not prescribe how AI will access data, which tools to use, what integrations to build, how many agents are needed, or which models to use — those are Design decisions (Step 3). Do not ask the user about capability domains, agent architecture, model class, or orchestration mechanism. If a technology concern surfaces, note it as a consideration for Design rather than resolving it here.
+- After writing the Workflow Requirements file, tell the user: "Workflow Requirements saved to `outputs/[name]-requirements.md`. Ready for the `design` skill (Step 3)."
 - If entering deconstruction without a prior analysis (direct workflow description), determine the lens by asking if not obvious from context.
-- For outcome-driven definitions, do not force step decomposition — the whole point is to capture what the agent system needs to know without prescribing execution steps.
-- When the problem-first funnel (option b) recommends outcome-driven, explain why: "This looks like a workflow where the agent system should determine its own approach. I'd recommend the outcome-driven path because [reasoning]."
+- For outcome-driven workflows, do not force step decomposition — the whole point is to capture what the agent system needs to know without prescribing execution steps.

--- a/plugins/handsonai/skills/design/SKILL.md
+++ b/plugins/handsonai/skills/design/SKILL.md
@@ -1,19 +1,20 @@
 ---
 name: design
 description: >
-  This skill should be used when the user has a Workflow Definition and wants to design
+  This skill should be used when the user has a Workflow Requirements document and wants to design
   an AI workflow. It gathers architecture decisions, assesses workflow autonomy level,
   chooses an orchestration mechanism and involvement mode, classifies steps, maps building blocks,
   identifies skill candidates, configures agents, and produces a Design Spec for approval.
-  Supports both step-decomposed and outcome-driven Workflow Definitions.
+  Supports both step-decomposed and outcome-driven Workflow Requirements.
   This is Step 3 (Design) of the AI Workflow Framework.
-  Note: the Compose entry point in /deconstruct (option d) handles its own lightweight design inline and bypasses this skill.
 user-invocable: true
 ---
 
 # Workflow Design
 
-Take a Workflow Definition and produce the Design deliverable: a Design Spec that captures architecture decisions, autonomy assessment, orchestration mechanism, per-step classifications (step-decomposed) or capability domain mapping (outcome-driven), skill candidates, and agent blueprints.
+Take a Workflow Requirements document (produced by Step 2 — Deconstruct) and produce the Design deliverable: a Design Spec that captures architecture decisions, autonomy assessment, orchestration mechanism, per-step classifications (step-decomposed) or capability domain mapping (outcome-driven), skill candidates, and agent blueprints.
+
+**Source of truth:** The Workflow Requirements document is canonical. The Design Spec must NOT restate sections that already exist there (Outcome, Metadata, Context Inventory, Acceptance Criteria, Example Scenarios, Human Gates, Steps Overview). Instead, reference the Workflow Requirements file. The Design Spec adds *only* what Design produces: architecture decisions, per-step or per-domain building-block classifications, skill candidates, agent configurations, integration options, model recommendations, and implementation order.
 
 **Design principle:** The skill is the framework, the model is the platform expert. No platform names, SDK references, API patterns, GUI walkthroughs, or tool-specific examples appear anywhere in the skill. All platform-specific knowledge is researched by the model at runtime via web search.
 
@@ -29,25 +30,25 @@ The Design phase is collaborative — you plan the architecture together with th
 
 This is directive, not optional — plan mode is the preferred path for design collaboration.
 
-#### Step 1 — Load Workflow Definition
+#### Step 1 — Load Workflow Requirements
 
-Read the Workflow Definition from `outputs/[workflow-name]-definition.md`. If the user specifies a file path, use that. Otherwise, look for the most recent Workflow Definition in `outputs/`.
+Read the Workflow Requirements from `outputs/[workflow-name]-requirements.md`. If the user specifies a file path, use that. Otherwise, look for the most recent Workflow Requirements in `outputs/`.
 
-Read the `Definition Type` field from the Scenario Metadata. If `Outcome-Driven`, use the outcome-driven processing path for all subsequent steps (see **Outcome-Driven Processing Path** below). If `Step-Decomposed` (or no Definition Type field is present), use the standard step-decomposed path.
+Read the `Definition Type` field from the Metadata table. If `Outcome-Driven`, use the outcome-driven processing path for all subsequent steps (see **Outcome-Driven Processing Path** below). If `Step-Decomposed` (or no Definition Type field is present), use the standard step-decomposed path.
 
 #### Step 2 — Confirm Understanding
 
-For step-decomposed definitions: Summarize the workflow name, step count, and outcome. Ask the user to confirm before proceeding.
+For step-decomposed requirements: Summarize the workflow name, step count, and outcome (from the Outcome section of the Workflow Requirements). Ask the user to confirm before proceeding.
 
-For outcome-driven definitions: Summarize the workflow name, goal, capability domains, and constraints. Ask the user to confirm before proceeding.
+For outcome-driven requirements: Summarize the workflow name, outcome, and the headline rules and constraints (from the Outcome and Rules & Constraints sections). Ask the user to confirm before proceeding.
 
 #### Step 3 — Architecture Decisions
 
-Before assessing autonomy and orchestration, gather the information needed to make platform-aware recommendations. The approach: **one question, then extract everything else from the Workflow Definition.**
+Before assessing autonomy and orchestration, gather the information needed to make platform-aware recommendations. The approach: **one question, then extract everything else from the Workflow Requirements.**
 
 **a. One question: Platform**
 
-Platform is the only thing not already in the Workflow Definition. Determine the user's AI platform:
+Platform is the only thing not already in the Workflow Requirements. Determine the user's AI platform:
 - If stated in conversation or definition, confirm: "You mentioned [platform] — is that still correct?"
 - If not stated, ask. Let the user name their tool — do not present a fixed list.
 
@@ -56,15 +57,15 @@ Accept whatever level of specificity the user provides — "Claude Code", "Googl
 - **For Orchestration Mechanism:** The recommendation is driven by workflow characteristics first (tool use? autonomous decisions? multiple domains?). If the recommended mechanism requires capabilities the named platform might or might not support (e.g., recommending an agent when "Google Gemini" could mean the web app or ADK), ask a **motivated follow-up** in context.
 - **For Build:** The specific offering (Claude Code vs. Claude.ai, ADK vs. Gemini web) is resolved when generating artifacts in the Build phase — not during Design.
 
-**b. Extract everything else from the Workflow Definition**
+**b. Extract everything else from the Workflow Requirements**
 
-After confirming the platform, read the Workflow Definition and extract:
+After confirming the platform, read the Workflow Requirements and extract:
 
-- **Tool integrations** — from Data In, Context Needed, and Context Shopping List across all steps. Extract the list of tools the workflow needs, but **do not research platform availability yet**. That happens in Build. Simply list the tools identified.
+- **Tool integrations** — from per-step Inputs, Context Needed, and the Context Inventory. Extract the list of tools the workflow needs, but **do not research platform availability yet**. That happens in Build. Simply list the tools identified.
 
-- **Trigger/schedule** — from Scenario Metadata. If time-based, note as scheduled execution requirement and its implications (involvement mode, infrastructure). If manual, no action needed.
+- **Trigger/schedule** — from the Metadata table. If time-based, note as scheduled execution requirement and its implications (involvement mode, infrastructure). If manual, no action needed.
 
-- **Context readiness flags** — from the Context Shopping List's AI Accessible? and Readiness Notes columns. Summarize items flagged as "Partial" or "No" — these may be structured data, but also documents, transcripts, or reference materials that aren't AI-accessible. These inform step classification — a step that depends on inaccessible context may need:
+- **Context readiness flags** — from the Context Inventory's `AI Accessible` column. Summarize items flagged as `Partial` or `No` — these may be structured data, but also documents, transcripts, or reference materials that aren't AI-accessible. These inform step classification — a step that depends on inaccessible context may need:
   - A prerequisite human step prepended (e.g., "Export CRM data to CSV")
   - A different autonomy classification (Autonomous → Guided or Human, because a human must bridge the context gap)
   - An integration research priority flag for the Build phase (this tool connection is critical, not just nice-to-have)
@@ -77,7 +78,7 @@ After confirming the platform, read the Workflow Definition and extract:
 
 Present a single confirmation block:
 
-> "Here's what I found in your Workflow Definition:
+> "Here's what I found in your Workflow Requirements:
 > - **Platform:** [confirmed platform]
 > - **Tools needed:** [extracted list]
 > - **Trigger:** [extracted trigger] → [implications for involvement mode]
@@ -94,6 +95,8 @@ Present a single confirmation block:
 - Scheduled trigger + platform doesn't support unattended runs → flag infrastructure needed
 - State which extracted facts influenced the autonomy assessment and orchestration mechanism recommendation
 
+**Packaging is determined later, in Step 5.** Once the mechanism is selected, Step 5 proposes a Packaging value based on platform and mechanism (e.g., single skill → Standalone Skill; agent + skills on ChatGPT → Workspace Agent). Do not ask about Packaging during Step 3 — it depends on Step 5's mechanism decision.
+
 #### Step 4 — Autonomy Assessment
 
 Before choosing an orchestration mechanism, assess where the *whole workflow* sits on the autonomy spectrum. This is the same spectrum used for per-step classification (Step 6), applied at the workflow level.
@@ -107,6 +110,7 @@ Human ———— Deterministic ———————— Guided —————
 
 | Level | Signals | Orchestration implications |
 |-------|---------|--------------------------|
+| **Human** | Step requires human judgment, creativity, or physical action; AI cannot perform | No AI artifact — captured as Human step in the Decomposition table |
 | **Deterministic** | Steps always execute in the same order, no branching on output quality, failure = stop or retry same step | Prompt or skill-powered prompt likely sufficient |
 | **Guided** | Some steps involve bounded AI judgment, human steers at checkpoints, sequence is mostly fixed but with bounded flexibility | Skill-powered prompt or agent |
 | **Autonomous** | Executor backtracks, re-invokes based on feedback, adjusts approach on failure, human checkpoints can redirect flow | Agent required |
@@ -140,12 +144,15 @@ Single-agent vs. multi-agent is an architecture detail decided during Agent Conf
 
 Ask the user to confirm the mechanism, involvement mode, and platform sub-choice (if applicable).
 
-**Fast-track for complete definitions:** If the Workflow Definition + conversation context provide enough information to resolve ALL architecture dimensions, the autonomy level, AND the orchestration mechanism, present the entire Design analysis as a single confirmation block instead of stepping through questions one at a time.
+**Fast-track for complete Workflow Requirements:** If the Workflow Requirements + conversation context provide enough information to resolve ALL architecture dimensions, the autonomy level, AND the orchestration mechanism, present the entire Design analysis as a single confirmation block instead of stepping through questions one at a time.
 
-For step-decomposed definitions:
+**Packaging decision:** Before the Layer 1 confirmation, propose a Packaging value based on the platform and the workflow's shape (single skill → Standalone Skill; multiple related artifacts → Plugin; ChatGPT with agent + skills → Workspace Agent; ad-hoc files → Loose Files). The user confirms or overrides.
+
+For step-decomposed workflows:
 
 > "Based on your workflow definition, here's my design analysis:
 > - **Platform:** [platform] ([surface])
+> - **Packaging:** [packaging value] — [reason]
 > - **Autonomy level:** [level] — [brief rationale]
 > - **Orchestration mechanism:** [mechanism] ([involvement mode])
 > - **Tools needed:** [list — availability to be researched during Build]
@@ -155,10 +162,11 @@ For step-decomposed definitions:
 >
 > Does this look right, or would you like to adjust anything?"
 
-For outcome-driven definitions:
+For outcome-driven workflows:
 
 > "Based on your outcome-driven workflow definition, here's my design analysis:
 > - **Platform:** [platform] ([surface])
+> - **Packaging:** [packaging value] — [reason]
 > - **Autonomy level:** Autonomous (by definition — agent determines its own execution path)
 > - **Orchestration mechanism:** Agent ([involvement mode])
 > - **Tools needed:** [list — availability to be researched during Build]
@@ -169,6 +177,20 @@ For outcome-driven definitions:
 > Does this look right, or would you like to adjust anything?"
 
 Only drop into the question-by-question flow when genuinely missing information.
+
+**Layer 1 confirmation moment** (after Step 5, before moving to Step 6):
+
+The architecture work is complete. Before classifying each step, confirm the L1 decisions are right — catching strategic errors before investing in L2/L3 work:
+
+> "Architecture confirmed:
+> - **Platform:** [platform] ([surface])
+> - **Mechanism:** [mechanism] ([involvement mode])
+> - **Autonomy:** [level]
+> - **Packaging:** [packaging value]
+>
+> Moving to Layer 2 — Decomposition. I'll classify each step and identify which building blocks deliver each one. Confirm to proceed, or push back on any of the above."
+
+If the user pushes back, revise the relevant L1 decisions and re-confirm before proceeding. This is a lightweight confirmation, not a hard gate — but it's the cheapest moment to catch architecture mistakes.
 
 #### Step 6 — Classify Each Step
 
@@ -214,7 +236,7 @@ Each row captures one step. The Orchestration column shows the block from that l
 
 Additionally, for each step record the **autonomy level** and **role** (these appear in the full spec output but are omitted from the compact table above for readability).
 
-If a step's inputs include items flagged as "No" or "Partial" in the Context Shopping List, note this in the classification. A step classified as Autonomous but dependent on inaccessible data should be flagged: "Autonomy contingent on resolving data access for [item]."
+If a step's inputs include items flagged as "No" or "Partial" in the Context Inventory, note this in the classification. A step classified as Autonomous but dependent on inaccessible data should be flagged: "Autonomy contingent on resolving data access for [item]."
 
 Present the mapping as a clear table. Walk through reasoning for non-obvious classifications. Ask if the user wants to adjust anything.
 
@@ -286,6 +308,21 @@ For outcome-driven: `**[Tool] access needed (Domains: X, Y):**`
 >
 > *Recommendation: [block] for [rationale]*
 
+**Layer 2 confirmation moment** (after Step 6, before Skill Discovery and Component Blueprints):
+
+The decomposition is complete. Before generating detailed component blueprints (the most expensive work to redo), confirm the L2 decisions are right:
+
+> "Decomposition confirmed:
+> - **Steps requiring new skills:** [count] — [list step IDs and proposed skill names]
+> - **Steps using existing skills:** [count] — [list step IDs and existing skill names]
+> - **Steps as inline prompts:** [count] — [list step IDs]
+> - **Steps requiring agents:** [count] — [list]
+> - **Human-performed steps:** [count] — [list]
+>
+> Moving to Layer 3 — Component Blueprints. I'll write the field-level spec for each new skill and agent. Confirm to proceed, or push back on the decomposition."
+
+If the user pushes back, revise the L2 decomposition (and possibly L1 if the disagreement is architectural). Re-confirm before proceeding. Like the L1 confirmation, this is lightweight — not a hard gate — but it's the last cheap moment to catch decomposition mistakes before the detailed spec work.
+
 #### Step 6b — Skill Discovery
 
 For every step classified as needing a **Skill** in Step 6, search for existing skills before assuming one needs to be built.
@@ -331,7 +368,7 @@ For every step classified as needing a **Skill** in Step 6, search for existing 
 
 **Presentation format:**
 
-For each step (or capability domain, for outcome-driven definitions) that needs a skill, present candidates in a table:
+For each step (or capability domain, for outcome-driven workflows) that needs a skill, present candidates in a table:
 
 > **[Step 3 / Domain: Research] needs a skill: "Format coaching prep notes"**
 > | Source | Skill | Status |
@@ -349,75 +386,115 @@ If no suitable existing skill is found for a step, tag that step as **"build new
 
 For steps where Skill Discovery (Step 6b) found an existing skill, skip to the next step.
 
-This step only applies to steps tagged **"build new"** in Step 6b. Tag those steps that should become skills. For each skill candidate, document:
-- Purpose (one sentence)
-- Covers steps / domains (which step numbers or capability domains this skill spans)
-- Inputs (what data the skill receives)
-- Outputs (what the skill produces)
-- Decision logic (key rules, criteria, frameworks)
-- Failure modes (what happens when inputs are missing or unexpected)
-- Required tools (which integration blocks the skill needs at runtime — e.g., MCP: Notion)
-- Depends on (other skills or artifacts that must exist before this skill can function)
+This step only applies to steps tagged **"build new"** in Step 6b. Tag those steps that should become skills. For each skill candidate, gather all 12 fields. The complete field set is defined in the Skill Candidates template section in Step 9 — collect every field during the collaborative session so the spec is complete on first write:
+
+- **ID** — stable skill ID (S1, S2, …)
+- **Name** — lowercase-hyphenated, ≤64 chars, no consecutive hyphens; matches the skill directory name
+- **Description** — ≤1024 chars, MUST start with "This skill should be used when..." — verbatim text for the SKILL.md frontmatter; drives auto-activation
+- **Purpose** — one-sentence internal summary for the spec reader
+- **Covers Steps / Domains** — which step IDs (or capability domains) this skill spans
+- **Inputs** — what the skill receives
+- **Outputs** — what the skill produces
+- **Decision Logic** — key rules, criteria, evaluation frameworks
+- **Failure Modes** — condition → action, one per line
+- **Required Tools** — integration blocks the skill needs at runtime (e.g., MCP: Notion)
+- **Depends On** — other skill IDs (S2, S3) or artifacts that must exist first, or "None"
+- **Stateful?** — Yes / No, does the skill maintain state across invocations? Drives Memory building-block decisions.
 
 #### Step 8 — Agent Configuration
 
-(When orchestration mechanism is Agent.) For each agent the workflow needs, document:
+(When orchestration mechanism is Agent.) For each agent the workflow needs, gather all 13 fields. The complete field set is defined in the Agent Configuration template section in Step 9 — collect every field during the collaborative session so the spec is complete on first write:
 
-| Component | What to specify |
+| Field | What to specify |
 |-----------|----------------|
-| **Name** | Unique agent name |
-| **Purpose** | When this agent should be invoked (trigger conditions) |
-| **Instructions** | Mission, responsibilities, behavior, goals, tone & style, output format |
-| **Model** | Recommended capability tier: reasoning-heavy / fast / vision |
-| **Tools** | External tools the agent needs (from Integration Options) |
-| **Skills** | Which skill candidates this agent should have access to |
-| **Trigger Examples** | 2-3 example scenarios showing when/how the agent is invoked |
+| **ID** | Stable agent ID (A1, A2, …) |
+| **Name** | Unique agent name (lowercase-hyphenated, matches the agent filename without extension) |
+| **Description** | ≤1024 chars, MUST start with "Use this agent when..." — verbatim text for the agent file frontmatter; drives invocation |
+| **Mission** | One-sentence primary purpose |
+| **Responsibilities** | Bulleted list of what the agent does once invoked |
+| **Output Format** | Structured description of what the agent's output should look like |
+| **Tone & Style** | Voice and register (e.g., "concise, technical, no hedging") |
+| **Constraints** | Must-not-dos, scope boundaries, source restrictions |
+| **Model** | Capability tier: reasoning-heavy / fast / vision |
+| **Memory Scope** | user / project / local / none — cross-session learning scope |
+| **Tools** | External tools the agent needs (reference Integration Options entries by tool name) |
+| **Skills** | Skill IDs the agent has access to (S1, S2, …) |
+| **Trigger Examples** | 2-3 structured examples (context → user message → expected behavior → invocation) — Build uses these verbatim as `<example>` blocks in the description |
 
 The build skill maps these to platform-specific fields at runtime (e.g., "reasoning-heavy" → `opus` on Claude Code, trigger examples → `<example>` blocks).
 
-For multi-agent: orchestration pattern, agent handoffs, human review gates.
+For multi-agent: orchestration pattern, agent handoffs, human review gates — see the Multi-Agent Configuration section in the template.
 
-#### Step 8b — Evaluation Criteria
+#### Step 8b — Verify Evaluation Inputs
 
-Before generating the spec, gather evaluation criteria from the user. These feed directly into Step 5 (Test) where the workflow is evaluated against them, and Step 7 (Improve) where iteration decisions reference the quality bar established here.
+The Workflow Requirements already includes **Acceptance Criteria** (what good looks like, dimensions that matter, minimum bar) and **Example Scenarios** (3-5 representative inputs with what to look for) from the Deconstruct step. Do **not** ask the user to re-state these.
 
-**For step-decomposed definitions:**
+Confirm them briefly:
 
-Prompt the user:
+> "Your Workflow Requirements includes Acceptance Criteria and [N] Example Scenarios. These feed directly into Step 5 (Test). Anything to add or adjust before I generate the Design Spec?"
 
-> "Before generating the spec, I need to understand what good output looks like for this workflow. This feeds directly into Step 5 (Test) where you'll evaluate the workflow against these criteria."
+If the user adds or adjusts anything, update the Workflow Requirements file (not the Design Spec) — that file remains the canonical source of acceptance criteria and test scenarios. The Design Spec references them by file path; it does not duplicate them.
 
-Then ask these four questions, one at a time:
-
-1. "Describe what a great output from this workflow looks like — not format, but quality. What would make you say 'this is exactly right'?"
-2. "Which dimensions matter most? For example: accuracy, completeness, tone, specificity, timeliness, format consistency."
-3. "Give me 3-5 real or realistic scenarios you'd run this on — different enough to test the workflow's range. For each, briefly describe the input and what you'd look for in the output."
-4. "What's your minimum bar? What quality level is acceptable vs. needs more work?"
-
-Capture the answers for the Evaluation Criteria section of the spec.
-
-**For outcome-driven definitions:**
-
-The Workflow Definition already includes Quality Criteria from the Deconstruct interview. Carry these forward rather than asking from scratch:
-
-> "Your Workflow Definition includes these quality criteria: [list from definition]. These feed directly into Step 5 (Test). Anything to add or adjust?"
-
-Then ask only the supplementary questions not already covered:
-- If test scenarios are missing: "Give me 3-5 real or realistic scenarios you'd run this on."
-- If minimum bar is missing: "What's your minimum bar? What quality level is acceptable vs. needs more work?"
+If the Workflow Requirements is missing Acceptance Criteria or Example Scenarios entirely (which shouldn't happen if Deconstruct was run), pause and ask the user to run `/deconstruct` again or fill them in manually before continuing.
 
 #### Step 9 — Generate Design Spec
 
 Write to `outputs/[workflow-name]-design-spec.md` using the template below. Every section is mandatory unless marked (optional). Do not add, remove, rename, or reorder sections.
 
-**Before writing, run the Build Skill Needs Checklist** (at the end of this step) to verify all required data has been captured.
+**Generation order:**
+
+1. Generate all spec sections (frontmatter through Stakeholders) following the template.
+2. **Run the Build Skill Needs Checklist** (at the end of this step) to verify every required field is present and well-formed.
+3. **Write the Self-Test Summary section** as the final section of the spec. For each checklist item, mark ✓ (passed) or ⚠️ (issue — describe inline). This makes the verification visible to the user and to downstream consumers.
+4. If any checklist item failed (⚠️), fix the underlying section before writing the spec. The Self-Test Summary should ideally show all ✓ — but if a ⚠️ remains (e.g., a deliberate gap that the user accepted), it's surfaced honestly.
+
+**Conditional sections to generate:**
+- `Orchestrator Prompt Outline` — only when mechanism is `Prompt` or `Skill-Powered Prompt`. Omit for `Agent`.
+- `Agent Configuration` — only when mechanism is `Agent`. (Mandatory for outcome-driven.)
+- `Multi-Agent Configuration` — only when more than one agent is defined.
+- `Stakeholders` — only for Organizational lens.
 
 ---
 
 **Template:**
 
 ```markdown
+---
+workflow: [kebab-case name]
+requirements_file: outputs/[workflow-name]-requirements.md
+spec_version: 2.1
+definition_type: Step-Decomposed | Outcome-Driven
+mechanism: Prompt | Skill-Powered Prompt | Agent
+involvement: Augmented | Automated
+platform: [user's platform, e.g., Claude Code, Claude.ai, Cowork, Codex, ChatGPT, Gemini CLI]
+platform_mode: code | guided
+packaging: Plugin | Standalone Skill | Workspace Agent | Loose Files
+counts:
+  steps: [N]
+  skills: [N]
+  agents: [N]
+  integrations: [N]
+---
+
 # [Workflow Name] — Design Spec
+
+## Source
+
+**Workflow Requirements:** `outputs/[workflow-name]-requirements.md`
+
+This Design Spec consumes the Workflow Requirements as canonical input. Outcome, Metadata, Context Inventory, Acceptance Criteria, Example Scenarios, Human Gates, Steps Overview, and per-step requirements are defined there — not restated here. Read the Workflow Requirements alongside this spec when building.
+
+The spec is organized into three layers that build on each other:
+
+1. **Architecture (L1)** — strategic decisions: platform, mechanism, autonomy, packaging
+2. **Decomposition (L2)** — for each step (or capability domain), what AI building block delivers it
+3. **Component Blueprints (L3)** — field-level specs for each new skill and agent
+
+---
+
+## Layer 1 — Architecture
+
+*Strategic decisions that shape everything downstream.*
 
 ## Execution Pattern
 
@@ -432,107 +509,26 @@ Write to `outputs/[workflow-name]-design-spec.md` using the template below. Ever
 | Platform Mode | code / guided | [inferred from platform or confirmed] |
 | Orchestration | Prompt / Skill-Powered Prompt / Agent | [reason] |
 | Involvement | Augmented / Automated | [reason] |
-| Trigger | [trigger description] | [implications for involvement, infrastructure] |
+| Packaging | Plugin / Standalone Skill / Workspace Agent / Loose Files | [reason — determines how Build groups and ships artifacts] |
+| Trigger | [trigger description from Workflow Requirements] | [implications for involvement, infrastructure] |
 
-## Scenario Summary
+**Packaging values:**
+- **Plugin** — Multiple related artifacts shipped together (e.g., handsonai-plugins marketplace plugin, set of `.claude/` files distributed via marketplace).
+- **Standalone Skill** — A single skill, uploaded directly (e.g., zip uploaded to Claude.ai, single SKILL.md in `.claude/skills/`, Codex skill in `.agents/skills/`, ChatGPT skill).
+- **Workspace Agent** — A ChatGPT Workspace Agent that bundles orchestration + skills + tools as a unit. (Custom GPTs are deprecated; Workspace Agents are the current ChatGPT primitive.)
+- **Loose Files** — Individual files in a project directory, no distribution layer.
 
-| Field | Value |
-|---|---|
-| **Workflow Name** | [name] |
-| **Description** | [full description] |
-| **Outcome** | [what a successful run produces] |
-| **Trigger** | [when/how it starts] |
-| **Type** | Augmented / Automated |
-| **Business Process** | [functional category] |
-| **Owner** | [person or role] |
+## Autonomy Spectrum Summary
 
-## Step-by-Step Decomposition
+The workflow-level autonomy assessment and the rationale that drove it. (Per-step autonomy classifications appear in the Decomposition table below.)
 
-| Step | Name | Phase | Autonomy | Orchestration | Integration (use/build) | Intelligence | Skill Candidate? | Human Gate? |
-|------|------|-------|----------|---------------|------------------------|--------------|-------------------|-------------|
+For step-decomposed workflows: group steps by autonomy level. For each group, explain WHY those steps have that classification.
 
-Column definitions:
-- **Autonomy**: Human / Deterministic / Guided / Autonomous (canonical terms only)
-- **Orchestration**: Prompt / Skill / Agent
-- **Integration**: Block + tool + action tag (e.g., "MCP: Notion (use)") or "—" if none
-- **Intelligence**: Model class + context sources + memory flag (e.g., "Model: fast" or "Model: reasoning; Context: pillar-definitions")
-- **Skill Candidate?**: Skill name (if new), "Exists: [name]" (if pre-built), or "No"
-- **Human Gate?**: Yes / No
-
-### Autonomy Spectrum Summary
-
-Group steps by autonomy level. For each group, explain WHY those steps have that classification.
-
-## Skill Candidates
-
-For each skill candidate (steps tagged with a new skill name above):
-
-### [skill-name] (Step N)
-
-| Dimension | Detail |
-|---|---|
-| **Purpose** | [one sentence] |
-| **Covers Steps / Domains** | [list of step numbers, or capability domain names for outcome-driven] |
-| **Inputs** | [name (type, default)] |
-| **Outputs** | [what the skill produces] |
-| **Decision Logic** | [key rules, criteria, evaluation frameworks — multiline OK] |
-| **Failure Modes** | [condition → action, one per line] |
-| **Required Tools** | [block: tool (action) — e.g., MCP: Notion (use)] |
-| **Depends On** | [other skills or artifacts that must exist first, or "None"] |
-
-## Agent Configuration (optional — only when orchestration = Agent)
-
-For each agent:
-
-### [agent-name]
-
-| Component | Detail |
-|---|---|
-| **Name** | [lowercase-hyphenated] |
-| **Purpose** | [when this agent should be invoked] |
-| **Instructions** | [mission, responsibilities, behavior, goals, tone, output format] |
-| **Model** | [capability tier: reasoning-heavy / fast / vision] |
-| **Tools** | [external tools needed, from Integration Options] |
-| **Skills** | [skill candidates this agent should have access to] |
-| **Trigger Examples** | [2-3 scenarios: situation → user message → agent response] |
-
-For multi-agent: orchestration pattern, agent handoffs, human review gates.
-
-## Step Sequence and Dependencies
-
-\`\`\`
-[ASCII diagram showing parallel and sequential paths]
-\`\`\`
-
-**Parallel:** [which steps can run concurrently]
-**Sequential:** [which steps must run in order]
-**Critical path:** [longest dependency chain]
-
-## Prerequisites
-
-1. [Numbered list of requirements that must be in place before the workflow can run]
-
-## Context Inventory
-
-| # | Artifact | Type | Used By | Status | Location | Key Contents |
-|---|---|---|---|---|---|---|
-
-Column definitions:
-- **Type**: MCP Data Source / Context / External
-- **Status**: Exists / Create
-- **Location**: File path, URL, database name, or "Create as [path]" / "Create inline in prompt"
-
-## Data Readiness Summary
-
-Items NOT fully AI-accessible. If all items are accessible, state: "All context items are AI-accessible. No data readiness actions required."
-
-| Context Item | Current State | Required Action | Affects Steps |
-|---|---|---|---|
-| [item] | AI-Accessible / Partial / No | [action needed] | [step numbers] |
+For outcome-driven workflows: replace this section with an **Autonomy Statement** — a brief paragraph stating: "This is an outcome-driven workflow. Autonomy is Autonomous — the agent system determines its own execution path based on the Outcome, Inputs, Rules & Constraints, and Acceptance Criteria defined in the Workflow Requirements."
 
 ## Integration Options
 
-For each tool identified in the Integration column of the Step-by-Step Decomposition (or Capability Domain Mapping for outcome-driven):
+For each tool identified in the Decomposition table (or Capability Domain Mapping for outcome-driven):
 
 ### [Tool Name] (Steps N, M / Domains: X, Y)
 
@@ -552,46 +548,232 @@ For each tool identified in the Integration column of the Step-by-Step Decomposi
 
 ## Model Recommendation
 
-**Default:** [reasoning-heavy / fast / vision] — [rationale]
+**Default capability:** [reasoning-heavy / fast / vision] — [rationale]
 
 **Per-step overrides** (optional):
-- Steps N, M: [different model class] — [rationale]
+- Steps N, M: [different capability] — [rationale]
+
+**Per-platform mapping** (Build resolves at generation time):
+- Claude Code / Claude.ai / Cowork: `opus` (reasoning-heavy) / `sonnet` (balanced) / `haiku` (fast)
+- ChatGPT / Codex: `gpt-5` or `o3` (reasoning-heavy) / `gpt-4o` (balanced) / `gpt-4o-mini` (fast)
+- Gemini: `gemini-2.5-pro` (reasoning-heavy) / `gemini-2.5-flash` (fast)
+
+(These mappings are guidance; Build verifies current model names via web search before generating.)
+
+---
+
+## Layer 2 — Decomposition
+
+*For each step or capability domain, what AI building block delivers it. Layer 2 sections in order: Step-by-Step Decomposition (or Capability Domain Mapping for outcome-driven), Orchestrator Prompt Outline (conditional on mechanism), Data Readiness Summary, Recommended Implementation Order.*
+
+## Step-by-Step Decomposition
+
+Steps are defined in the Workflow Requirements. This table adds the building-block classification and the concrete Build output for each:
+
+| Step | Name (from Requirements) | Autonomy | Orchestration | Integration (use/build) | Intelligence | Build Output | Human Gate? |
+|------|------|----------|---------------|------------------------|--------------|--------------|-------------|
+
+Column definitions:
+- **Step**: Step ID from Workflow Requirements (e.g., Step 1, Step 2)
+- **Autonomy**: Human / Deterministic / Guided / Autonomous (canonical terms only)
+- **Orchestration**: Prompt / Skill / Agent
+- **Integration**: Block + tool + action tag (e.g., "MCP: Notion (use)") or "—" if none
+- **Intelligence**: Model class + context sources + memory flag (e.g., "Model: fast" or "Model: reasoning; Context: C2, C5")
+- **Build Output**: One of: `New skill: S1` (build a new skill, defined below) / `Use existing: [name]` (reference an existing skill) / `New agent: A1` (build a new agent, defined below) / `Inline prompt → Workflow Requirements Step N` (this step becomes a prompt block in the orchestrator, sourced from the named step's requirements) / `MCP server: [name]` (configure a connector) / `Human (no artifact)` (no AI artifact — human-performed)
+- **Human Gate?**: Yes / No (sourced from Workflow Requirements Human Gates table)
+
+## Orchestrator Prompt Outline
+
+*Include this section only when mechanism is `Prompt` or `Skill-Powered Prompt`. Omit for `Agent` (the agent IS the orchestrator — see Agent Configuration below).*
+
+The high-level shape of the orchestrator prompt the user runs to execute the workflow. This is not the full prompt text — it's the structural skeleton Build expands into the orchestrator. Build derives full step content from the Workflow Requirements' Step Details.
+
+```
+[Intro: one paragraph describing what this prompt does and when to run it]
+
+[Step 1 invocation]
+  - Source: Workflow Requirements Step 1
+  - Build Output: [from Decomposition table]
+  - User provides: [inputs from Workflow Requirements]
+  - Produces: [outputs from Workflow Requirements]
+
+[PAUSE for user review — sourced from Workflow Requirements Human Gates table]
+  - What user is reviewing: [describe]
+  - User decides: [decision criteria]
+
+[Step 2 invocation]
+  - ...
+
+[Final output: what the workflow delivers, format, where it goes]
+```
+
+Use the actual Step IDs and Build Output values. Mark PAUSE points where Human Gates apply. Indicate where the user provides input vs. where the workflow runs autonomously.
+
+## Data Readiness Summary
+
+Items in the Workflow Requirements' Context Inventory flagged as `Partial` or `No` for AI Accessible. If all items are `Yes`, state: "All context items are AI-accessible. No data readiness actions required."
+
+| Context ID | Current State | Required Action | Affects Steps |
+|---|---|---|---|
+| C1 | Partial / No | [action needed — e.g., "Export weekly to /data/foo.csv"] | [step numbers] |
 
 ## Recommended Implementation Order
 
+Build artifacts in this order. Dependencies within each tier follow the `Depends On` field of each skill.
+
 ### Quick Wins (implement first)
-1. **[name]** — [rationale]
+1. **[Artifact ID + name]** — [rationale]
 
 ### Core (implement second)
-1. **[name]** — [rationale]
+1. **[Artifact ID + name]** — [rationale]
 
 ### Future Enhancement (optional)
-1. **[name]** — [rationale]
+1. **[Artifact ID + name]** — [rationale]
 
-## Where to Run
+---
 
-**[Platform]** with [setup requirements]. [Recommendation for frequent use.]
+## Layer 3 — Component Blueprints
 
-## Evaluation Criteria
+*Field-level specs for each new skill, agent, and configuration. Build uses these to generate artifacts.*
 
-### What good output looks like
-[Concrete description in plain language — what would make you say "this is exactly right"?]
+## Skill Candidates
 
-### Quality dimensions
-[Which dimensions matter for this workflow — e.g., accuracy, completeness, tone, format, timeliness, specificity]
+For each Build Output tagged `New skill: SN` above:
 
-### Test scenarios
-[3-5 representative inputs that exercise the workflow's range — real or realistic examples]
+### S1 — [skill-name]
 
-| # | Scenario | Input description | What to look for |
-|---|----------|-------------------|------------------|
+| Field | Detail |
+|---|---|
+| **ID** | S1 |
+| **Name** | [lowercase-hyphenated, ≤64 chars, no consecutive hyphens; matches the skill directory name] |
+| **Description** | [≤1024 chars; MUST start with "This skill should be used when..." — this is the literal description that goes into the SKILL.md frontmatter and drives auto-activation on Claude.ai, Cowork, and code-mode platforms] |
+| **Purpose** | [one-sentence internal summary — for the Design Spec reader, not the skill description] |
+| **Covers Steps / Domains** | [list of Step IDs, or capability domain names for outcome-driven] |
+| **Inputs** | [name — description, one per line; "type" is the expected user-provided value description, not a strict type system] |
+| **Outputs** | [what the skill produces] |
+| **Decision Logic** | [key rules, criteria, evaluation frameworks — multiline OK] |
+| **Failure Modes** | [condition → action, one per line] |
+| **Required Tools** | [block: tool (action) — e.g., MCP: Notion (use)] |
+| **Depends On** | [other skill IDs (S2, S3) or artifacts that must exist first, or "None"] |
+| **Stateful?** | Yes / No — does the skill maintain state across invocations? Drives Memory building-block decisions. |
 
-### Minimum quality bar
-[What's acceptable vs. what needs iteration — in plain terms, not a numeric threshold]
+## Agent Configuration (mandatory when orchestration = Agent; otherwise omit)
+
+For each Build Output tagged `New agent: AN` above:
+
+### A1 — [agent-name]
+
+| Field | Detail |
+|---|---|
+| **ID** | A1 |
+| **Name** | [lowercase-hyphenated, matches the agent filename without extension] |
+| **Description** | [≤1024 chars; MUST start with "Use this agent when..." — this is the literal description that goes into the agent file frontmatter and drives invocation. Include 2-3 `<example>` blocks (see Trigger Examples field below) inline at the end.] |
+| **Mission** | [one-sentence primary purpose] |
+| **Responsibilities** | [bulleted list of what the agent does once invoked] |
+| **Output Format** | [structured description of what the agent's output should look like — sections, fields, format constraints] |
+| **Tone & Style** | [voice/register, e.g., "concise, technical, no hedging"] |
+| **Constraints** | [must-not-dos, scope boundaries, source restrictions] |
+| **Model** | [capability tier: reasoning-heavy / fast / vision] |
+| **Memory Scope** | user / project / local / none — controls cross-session learning (Claude Code agent format supports this; on other platforms, document the equivalent) |
+| **Tools** | [external tools needed — reference Integration Options entries by tool name] |
+| **Skills** | [Skill IDs the agent has access to — S1, S2, …] |
+| **Trigger Examples** | [2-3 structured examples, each: context → user message → expected agent behavior → invocation. Build uses these verbatim to construct the `<example>` blocks in the agent's description field.] |
+
+## Multi-Agent Configuration (only when more than one agent is defined)
+
+**Orchestration Pattern:** Supervisor (one agent delegates to others) / Pipeline (agents in sequence) / Parallel (agents run concurrently) / Network (agents call each other peer-to-peer)
+
+**Coordinator:** [Agent ID that coordinates, or "Pattern-based" if no single coordinator]
+
+**Handoff Contracts:**
+
+| From → To | Trigger | Data Passed | Format |
+|---|---|---|---|
+| A1 → A2 | [when A1 finishes / when condition X] | [what data passes] | [format / schema description] |
+
+**Aggregation Strategy:** [How results combine if parallel or network — last-writer-wins, merge, supervisor-decides, etc. Write "N/A" for Pipeline.]
+
+## Prerequisites
+
+1. [Numbered list of requirements that must be in place before the workflow can run — focus on platform setup, accounts, credentials, plugin installs. The Workflow Requirements covers content artifacts via its Context Inventory.]
+
+## Deployment Plan
+
+For each artifact produced, document where it lives and how it gets deployed:
+
+| Artifact | Target Location | Deployment Steps |
+|---|---|---|
+| S1 — `[name]` | [platform-specific path or destination] | [high-level steps; Build expands during artifact generation] |
+| A1 — `[name]` | [platform-specific path or destination] | [high-level steps] |
+| MCP: [tool] | [where the config lives] | [install/auth steps] |
+
+**Packaging note:** [How the artifacts ship together based on the Packaging decision — e.g., "All S1–S3 + A1 bundle into a plugin in the user's marketplace fork"; "Each skill uploaded individually to Claude.ai"; "All instructions consolidated into one GPT's instructions field"]
+
+**Recommended for frequent use:** [recommendation, e.g., "Save as Claude Project for one-click reuse"]
+
+---
+
+## Cross-Layer Sections
+
+*These sections apply across all three layers — handoff and metadata that doesn't belong to a single layer.*
+
+## Evaluation Inputs
+
+**Acceptance Criteria, Example Scenarios, and Human Gates are sourced from the Workflow Requirements file** (`outputs/[name]-requirements.md`). Do not duplicate them here. Step 5 (Test) reads them from that file directly.
+
+## Deferred to Build
+
+Decisions intentionally left for Build to resolve. Build should not need to re-ask the user about anything else in the spec.
+
+- [ ] Specific platform offering (if platform was given at ecosystem level, e.g., "Claude" vs Claude Code/Claude.ai/Cowork)
+- [ ] Shareability (file vs code distribution mode)
+- [ ] Exact model version per platform (mapping above is guidance; Build verifies current names)
+- [ ] Integration setup specifics (auth flow, region, plan tier)
 
 ## Stakeholders (optional — only for Organizational lens)
 
-[Role swimlane diagram and stakeholder details]
+[Role swimlane diagram and stakeholder details — sourced from Workflow Requirements Metadata.]
+
+## Self-Test Summary
+
+*Populated by the Design skill after running the Build Skill Needs Checklist. Each item marks ✓ (passed) or ⚠️ (issue — described inline). Lets users and downstream consumers see what was verified before approval.*
+
+### Structure
+- ✓ / ⚠️ Frontmatter present with all required fields (workflow, requirements_file, spec_version, definition_type, mechanism, involvement, platform, platform_mode, packaging, counts)
+- ✓ / ⚠️ Source section names Workflow Requirements file
+- ✓ / ⚠️ Architecture Decisions table complete (7 rows)
+- ✓ / ⚠️ Decomposition table complete with all step IDs from Workflow Requirements
+- ✓ / ⚠️ All Autonomy values use canonical terms (Human / Deterministic / Guided / Autonomous)
+- ✓ / ⚠️ All Integration column entries follow the `block: tool (use/build)` format
+- ✓ / ⚠️ All Build Output values use canonical forms (`New skill: SN` / `Use existing: [name]` / `New agent: AN` / `Inline prompt → Workflow Requirements Step N` / `MCP server: [name]` / `Human (no artifact)`)
+- ✓ / ⚠️ Packaging value uses a canonical form (`Plugin` / `Standalone Skill` / `Workspace Agent` / `Loose Files`)
+
+### Skill Candidates
+- ✓ / ⚠️ Every `New skill: SN` reference has a matching entry
+- ✓ / ⚠️ Every skill has all 12 fields
+- ✓ / ⚠️ Every skill Name conforms to format rules (lowercase-hyphen, ≤64 chars, no consecutive hyphens)
+- ✓ / ⚠️ Every skill Description starts with "This skill should be used when..." and is ≤1024 chars
+
+### Agent Configuration
+- ✓ / ⚠️ Every `New agent: AN` reference has a matching entry
+- ✓ / ⚠️ Every agent has all 13 fields
+- ✓ / ⚠️ Every agent Description starts with "Use this agent when..." and is ≤1024 chars
+- ✓ / ⚠️ Multi-Agent Configuration present when >1 agent defined
+
+### Cross-references
+- ✓ / ⚠️ Every tool in Integration column has a matching Integration Options entry with a Source URL
+- ✓ / ⚠️ Every skill `Depends On` reference points to a defined skill ID
+
+### Mechanism-specific
+- ✓ / ⚠️ Orchestrator Prompt Outline present (when mechanism is Prompt or Skill-Powered Prompt)
+- ✓ / ⚠️ Agent Configuration present (when mechanism is Agent)
+
+### Completeness
+- ✓ / ⚠️ Model Recommendation present with default capability and per-platform mapping
+- ✓ / ⚠️ Data Readiness Summary present (even if "all accessible")
+- ✓ / ⚠️ Deployment Plan present with target location, deployment steps, and Packaging note
+- ✓ / ⚠️ Evaluation Inputs present (pointer, not duplication)
+- ✓ / ⚠️ Deferred to Build present
 ```
 
 ---
@@ -600,17 +782,31 @@ For each tool identified in the Integration column of the Step-by-Step Decomposi
 
 Before saving the spec, verify every item. If any is missing, go back and add it:
 
-- [ ] `Architecture Decisions` table has Platform, Platform Mode, Orchestration, and Involvement rows
-- [ ] Every step in the decomposition table has separate Orchestration, Integration, and Intelligence columns (not collapsed into a single "Building Block(s)" column)
+- [ ] **Frontmatter** is present with workflow, requirements_file, spec_version, definition_type, mechanism, involvement, platform, platform_mode, packaging, and counts
+- [ ] **Source** section names the Workflow Requirements file path
+- [ ] `Architecture Decisions` table has Lens, Platform, Platform Mode, Orchestration, Involvement, Packaging, and Trigger rows
+- [ ] Every step in the decomposition table has separate Orchestration, Integration, Intelligence, and Build Output columns
+- [ ] Step IDs in the decomposition table match the Step IDs in the Workflow Requirements (Step 1, Step 2, …)
 - [ ] Every step uses canonical autonomy terms: Human / Deterministic / Guided / Autonomous
 - [ ] Every Integration column entry includes the block type, tool name, and use/build tag
-- [ ] Every skill candidate has all 8 fields: Purpose, Covers Steps, Inputs, Outputs, Decision Logic, Failure Modes, Required Tools, Depends On
-- [ ] Every "Exists" item in Context Inventory has a Location value
+- [ ] Every Build Output value is one of the canonical forms (`New skill: SN`, `Use existing: [name]`, `New agent: AN`, `Inline prompt → Workflow Requirements Step N`, `MCP server: [name]`, `Human (no artifact)`)
+- [ ] Every `New skill: SN` reference has a matching Skill Candidates entry with the SN ID
+- [ ] Every `New agent: AN` reference has a matching Agent Configuration entry with the AN ID
+- [ ] Every Skill Candidate has all 12 fields: ID, Name, Description, Purpose, Covers Steps, Inputs, Outputs, Decision Logic, Failure Modes, Required Tools, Depends On, Stateful?
+- [ ] Every Skill Candidate's Name conforms to format rules (lowercase-hyphen, ≤64 chars, no consecutive hyphens)
+- [ ] Every Skill Candidate's Description starts with "This skill should be used when..." and is ≤1024 chars
+- [ ] Every Agent Configuration has all 13 fields: ID, Name, Description, Mission, Responsibilities, Output Format, Tone & Style, Constraints, Model, Memory Scope, Tools, Skills, Trigger Examples
+- [ ] Every Agent Configuration's Description starts with "Use this agent when..." and is ≤1024 chars
+- [ ] If more than one agent is defined, Multi-Agent Configuration section is present with Orchestration Pattern, Coordinator, Handoff Contracts, and Aggregation Strategy
 - [ ] Every tool in the Integration column has a matching entry in Integration Options with at least one Source URL
-- [ ] Model Recommendation section is present with a default class
-- [ ] Data Readiness Summary is present (even if "all accessible")
-- [ ] Agent Configuration is present if orchestration = Agent (with Skills and Trigger Examples fields)
-- [ ] Evaluation Criteria section is present with at least 3 test scenarios
+- [ ] Model Recommendation section is present with a default capability and per-platform mapping
+- [ ] Data Readiness Summary is present (even if "all accessible") — references Context IDs from the Workflow Requirements
+- [ ] Deployment Plan is present with target location and deployment steps for each artifact, plus a Packaging note
+- [ ] Packaging value is one of the canonical forms (`Plugin`, `Standalone Skill`, `Workspace Agent`, `Loose Files`)
+- [ ] Orchestrator Prompt Outline section is present when mechanism is `Prompt` or `Skill-Powered Prompt` (omitted when mechanism is `Agent`)
+- [ ] Evaluation Inputs section is present, pointing to the Workflow Requirements file (do not duplicate Acceptance Criteria or Example Scenarios)
+- [ ] Deferred to Build section lists what Build will resolve at generation time
+- [ ] Self-Test Summary section is present at the end of the spec, with each item marked ✓ (passed) or ⚠️ (issue — described inline)
 
 #### Step 10 — Spec Approval Gate
 
@@ -640,15 +836,19 @@ After the user approves, instruct them to **exit plan mode** if they entered it 
 
 ### Outcome-Driven Processing Path
 
-When the Workflow Definition has `Definition Type: Outcome-Driven`, the following modifications apply to the standard workflow:
+When the Workflow Requirements has `Definition Type: Outcome-Driven`, the following modifications apply to the standard workflow:
 
-**Step 3 (Architecture Decisions):** Same as standard — extract tools from the Capability Domains and Tools/Data sections instead of from step data flows.
+**Step 3 (Architecture Decisions):** Same as standard, but the source sections differ. For outcome-driven Workflow Requirements, extract tools from the **Inputs**, **Rules & Constraints**, and **Context Inventory** sections (there are no per-step data flows to read from). Capability Domains do not exist in the Workflow Requirements — they are derived in Step 6.
 
 **Step 4 (Autonomy Assessment):** State as fact: "This is an outcome-driven workflow — autonomy is **Autonomous** by definition. The agent system determines its own execution path."
 
 **Step 5 (Orchestration Mechanism):** State as fact: "Orchestration is **Agent**." Still determine the involvement mode (Augmented/Automated) from the definition's Human Gates section and trigger type. Still ask the platform sub-choice if the platform has multiple agent offerings.
 
-**Step 6 (Classify Each Step) → Capability Domain Mapping:** Replace per-step classification with capability domain mapping. For each capability domain from the definition:
+**Step 6 (Classify Each Step) → Capability Domain Mapping:** Replace per-step classification with capability domain mapping.
+
+**Important:** Capability Domains are derived by Design — they are **not** captured in the Workflow Requirements (the Workflow Requirements stays in "what" territory; capability decomposition is "how"). Infer capability domains from the Workflow Requirements' Outcome, Inputs, Rules & Constraints, and Acceptance Criteria. Propose them to the user and confirm before mapping.
+
+For each derived capability domain:
 
 | Domain | Integration Needs | Intelligence Requirements | Reusable Skill? |
 |--------|-------------------|--------------------------|-----------------|
@@ -656,13 +856,13 @@ When the Workflow Definition has `Definition Type: Outcome-Driven`, the followin
 
 Same Integration Discovery and Skill Discovery processes apply, operating on capability domains instead of steps.
 
-**Step 7 (Skill Candidates):** Same — identify which capability domains should become skills.
+**Step 7 (Skill Candidates):** Same field structure — identify which capability domains should become skills. Each skill candidate uses the full 12-field Skill Candidate block (with Covers Domains in place of Covers Steps).
 
-**Step 8 (Agent Configuration):** This becomes the primary section. Agent Configuration is mandatory for outcome-driven definitions. Document the agent(s) with all standard fields, drawing instructions from the definition's Goal, Constraints, and Expected Outputs.
+**Step 8 (Agent Configuration):** This becomes the primary section. Agent Configuration is **mandatory** (not optional) for outcome-driven workflows. Document the agent(s) with all 13 standard fields, drawing Description, Mission, Responsibilities, Output Format, and Constraints from the Workflow Requirements' Outcome, Rules & Constraints, and Acceptance Criteria.
 
-**Step 8b (Evaluation Criteria):** Carry forward from the definition's Quality Criteria — see above.
+**Step 8b (Verify Evaluation Inputs):** Same as step-decomposed — confirm Acceptance Criteria and Example Scenarios in the Workflow Requirements are complete; do not duplicate.
 
-**Step 9 (Generate Spec):** Use the modified template sections below. The spec uses the same filename pattern. Conditional sections replace Step-by-Step Decomposition with Capability Domain Mapping, and Autonomy Spectrum Summary with a brief Autonomous statement.
+**Step 9 (Generate Spec):** Use the modified template sections below. The spec uses the same filename pattern and same frontmatter shape (with `definition_type: Outcome-Driven`). The Step-by-Step Decomposition section is replaced with Capability Domain Mapping; the Autonomy Spectrum Summary becomes a brief Autonomous statement; Build Output is captured per domain rather than per step.
 
 **Outcome-driven spec template modifications:**
 
@@ -671,45 +871,53 @@ Replace the `## Step-by-Step Decomposition` section with:
 ```markdown
 ## Capability Domain Mapping
 
-| Domain | Description | Integration (use/build) | Intelligence | Reusable Skill? |
-|--------|-------------|------------------------|--------------|-----------------|
+(Capability domains are derived by Design from the Workflow Requirements' Outcome, Inputs, Rules, and Acceptance Criteria. They are not present in the Workflow Requirements.)
+
+| Domain | Description | Integration (use/build) | Intelligence | Build Output |
+|--------|-------------|------------------------|--------------|--------------|
+
+**Build Output values:** Same canonical forms as the step-decomposed table (`New skill: SN`, `Use existing: [name]`, `New agent: AN`, etc.). For outcome-driven workflows, expect most domains to map to either `New skill: SN` (if the agent should delegate to a reusable skill) or `Handled by agent` (if the agent handles the domain inline with its own instructions).
 
 ### Autonomy Statement
 
-This is an outcome-driven workflow. Autonomy is Autonomous — the agent system determines its own execution path based on the goal, inputs, and constraints.
+This is an outcome-driven workflow. Autonomy is Autonomous — the agent system determines its own execution path based on the Outcome, Inputs, Rules & Constraints, and Acceptance Criteria defined in the Workflow Requirements.
 ```
 
-Replace the `## Skill Candidates` section header with capability-domain-based skill candidates (same field structure, keyed by domain instead of step number).
-
-The `## Agent Configuration` section is **mandatory** (not optional) for outcome-driven specs.
-
-All other spec sections remain the same, except **Step Sequence and Dependencies** is omitted for outcome-driven specs — the agent determines its own execution path, so there is no fixed step sequence to document.
+Skill Candidates use the same 12-field block (with `Covers Domains` instead of `Covers Steps`). Agent Configuration is **mandatory** for outcome-driven specs.
 
 **Build Skill Needs Checklist modifications for outcome-driven:**
-- [ ] `Architecture Decisions` table has Platform, Platform Mode, Orchestration (Agent), and Involvement rows
-- [ ] Capability Domain Mapping table is present with Integration and Intelligence columns
-- [ ] Every Integration column entry includes block type, tool name, and use/build tag
-- [ ] Every skill candidate has all 8 fields: Purpose, Covers Steps / Domains, Inputs, Outputs, Decision Logic, Failure Modes, Required Tools, Depends On
-- [ ] Every "Exists" item in Context Inventory has a Location value
-- [ ] Every tool in the Integration column has a matching entry in Integration Options with at least one Source URL
-- [ ] Model Recommendation section is present with a default class
-- [ ] Data Readiness Summary is present (even if "all accessible")
-- [ ] Agent Configuration is present with Skills and Trigger Examples fields
-- [ ] Evaluation Criteria section is present with at least 3 test scenarios
-- [ ] Quality criteria carried forward from Workflow Definition
+
+Use the full step-decomposed checklist with these substitutions:
+- Replace "Step-by-Step Decomposition" with "Capability Domain Mapping"
+- Replace "Step IDs match Workflow Requirements Step IDs" with "Capability Domains are derived from Workflow Requirements (not restated from a section that doesn't exist there)"
+- Replace "Inline prompt → Workflow Requirements Step N" Build Output value with "Handled by agent"
+- Agent Configuration is mandatory (not optional)
+
+All other checklist items apply unchanged.
 
 ## Outputs
 
 ### `outputs/[workflow-name]-design-spec.md` — Design Spec
 
-Uses the mandatory template defined in Step 9. For step-decomposed definitions: Execution Pattern, Architecture Decisions, Scenario Summary, Step-by-Step Decomposition (with separate Orchestration/Integration/Intelligence columns), Autonomy Spectrum Summary, Skill Candidates (8 fields each), Agent Configuration (optional, with Skills and Trigger Examples), Step Sequence and Dependencies, Prerequisites, Context Inventory (with Location column), Data Readiness Summary, Integration Options (with Source URLs), Model Recommendation, Recommended Implementation Order, Where to Run, Evaluation Criteria (with test scenarios), Stakeholders (optional).
+Uses the mandatory template defined in Step 9. The Design Spec **references** the Workflow Requirements as canonical source — it does not restate Outcome, Metadata, Context Inventory, Acceptance Criteria, Example Scenarios, Human Gates, Steps Overview, or per-step requirements.
 
-For outcome-driven definitions: Execution Pattern, Architecture Decisions, Scenario Summary, Capability Domain Mapping (with Integration/Intelligence columns), Autonomy Statement, Skill Candidates (8 fields each, keyed by domain), Agent Configuration (mandatory, with Skills and Trigger Examples), Prerequisites, Context Inventory, Data Readiness Summary, Integration Options, Model Recommendation, Recommended Implementation Order, Where to Run, Evaluation Criteria (with test scenarios carried forward from definition), Stakeholders (optional).
+The spec opens with YAML frontmatter (workflow, requirements_file, spec_version, definition_type, mechanism, involvement, platform, platform_mode, packaging, counts) so Build and downstream skills can summarize the spec without parsing prose.
+
+The spec is organized into three layered groups:
+
+- **Layer 1 — Architecture:** Execution Pattern, Architecture Decisions (with Packaging), Autonomy Spectrum Summary, Integration Options (with Source URLs), Model Recommendation (with per-platform mapping)
+- **Layer 2 — Decomposition:** Step-by-Step Decomposition (with Build Output column) — or Capability Domain Mapping for outcome-driven — Orchestrator Prompt Outline (when mechanism is Prompt or Skill-Powered Prompt), Data Readiness Summary, Recommended Implementation Order
+- **Layer 3 — Component Blueprints:** Skill Candidates (12 fields each), Agent Configuration (optional, mandatory for outcome-driven; 13 fields each), Multi-Agent Configuration (when applicable), Prerequisites, Deployment Plan
+
+**Cross-layer sections:** Evaluation Inputs (pointer to Workflow Requirements), Deferred to Build, Stakeholders (optional), Self-Test Summary (results of the Build Skill Needs Checklist).
+
+For outcome-driven workflows: Step-by-Step Decomposition is replaced by Capability Domain Mapping; Autonomy Spectrum Summary is replaced by an Autonomy Statement; Orchestrator Prompt Outline is omitted (the agent IS the orchestrator); Agent Configuration is mandatory.
 
 ## Guidelines
 
 - Use plain language; avoid jargon unless the user introduced it
-- After writing the spec, tell the user: "Design Spec saved to `outputs/[name]-design-spec.md`."
+- After writing the spec, tell the user: "Design Spec saved to `outputs/[name]-design-spec.md`. Read it alongside the Workflow Requirements at `outputs/[name]-requirements.md`."
 - Do not proceed past the Spec Approval Gate (Step 10) without explicit user approval
 - Do not research integration availability — that happens in the Build phase
 - Do not generate platform artifacts — that happens in the Build phase
+- Do not restate Workflow Requirements content in the Design Spec — reference the file

--- a/plugins/handsonai/skills/naming-workflows/SKILL.md
+++ b/plugins/handsonai/skills/naming-workflows/SKILL.md
@@ -206,7 +206,7 @@ When user provides a workflow description:
 | Trigger | text | e.g., "Weekly (Sunday)", "On email arrival", "Manual" |
 | Apps | multi-select | Notion, Web Search, Gmail, Slack, GitHub, etc. |
 | SOP | url | Link to SOP markdown file (populated by `writing-workflow-sops`) |
-| Workflow Definition | url | Link to workflow definition markdown file (populated by framework Deconstruct phase) |
+| Workflow Requirements | url | Link to workflow requirements markdown file (populated by framework Deconstruct phase) |
 | Design Spec | url | Link to Design Spec markdown file (populated by framework Design phase) |
 | Assets Used | relation | Link to Assets database (optional) |
 

--- a/plugins/handsonai/skills/writing-process-guides/SKILL.md
+++ b/plugins/handsonai/skills/writing-process-guides/SKILL.md
@@ -21,7 +21,7 @@ Write comprehensive Business Process Guide documentation and save as markdown fi
 ## Process
 
 1. **Load process context** — Determine how the user is arriving:
-   - **From framework artifacts** (primary path): Read the Workflow Definitions for each component workflow (`outputs/<name>-definition.md`). If Design Specs and SOPs exist, read those too for sequencing, autonomy levels, and cross-references.
+   - **From framework artifacts** (primary path): Read the Workflow Requirements for each component workflow (`outputs/<name>-requirements.md`). If Design Specs and SOPs exist, read those too for sequencing, autonomy levels, and cross-references.
    - **From Notion or another tracker** (if available): Fetch the business process record and its linked workflows for supplementary metadata (name, domain, description, linked workflows).
    - **From conversation**: If no artifacts exist, gather process details interactively (name, component workflows, sequence, triggers).
 2. **Gather strategic context** from user — frequency, timing, decision points between workflows, success criteria
@@ -87,7 +87,7 @@ For Notion users with the AI Registry template: update the "Guide" URL property 
 ## Interaction Pattern
 
 ### From framework artifacts (primary path)
-1. Read Workflow Definitions (and SOPs/Design Specs if they exist) for each component workflow
+1. Read Workflow Requirements (and SOPs/Design Specs if they exist) for each component workflow
 2. Gather strategic context from user (frequency, timing, decision points)
 3. Draft Process Guide and present for review
 4. Write markdown file after user approval

--- a/plugins/handsonai/skills/writing-workflow-sops/SKILL.md
+++ b/plugins/handsonai/skills/writing-workflow-sops/SKILL.md
@@ -51,7 +51,7 @@ An agent can orchestrate at any autonomy level. An agent that runs a fixed scrip
 ## Process
 
 1. **Load workflow context** — Determine how the user is arriving:
-   - **From framework artifacts** (primary path): Read the Workflow Definition (`outputs/<name>-definition.md`) and Design Spec (`outputs/<name>-design-spec.md`). Extract name, description, trigger, type, execution mode, autonomy level, refined steps, skill candidates, agent config, and failure modes.
+   - **From framework artifacts** (primary path): Read the Workflow Requirements (`outputs/<name>-requirements.md`) and Design Spec (`outputs/<name>-design-spec.md`). Extract name, description, trigger, type, execution mode, autonomy level, refined steps, skill candidates, agent config, and failure modes.
    - **From Notion or another tracker** (if available): Fetch the workflow record for supplementary metadata (name, description, type, trigger, apps, assets used).
    - **From conversation**: If no artifacts exist, gather workflow details interactively (name, purpose, trigger, type, steps, etc.)
 2. **Classify on both axes** — Determine execution mode (augmented / automated / manual) and autonomy level (deterministic / guided / autonomous / n/a). If loaded from a Design Spec, these are already defined — confirm with user rather than re-assessing from scratch. Autonomy level determines full vs. lightweight SOP template.
@@ -132,7 +132,7 @@ For Notion users with the AI Registry template: update the "SOP" URL property on
 ## Interaction Pattern
 
 ### From framework artifacts (primary path)
-1. Read the Workflow Definition and Design Spec from the `outputs/` folder
+1. Read the Workflow Requirements and Design Spec from the `outputs/` folder
 2. Confirm classification (execution mode + autonomy level) with user
 3. Fill any gaps not covered by the artifacts
 4. Draft SOP using the appropriate template and present for review

--- a/src/content/docs/ai-workflow-framework/build/index.mdx
+++ b/src/content/docs/ai-workflow-framework/build/index.mdx
@@ -17,7 +17,7 @@ If you're returning from [Test (Step 5)](../test/) to fix issues, you may also h
 
 ## Prepare Context
 
-Before the model generates any artifacts, you need to resolve the context your workflow depends on. The **Context Shopping List** (from [Deconstruct](../deconstruct/)) and the **Data Readiness Summary** (from Design) identify every document, file, and reference material the workflow needs — and flag which ones are available, which need to be created, and which need formatting.
+Before the model generates any artifacts, you need to resolve the context your workflow depends on. The **Context Inventory** in the Workflow Requirements (from [Deconstruct](../deconstruct/)) and the **Data Readiness Summary** (from Design) identify every document, file, and reference material the workflow needs — and flag which ones are available, which need to be created, and which need formatting.
 
 Build begins by working through this list:
 
@@ -44,20 +44,20 @@ The orchestration mechanism determines which steps you follow. Work through **on
 <Tabs>
   <TabItem label="Prompt">
 
-1. **Create context** — Build the context artifacts listed in your Design Spec's Context Inventory
-2. **Set up project workspace** (optional) — If the Design Spec's Where to Run recommends a project
+1. **Create context** — Build the context artifacts listed in your Workflow Requirements' Context Inventory
+2. **Set up project workspace** (optional) — If the Design Spec's Deployment Plan recommends a project
 3. **Generate platform artifacts** — The model generates the prompt and any configuration needed for your platform
   </TabItem>
   <TabItem label="Skill-Powered Prompt">
 
-1. **Create context** — Build the context artifacts listed in your Design Spec's Context Inventory
-2. **Set up project workspace** (optional) — If the Design Spec's Where to Run recommends a project
+1. **Create context** — Build the context artifacts listed in your Workflow Requirements' Context Inventory
+2. **Set up project workspace** (optional) — If the Design Spec's Deployment Plan recommends a project
 3. **Build skills** — Build skills for the steps tagged as skill candidates in your Design Spec. The model generates skills in the format appropriate to your platform.
 4. **Generate platform artifacts** — The model generates the prompt and skill configurations for your platform
   </TabItem>
   <TabItem label="Agent">
 
-1. **Create context** — Build the context artifacts listed in your Design Spec's Context Inventory
+1. **Create context** — Build the context artifacts listed in your Workflow Requirements' Context Inventory
 2. **Build skills** — Build skills for tagged candidates
 3. **Connect tools** — Wire external tools from the Tools and Connectors section of your Design Spec
 4. **Generate platform artifacts** — The model generates agent configs (single or multi-agent), skills, and connectors for your platform

--- a/src/content/docs/ai-workflow-framework/deconstruct/index.md
+++ b/src/content/docs/ai-workflow-framework/deconstruct/index.md
@@ -1,29 +1,46 @@
 ---
-title: "Step 2: Deconstruct Workflows into Structured Specifications"
-description: Interactively break down any business workflow into discrete steps, surfacing decision points, data flows, context needs, and failure modes.
----> **Platforms:** `claude` `openai` `gemini` `m365-copilot`
+title: "Step 2: Deconstruct Workflows into Requirements"
+description: Capture your workflow as a PRD — clear requirements, decision rules, and edge cases that feed directly into the Design step.
+---
+> **Platforms:** `claude` `openai` `gemini` `m365-copilot`
 
 ## What This Is
 
-An interactive deep-dive that breaks down a business workflow into discrete steps — surfacing every hidden sub-step, decision point, data handoff, context requirement, and failure mode. Works with both individual workflows (one person's tasks) and organizational workflows (multi-role value chain processes), adding role transitions as an additional dimension for organizational workflows.
+Step 2 is the **PRD for your workflow**. It captures *what* the workflow must do, *the rules it must follow*, and *the edge cases it must handle* — in clear requirements language that feeds directly into Step 3 (Design).
+
+The output is a single Markdown file: the **Workflow Requirements** document. It's structured so the Design step — or any AI model — can read it and act on it without re-interviewing you.
 
 | | |
 |---|---|
-| **What you'll do** | Describe your workflow (or problem) and work through a guided conversation that probes each step for sub-steps, decision points, data flows, context needs, and failure modes |
-| **What you'll get** | A **Workflow Definition** — a structured Markdown file capturing every step in detail |
+| **What you'll do** | Choose one of two paths (you know the steps, or you know the outcome), then work through a guided conversation that captures the requirements |
+| **What you'll get** | A **Workflow Requirements** document — `outputs/[name]-requirements.md` |
 | **Time** | ~15-25 minutes of interactive conversation |
 
 ## Why This Matters
 
-You can't operationalize AI on a process you don't understand. Before you can build an AI-powered workflow, you need to break it down into discrete steps, identify the decision points and data flows, and understand what context each step needs and what happens when things go wrong.
+You can't operationalize AI on a process you don't understand. Before you can design how AI building blocks will deliver the work, you need to capture the work itself: what triggers it, what good output looks like, the decision rules, the edge cases, the context it needs.
 
-The skill walks you through that deconstruction interactively. You provide the business scenario and rough steps — and the model either applies the 6-question framework to every step (step-decomposed path) or captures your goal, constraints, quality criteria, and capability domains (outcome-driven path). The deliverable:
+Step 2 separates *what* from *how*. The Workflow Requirements stays in "what" territory — outcome, rules, acceptance criteria. Step 3 (Design) handles the "how" — orchestration mechanism, agents, models, integrations. Keeping the two artifacts distinct means:
 
-- A **Workflow Definition** — the structured breakdown of your workflow into refined steps, with decision points, data flows, context needs, and failure modes captured for every step
+- The Workflow Requirements is the canonical source of truth for *what the workflow does*
+- The Design Spec doesn't restate requirements; it references them
+- Step 5 (Test) reads acceptance criteria and example scenarios straight from the Workflow Requirements
+- Step 7 (Improve) compares the deployed workflow against the requirements baseline
 
-The context needs and failure modes captured here directly inform design decisions in the next step — they tell you what context to create, what tools to connect, and where human review gates are needed.
+This builds directly on the concept of workflow deconstruction. If terms like the "6-question framework" or "AI building blocks" are new to you, review the [Key Concepts section of the AI Workflow Framework](../#key-concepts) for quick definitions before starting.
 
-This builds directly on the concepts of workflow deconstruction. If terms like the "6-question framework" or "AI building blocks" are new to you, review the [Key Concepts section of the AI Workflow Framework](../#key-concepts) for quick definitions before starting.
+## The Two Paths
+
+Step 2 presents one question upfront: **do you know the steps, or just the outcome?**
+
+| Path | When to use | Mental model |
+|---|---|---|
+| **Step-decomposed** | You can describe how the work gets done | "I know the steps" |
+| **Outcome-driven** | You know what "done" looks like but the path varies; you want an agent system to figure it out at runtime | "I know the outcome" |
+
+Both paths produce a Workflow Requirements document with the same shared structure — only the middle "what does the workflow do" block differs.
+
+**Don't have either yet?** If you only have a problem ("People drop off during enrollment and I have no way to follow up"), describe it. The model proposes a candidate workflow, then routes you into one of the two paths above. No separate "problem-first" path to learn.
 
 ## How to Use This
 
@@ -35,101 +52,59 @@ This step is facilitated by the **`deconstruct`** AI Workflow Framework Skill. H
 I need to deconstruct my [workflow name] workflow.
 ```
 
-The skill runs an interactive deep dive — interviewing you about your scenario, refining your steps, then probing each step for sub-steps, decisions, data flows, context needs, and failure modes. It produces a structured Workflow Definition file.
+The skill asks you to choose a path, runs an interactive interview to capture the requirements, validates the workflow end-to-end, and writes the Workflow Requirements file.
 
 :::tip[If your AI tool doesn't support skills]
 Download the skill file from [GitHub](https://github.com/jamesgray-ai/handsonai-plugins/tree/main/plugins/handsonai/skills/deconstruct) and paste it into your system prompt or project instructions.
 :::
-### Example: What the first exchange looks like
 
-After you start the conversation, the model will ask about your scenario. Here's what a typical opening looks like:
+### Example: Step-decomposed path
 
-> **Model:** Let's start by understanding the workflow you want to deconstruct. First — what's the business scenario? What's the objective of this workflow, and why does it matter?
+After you start the conversation, the model asks you to choose a path. If you pick step-decomposed, here's what the opening looks like:
+
+> **Model:** Do you know the steps, or just the outcome?
+> - **Step-decomposed** — You can describe how the work gets done.
+> - **Outcome-driven** — You know what "done" looks like but want an agent system to figure out the steps.
 >
-> **You:** I research LinkedIn prospects before sales outreach. The goal is to find people who'd be a good fit for our AI training programs, understand their background, and write personalized outreach messages. Right now it takes me about 45 minutes per prospect and I do maybe 10 a week.
+> **You:** Step-decomposed. I research LinkedIn prospects before sales outreach. The goal is to find people who'd be a good fit for our AI training programs, understand their background, and write personalized outreach messages.
 >
-> **Model:** Got it — LinkedIn prospect research for personalized sales outreach, with the goal of identifying fit and crafting tailored messages. That's a great workflow to deconstruct. Now, can you walk me through the high-level steps? Don't worry about being complete or precise — just describe what you typically do from start to finish, and we'll refine it together.
+> **Model:** Got it — LinkedIn prospect research for personalized sales outreach. Can you walk me through the high-level steps? Don't worry about being complete or precise — we'll refine them together.
 >
 > **You:** I guess I start by finding people on LinkedIn, then I look at their profile, check their company, see if they've posted anything relevant, then I write the message. There's probably more to it but that's the gist.
 
-From there, the model takes your rough steps and systematically breaks each one down — uncovering the sub-steps, decisions, data, and context you didn't think to mention.
+From there, the model takes your rough steps and systematically breaks each one down — uncovering the sub-steps, decision rules, edge cases, and context you didn't think to mention. Each step in the final Workflow Requirements is captured as **Goal / Inputs / Outputs / Rules & Edge Cases / Context Needed**.
 
-### Example: Starting with a problem instead of a workflow
+### Example: Outcome-driven path
 
-You don't need an existing process. If you have a gap or pain point, describe that — the model will help you design a workflow from scratch:
+If you pick outcome-driven, the model captures the outcome, inputs, acceptance criteria, and rules — without prescribing steps:
 
-> **Model:** Let's start by understanding the workflow you want to deconstruct. First — what's the business scenario? What's the objective of this workflow, and why does it matter?
+> **You:** Outcome-driven. I want a competitive analysis report produced weekly. I don't want to prescribe how the agent researches or structures it.
 >
-> **You:** I don't really have a workflow for this — it's more of a problem. People sign up for my online course but a lot of them never finish. I have no way to know who's dropping off, when they stop engaging, or how to follow up. I'm just losing students and I don't find out until it's too late.
->
-> **Model:** Got it — so this isn't an existing process to break down, it's a gap you need to fill. Let me make sure I understand the problem before we design a solution. A few questions: What does "signing up" look like — is there a registration step, a payment, or both? And when you say people don't finish, do you have any data on where they tend to drop off, or is that part of the problem — you just don't know?
->
-> **You:** They register and pay through my course platform. I can see completion rates in the dashboard but I don't check it regularly, and there's no alert or trigger when someone stops. I only notice if I happen to look.
->
-> **Model:** That's clear. So the core gap is: no systematic way to detect drop-offs and no follow-up process when they happen. Let me propose a candidate workflow that would solve this, and you can tell me what fits and what doesn't.
-
-From there, the model proposes a step-by-step workflow to address the problem, asks you to react and refine, and then continues into the deep dive just like any other workflow.
-
-### Example: Defining an outcome for an agent system
-
-When you know what you want produced but don't want to prescribe how the AI gets there, choose the outcome-driven path:
-
-> **Model:** How would you like to approach this?
-> (a) Deconstruct a known process — you can describe the steps and I'll interview you to surface hidden details
-> (b) Start from a problem — you know what's broken; I'll propose a workflow and we refine it together
-> (c) Define an outcome — you know what you want produced but want an agent system to figure out the approach
->
-> **You:** (c) — I want a competitive analysis report produced weekly, but I don't want to prescribe how the agent researches or structures it.
->
-> **Model:** Got it — outcome-driven. Let's define what the agent system needs to know. First: what does a successful run produce? Describe the deliverable.
+> **Model:** Got it. What does a successful run produce? Describe the deliverable — format, structure, scope.
 >
 > **You:** A 2-3 page report covering our top 5 competitors — what they shipped, pricing changes, new messaging, and any strategic moves. Formatted as a markdown doc with an executive summary at the top.
 >
-> **Model:** Clear. Now, what does the agent system receive to start? What triggers the work, and what materials does it have access to?
+> **Model:** Clear. What does the agent system receive to start? What triggers the work, and what materials does it have access to?
 >
 > **You:** It runs every Monday morning. It has access to our competitor list (a shared doc with URLs), our product positioning doc, and the web.
 
-From there, the model continues through constraints, quality criteria, capability domains, tools/data, and human gates — building an outcome-driven Workflow Definition without decomposing into fixed steps.
+From there, the model continues through constraints, acceptance criteria, context sources, and human gates — building an outcome-driven Workflow Requirements without decomposing into fixed steps.
 
-### Compose (option d) — for clear workflows with components ready
+### Example: Starting with a problem
 
-Compose is for one specific scenario: you already have reusable building blocks (skills, sub-agents, or both) covering your workflow's steps, **and** the workflow is straightforward enough to hold in your head.
+You don't need an existing process. If you have a gap or pain point, describe that — the model proposes a candidate workflow, then asks which of the two paths fits:
 
-Both conditions must be true. If either is missing, the Known Process path (option a) is the right call.
+> **Model:** Do you know the steps, or just the outcome?
+>
+> **You:** Neither, really. People sign up for my online course but a lot of them never finish. I have no way to know who's dropping off or how to follow up.
+>
+> **Model:** That's a gap, not a process. Let me propose a candidate workflow: (1) detect drop-offs by polling course completion data, (2) classify the drop-off reason, (3) draft a personalized follow-up message, (4) send it. Sound roughly right?
+>
+> **You:** Yes, that's the shape of it.
+>
+> **Model:** Good. Two paths from here: do you want to refine these steps with me (step-decomposed), or describe the outcome and let an agent figure out the steps (outcome-driven)?
 
-| Use Compose when | Use Known Process when |
-|---|---|
-| You already have a skill or sub-agent for each step | You'd need to build a new component for one or more steps |
-| You can describe each step in one clear sentence | Steps are vague, branching, or you're not sure they're complete |
-| Decision points (if any) are simple and few | Multiple decision points, scoring, or context-dependent routing |
-| You just need an orchestration prompt | You need a tested workflow with a documented spec |
-
-#### How Compose works
-
-A three-turn conversation inside `/deconstruct`:
-
-1. **Intake.** You answer four things in one message: workflow name + outcome, where your components live (Claude account, Claude Code, ChatGPT, or a mix), the steps, and which component runs each step.
-2. **Confirm + autonomy.** The AI restates what it heard, flags anything off (vague steps, missing components, hidden complexity), then asks two questions that shape the prompt: deterministic or guided? augmented or automated?
-3. **Output.** The AI writes the orchestration prompt in a standard shape — frontmatter (workflow name, outcome, autonomy, involvement, components) + Intent + Prompt body. You copy it, save it wherever you keep prompts, and run it.
-
-No Workflow Definition file, no Design Spec, no `/build` or `/test` invocation. The prompt is the artifact.
-
-#### Example: Weekly Competitive Intelligence Digest
-
-A student wants a workflow that pulls insights from 3 competitor blog posts, scores them by relevance, and produces a LinkedIn post summarizing the top 2.
-
-**Turn 1** — the student answers:
-
-- Workflow: Weekly Competitive Intelligence Digest. Output: a LinkedIn post drawing from the top 2 insights.
-- Components live in: Claude account.
-- Steps: (1) extract insights from each of 3 articles; (2) score insights 1–10 on relevance; (3) pick the top 2 and draft a LinkedIn post.
-- Components: `extracting-article-insights` (skill), `competitive-relevance-scorer` (skill), `drafting-linkedin-posts` (skill).
-
-**Turn 2** — the AI confirms back, notes that step 2's scoring makes this a *guided* workflow, and asks for autonomy + involvement. Student picks **guided, augmented** (pause after scoring so the student picks which insights make the post).
-
-**Turn 3** — the AI outputs an orchestration prompt with frontmatter, an Intent paragraph, and a Prompt body that chains the three skills with a PAUSE after scoring. The student copies the prompt into a Google Doc and runs it against the week's three articles.
-
-Three turns. One artifact. No file written to `outputs/`.
+You pick the path, and the conversation continues into the deep dive.
 
 ### Not sure which workflow to try?
 
@@ -146,41 +121,52 @@ Or pick something you do regularly and could describe to a colleague over coffee
 - **Course enrollment follow-up** — people start signing up but don't finish, and there's no process to detect drop-offs or send reminders
 - **Competitive analysis pipeline** (outcome-driven) — you know what the deliverable looks like but want an agent system to determine the research approach
 
-You don't need to know all the steps before you start — that's what the skill helps you figure out. Even "I onboard new clients and it takes forever" is enough to begin. You can also start with a problem instead of a workflow — "People drop off during enrollment and I have no way to follow up" is a perfectly valid starting point.
+You don't need to know all the steps before you start — that's what the skill helps you figure out. Even "I onboard new clients and it takes forever" is enough to begin.
 
 ## What the Skill Produces
 
-The **Workflow Definition** captures one of two formats, depending on the path you chose:
+The **Workflow Requirements** document uses a shared structure for both paths — only the middle "what does the workflow do" block differs. Every section is structured so Design (or any agent model) can parse it without re-asking questions.
 
-**Step-decomposed** (paths a and b):
+**Shared sections (both paths):**
 
-- **Scenario metadata** — name, description, outcome, trigger, type, objective, owners, definition type
-- **Refined step-by-step breakdown** — each step with action, sub-steps, decision points, data in/out, context needs, failure modes
-- **Step sequence and dependencies** — what's sequential, what's parallel, where the critical path is
-- **Context shopping list** — every artifact the workflow needs, with status, key contents, AI accessibility, and readiness notes
-- **Optimization summary** (if optimizations were applied) — what changed from the original process and why, including any optimizations declined and the reasoning
+- **Outcome** — what a successful run produces, when it runs, who consumes it
+- **Metadata** — workflow name, trigger, owner, lens (Individual / Organizational), Definition Type (Step-Decomposed / Outcome-Driven)
+- **Context Inventory** — every artifact the workflow needs, with stable IDs (C1, C2, …), status (Exists / Needs Creation), AI accessibility (Yes / Partial / No), and location
+- **Acceptance Criteria** — what good output looks like, dimensions that matter (accuracy, completeness, tone, etc.), and the minimum bar
+- **Example Scenarios** — 3-5 representative inputs with what to look for in the output (feeds Step 5 — Test)
+- **Human Gates** — where human review or input is required
+- **Optimization Notes** (optional, step-decomposed only) — what changed from the original process and why
 
-Most workflows expand from 5-8 rough steps to 12-20 refined steps after the deep dive.
+**Step-decomposed middle block:**
 
-**Outcome-driven** (path c):
+- **Steps Overview** — a scannable numbered list, one line per step
+- **Step Details** — each step captured as **Goal / Inputs / Outputs / Rules & Edge Cases / Context Needed**, plus a **Role** field when the workflow uses the Organizational lens (to capture which role owns each step)
+- **Sequence** — sequential vs. parallel steps, critical path, role swimlane
 
-- **Scenario metadata** — name, description, outcome, trigger, type, objective, owners, definition type
-- **Goal** — what a successful run produces
-- **Inputs** — what the agent system receives to start
-- **Expected outputs** — format, structure, and quality expectations
-- **Constraints** — boundaries and guardrails
-- **Quality criteria** — evaluation dimensions (feeds directly into Test)
-- **Capability domains** — what the agent system needs to be good at (research, analysis, writing, etc.)
-- **Tools and data sources** — external systems with data readiness assessment
-- **Human gates** — where human review is expected
+Most step-decomposed workflows expand from 5-8 rough steps to 12-20 refined steps after the deep dive.
 
-Both formats are the input for the [Design phase](../design/) in Step 3 — Design. Step-decomposed definitions go through per-step classification and building block mapping. Outcome-driven definitions go through capability domain mapping with pre-determined Autonomous autonomy and Agent orchestration.
+**Outcome-driven middle block:**
 
-### Process optimization
+- **Inputs** — what the agent system receives to start (data, materials, references, access)
+- **Rules & Constraints** — must-do / must-never-do, scope boundaries, guardrails, tone, length limits
 
-For step-decomposed workflows, the skill includes an **Optimize for AI** pass after the deep dive. Once the full process is mapped, the model steps back and challenges it — looking for steps that exist only because a human was doing the work (an integration eliminates the manual transfer), steps that can be collapsed (AI drafts and formats in one pass), steps that can be parallelized (no data dependency), handoffs that can be simplified, and new steps needed for the AI version. These are presented as recommendations for you to accept or reject — you may have good reasons to keep steps as-is (compliance, audit trail, stakeholder expectations). The Workflow Definition records what changed and why.
+Outcome-driven workflows **don't** capture capability domains, agent count, or orchestration approach — those are Design decisions. Step 2 stays in "what" territory.
 
-### Workflow validation
+### Why this format
+
+The Workflow Requirements reads like a PRD, not an interview transcript:
+
+- **Requirements voice** — each line states what must be true, not what the user said in conversation
+- **Fixed structure** — same section headings every time, so downstream skills (Design, Test, Improve) can locate any requirement by path
+- **Stable IDs** — steps are numbered, context items are `C1, C2, C3, …`, scenarios are `E1, E2, E3, …`
+- **Tables for lists of items with shared fields** — easier to parse than prose
+- **No interview residue** — no "the user mentioned", "usually", or other narrative
+
+### Process optimization (step-decomposed only)
+
+For step-decomposed workflows, the skill includes an **Optimize for AI** pass after the deep dive. Once the full process is mapped, the model steps back and challenges it — looking for steps that exist only because a human was doing the work (an integration eliminates the manual transfer), steps that can be collapsed (AI drafts and formats in one pass), steps that can be parallelized (no data dependency), handoffs that can be simplified, and new steps needed for the AI version. These are presented as recommendations for you to accept or reject — you may have good reasons to keep steps as-is (compliance, audit trail, stakeholder expectations). The Workflow Requirements records what changed and why.
+
+### Workflow validation (step-decomposed only)
 
 After optimization, the skill runs a **validation pass** — walking through the refined workflow end-to-end to catch gaps before it moves to Design. This is the quality gate that stress-tests the workflow for:
 
@@ -190,18 +176,19 @@ After optimization, the skill runs a **validation pass** — walking through the
 - **Redundancy** — Steps that duplicate work or produce outputs no downstream step consumes?
 - **Handoff clarity** — Is it clear what passes between each step, and in what form?
 
-The model presents its findings as a summary and asks you to confirm or address each one. Any issues get resolved before the Workflow Definition is finalized.
+The model presents its findings as a summary and asks you to confirm or address each one. Any issues get resolved before the Workflow Requirements is finalized.
 
 ## Tips for Better Results
 
-- **Start with workflows you actually do.** Real processes have real complexity that produces useful analysis. Hypothetical workflows tend to be too clean.
-- **Include the messy details.** "Sometimes I skip this step if the client is a repeat customer" is exactly the kind of decision logic the model needs to capture.
-- **Don't over-prepare your steps.** The model is designed to work with rough, incomplete descriptions. Let it do the work of refining and organizing.
-- **Gather your context resources early.** The model will identify specific resources the workflow needs — documents like buyer personas and style guides, but also spreadsheets, databases, CRM access, application credentials, and sample data. If you already have these, have them ready. If you don't, the analysis will tell you exactly what to create or set up and what each resource should contain.
+- **Start with workflows you actually do.** Real processes have real complexity that produces useful requirements. Hypothetical workflows tend to be too clean.
+- **Include the messy details.** "Sometimes I skip this step if the client is a repeat customer" is exactly the kind of decision rule that belongs in the requirements.
+- **Don't over-prepare your steps.** The model works with rough, incomplete descriptions. Let it do the work of refining.
+- **Gather your context resources early.** The model identifies specific resources the workflow needs — documents, spreadsheets, databases, CRM access, application credentials, sample data. If you already have these, have them ready. If you don't, the analysis tells you exactly what to create or set up.
 
 :::tip[Register your workflow in the AI Registry]
 If you're using the [AI Registry](../../use-the-playbook/build/ai-registry/) Notion database, register your workflow as soon as naming is confirmed — the skill walks you through it. This creates a record of the workflow with its name, description, trigger, outcome, and type. You'll update this entry as you move through Build. Even if you're not using Notion, save the metadata somewhere — it's the first entry in your workflow inventory. See [Builder Tools Setup](../../builder-setup/notion-registry-setup/) if you haven't set up the AI Registry yet.
 :::
+
 ## Related
 
 - **Previous step:** Not sure which workflow to deconstruct? Start with [Analyze Workflows](../analyze/) (Step 1) to identify your best candidates.

--- a/src/content/docs/ai-workflow-framework/design.md
+++ b/src/content/docs/ai-workflow-framework/design.md
@@ -1,268 +1,245 @@
 ---
 title: Design Your AI Workflow
-description: Gather architecture decisions, assess workflow autonomy level, choose an orchestration mechanism and involvement mode, classify steps on the autonomy spectrum, map AI building blocks, identify skill candidates, and document agent blueprints — producing a platform-agnostic Design Spec.
+description: Take your Workflow Requirements and design the AI architecture — three layers of decisions (Architecture, Decomposition, Component Blueprints) produced as a platform-agnostic Design Spec that any model on any platform can build from.
 ---> **Part of:** [AI Workflow Framework](../)
 
 :::tip[New to the building blocks?]
 See the [Agentic Building Blocks](../../agentic-building-blocks/) reference for definitions, examples, and cross-platform comparisons of all blocks.
 :::
 
-:::note
-Coming from `/deconstruct` option (d) Compose? You're not here — Compose generates the orchestration prompt inline without invoking `/design`. See the [Compose section on the Deconstruct page](/ai-workflow-framework/deconstruct/#compose-option-d--for-clear-workflows-with-components-ready) for that path.
-:::
-
 ## What This Is
 
-The Design phase is where you decide *how* your workflow should be built — before you build it. You take the Workflow Definition from the [Deconstruct step](../deconstruct/) and make design decisions. The Design skill supports both **step-decomposed** and **outcome-driven** Workflow Definitions:
+The Design phase is where you decide *how* your workflow should be built — before you build it. You take the **Workflow Requirements** from the [Deconstruct step](../deconstruct/) (the *what*) and produce a **Design Spec** (the *how*) — the architectural blueprint Build consumes to generate skills, agents, and prompts.
 
-**For step-decomposed definitions**, you make five design decisions:
+The Workflow Requirements is the canonical source of truth. The Design Spec references it, never restates it. Build reads both together.
 
-1. **Architecture decisions** — What platform are you using, and what integrations and constraints does the Workflow Definition reveal?
-2. **Autonomy assessment** — Where does the whole workflow sit on the autonomy spectrum (Deterministic → Guided → Autonomous)?
-3. **Orchestration mechanism** — Who drives the workflow (Prompt, Skill-Powered Prompt, or Agent)?
-4. **Autonomy classification** — How much AI assistance does each step need?
-5. **Building block mapping** — What specific AI components does each step require?
+### Design has three layers
 
-**For outcome-driven definitions**, the flow is streamlined — autonomy (Autonomous) and orchestration (Agent) are pre-determined by definition. The Design phase focuses on:
+Design walks through three layers of decisions that build on each other. Each layer is approved before the next begins, so strategic errors get caught before you've invested time in detailed specs:
 
-1. **Architecture decisions** — Platform and tool integrations extracted from capability domains
-2. **Involvement mode** — Augmented or Automated, determined from the definition's human gates and trigger type
-3. **Capability domain mapping** — What integrations, intelligence, and reusable skills does each capability domain need?
-4. **Agent configuration** — The primary design artifact: agent blueprints drawn from the definition's goal, constraints, and expected outputs
-5. **Evaluation criteria** — Carried forward from the definition's quality criteria, with supplementary questions as needed
+| Layer | What it decides | Why it's separate |
+|---|---|---|
+| **Layer 1 — Architecture** | Platform, mechanism (Prompt/Skill-Powered Prompt/Agent), autonomy level, packaging, model class, integration options | Strategic. Cheap to revisit. Wrong call here cascades everywhere. |
+| **Layer 2 — Decomposition** | For each step (or capability domain), what AI building block delivers it: a new skill, an existing skill, an inline prompt block, an agent, or a human action | Structural. Decides what gets built and what gets reused. |
+| **Layer 3 — Component Blueprints** | Field-level specs for each new skill and agent — name, description, inputs/outputs, decision logic, failure modes, tools, deployment | Detailed. Most expensive to redo. Build uses these to generate artifacts. |
 
-:::note[Framework vs. platform — by design]
-This framework guides you through *which decisions to make* and *what building blocks to design* — it is platform-agnostic. The AI model provides the platform-specific expertise: it researches your chosen platform's current tools, SDKs, and best practices at runtime via web search. This separation ensures the framework stays current as platforms evolve, without requiring documentation updates every time a platform changes its offerings.
-:::
+The Design skill walks you through these layers in order, with a lightweight confirmation moment between each. The final Spec Approval Gate at the end is the only hard gate.
+
 | | |
 |---|---|
-| **What you'll do** | Upload your Workflow Definition, choose your architecture approach, confirm your platform, review the AI's autonomy assessment and orchestration mechanism recommendation, review step classifications, and adjust anything that doesn't look right |
-| **What you'll get** | A **Design Spec** — architecture approach with rationale, architecture decisions, autonomy level assessment, orchestration mechanism with involvement mode, per-step autonomy classifications, building block mapping, skill candidates, agent blueprints (when applicable), and a prioritized build sequence |
-| **Time** | ~15–25 minutes (architecture questions + reviewing the AI's analysis) |
+| **What you'll do** | Confirm your platform, work through three layers of design decisions with lightweight confirmation at each handoff, and approve the final spec |
+| **What you'll get** | A **Design Spec** — three-layer architecture and component blueprints, with frontmatter, stable IDs, and a Self-Test Summary |
+| **Time** | ~15–25 minutes |
 
 ## Why This Matters
 
-Not every workflow needs the same level of AI infrastructure. A weekly status report might need a single well-crafted prompt. A multi-department content pipeline might need specialized agents coordinating across stages. Choosing the wrong orchestration mechanism means either over-engineering (building agents when a prompt would do) or under-building (forcing a prompt to do agent-level work).
+Not every workflow needs the same level of AI infrastructure. A weekly status report might need a single well-crafted prompt. A multi-department content pipeline might need specialized agents coordinating across stages. Choosing the wrong mechanism means either over-engineering (building agents when a prompt would do) or under-building (forcing a prompt to do agent-level work).
 
-Design also maps each step to specific **AI building blocks** — Prompt, Context, Skill, Agent, MCP, Project, API, or SDK — so you know exactly what to build. The recommended implementation order (quick wins first, complex agent steps last) gives you a practical sequence for rolling out AI incrementally.
+Design also makes the workflow **portable**. Because the Design Spec follows the agentskills.io standard and uses stable IDs for every component, the same spec can be built on Claude Code, Claude.ai, Cowork, Codex, ChatGPT, or Gemini CLI — with only the platform-specific bits (Packaging, Deployment Plan) adjusted at the handoff.
 
-## Architecture Approach
+:::note[Framework vs. platform — by design]
+This framework guides you through *which decisions to make* and *what building blocks to design* — it is platform-agnostic. The AI model provides the platform-specific expertise: it researches your chosen platform's current tools, SDKs, and best practices at runtime via web search. This separation ensures the framework stays current as platforms evolve.
+:::
 
-Before any other decisions, choose how you'll build your workflow. This is the first fork in the road — it shapes which platforms, tools, and building blocks are available to you.
+---
+
+## Layer 1 — Architecture
+
+Strategic decisions that shape everything downstream. You start here.
+
+### Architecture Approach
 
 | Approach | What it means | Build in |
 |----------|---------------|----------|
-| **No-code** | Build entirely in a platform's UI — projects, custom GPTs, gems, notebooks | Claude Projects, ChatGPT GPTs, Gemini Gems, M365 Copilot |
+| **No-code** | Build entirely in a platform's UI — projects, workspace agents, gems, notebooks | Claude Projects, ChatGPT Workspace Agents, Gemini Gems, M365 Copilot |
 | **Code-first** | Build with APIs and SDKs — programmatic model access, code-based agents, version-controlled workflows | Claude Agent SDK, OpenAI Agents SDK, Google ADK, LangChain, etc. |
 
-### Which approach fits?
+The model analyzes your workflow and recommends an approach based on signals like integration needs, deployment scale, and developer experience. Most workflows start no-code and graduate to code-first when scale or integration demands it.
 
-The model analyzes your workflow and recommends an approach based on these signals:
+### Platform decision
 
-| Signal | Points toward |
-|--------|---------------|
-| Need to integrate into an existing application | Code-first |
-| Need CI/CD deployment or version control | Code-first |
-| Need to process high volume or run at scale | Code-first |
-| Non-developer or exploring AI for the first time | No-code |
-| Prototyping before committing to production | No-code first, then code-first |
-| Workflow runs inside a single AI platform | No-code |
-| Workflow needs to orchestrate across multiple services | Code-first |
+You name your AI platform — at whatever level of specificity you have. "Claude Code," "ChatGPT," "Google Gemini," "Claude" are all fine. The ecosystem is enough for Design decisions; the specific offering (Claude Code vs. Claude.ai vs. Cowork) is resolved when Build generates artifacts.
 
-Most workflows start no-code. Code-first becomes the right choice when you need programmatic control, integration into existing systems, or production-grade deployment. The same three orchestration mechanisms (Prompt, Skill-Powered Prompt, Agent) apply to both approaches — the architecture approach determines *how* you implement them, not *what* you implement.
+### Other Architecture Decisions extracted from the Workflow Requirements
 
-:::tip[You can switch later]
-Many teams prototype no-code, validate the workflow works, then rebuild code-first for production. The Design Spec captures the design either way — only the Build step changes.
-:::
-## Architecture Decisions
+Rather than walking through a checklist, the Design skill uses an **extract-then-confirm** approach: ask one question (platform), extract everything else from the Workflow Requirements, present the analysis for confirmation.
 
-Before assessing autonomy and choosing an orchestration mechanism, the model gathers the information that shapes platform-aware recommendations. Rather than walking through a checklist, it uses an **extract-then-confirm** approach: ask one question, extract everything else from your Workflow Definition, and present the analysis for confirmation.
+- **Tool integrations** — pulled from per-step Inputs, Context Needed, and the Context Inventory
+- **Trigger/schedule** — pulled from the Metadata table; time-based triggers imply scheduled execution
+- **Context readiness flags** — pulled from the Context Inventory's AI Accessible column; flags items needing resolution before Build
 
-**One question: Platform.** The only thing not already in your Workflow Definition is which AI platform you'll use. If you've already mentioned it in conversation, the model confirms. If not, it asks — and accepts whatever level of specificity you provide ("Claude Code", "ChatGPT", "Google Gemini", "Claude" are all fine). The model doesn't try to disambiguate to a specific offering upfront — the ecosystem is enough for Design decisions, and the specific tool is resolved during Build when generating artifacts.
+### Autonomy Assessment
 
-**Everything else is extracted from the Workflow Definition:**
-
-- **Tool integrations** — pulled from data flows, context needs, and step details across all steps. The model lists the tools identified but defers platform availability research to the Build step.
-- **Trigger/schedule** — pulled from your Scenario Metadata. Time-based triggers are noted as scheduled execution requirements with implications for involvement mode and infrastructure.
-- **Browser access** — if any step involves logging into a website, it's flagged during step classification rather than asked about separately. The connection details are handled during Build.
-- **Shareability** — deferred to Build, where it determines artifact format (file-based vs. code-based). Not asked during Design.
-
-Code comfort and deployment surface are inferred from the platform choice when specific (Claude Code = CLI + code-comfortable, ChatGPT = web + no-code) or resolved during Build when vague.
-
-After extracting, the model presents a single confirmation block showing the platform, extracted tool integrations with availability mapping, trigger implications, and any flags — then asks if anything was missed or needs adjustment. The confirmed decisions gate all subsequent recommendations.
-
-## Autonomy Assessment
-
-Before choosing an orchestration mechanism, the model assesses where the *whole workflow* sits on the autonomy spectrum. This is the same spectrum used for per-step classification later — applied at the workflow level.
+Where the *whole workflow* sits on the autonomy spectrum:
 
 ```
-Deterministic ———————— Guided ———————— Autonomous
-(fixed path)       (bounded decisions)     (context-driven path)
+Human ———— Deterministic ———————— Guided ———————— Autonomous
+(human-performed)  (fixed path)       (bounded decisions)     (context-driven path)
 ```
 
 | Level | Signals | Orchestration implications |
 |-------|---------|--------------------------|
-| **Deterministic** | Steps always execute in the same order, no branching on output quality, failure = stop or retry same step | Prompt or skill-powered prompt likely sufficient |
-| **Guided** | Some steps involve bounded AI judgment, human steers at checkpoints, sequence is mostly fixed but with bounded flexibility | Skill-powered prompt or agent |
-| **Autonomous** | Executor backtracks, re-invokes based on feedback, adjusts approach on failure, human checkpoints can redirect flow | Agent required |
+| **Human** | Step requires human judgment, creativity, or physical action; AI cannot perform | No AI artifact — captured as Human step in the Decomposition table |
+| **Deterministic** | Steps execute in fixed order, no branching on quality, failure = stop or retry | Prompt or Skill-Powered Prompt likely sufficient |
+| **Guided** | Bounded AI judgment at steps, human steers at checkpoints, mostly fixed sequence | Skill-Powered Prompt or Agent |
+| **Autonomous** | Executor backtracks, re-invokes, adjusts on failure, checkpoints can redirect | Agent required |
 
-The model presents this as a confident assessment — for example: *"This workflow is **Guided** because most steps follow a fixed sequence, but the research step involves bounded judgment about which sources to pursue."* If you disagree, you discuss and adjust.
+### Orchestration Mechanism
 
-## Orchestration Mechanism
-
-Based on the autonomy assessment and architecture decisions, the model recommends who drives the workflow. The orchestration mechanism answers: **who follows the steps?**
+Based on the autonomy assessment and architecture decisions, the model recommends who drives the workflow:
 
 | Mechanism | Description | Signals |
 |-----------|-------------|---------|
 | **Prompt** | Human follows structured instructions step by step, all logic inline | Sequential steps, human provides inputs and makes decisions |
-| **Skill-Powered Prompt** | Human invokes reusable skills in a defined sequence | Repeatable sub-routines, moderate complexity, steps that recur across workflows |
+| **Skill-Powered Prompt** | Human invokes reusable skills in a defined sequence | Repeatable sub-routines, moderate complexity |
 | **Agent** | Agent orchestrates the flow, invoking skills and making sequencing decisions | Tool use required, autonomous decisions, multi-step reasoning |
 
-Single-agent vs. multi-agent is an architecture detail decided during agent configuration (later in Design) if "Agent" is selected — not a top-level choice here.
-
-The model presents a confident recommendation — for example: *"Based on your workflow's **Guided** autonomy and the two reusable sub-routines I identified, I recommend **Skill-Powered Prompt** with **Augmented** involvement."*
-
-If you disagree, the model explains the alternatives and you discuss. Most workflows start as Prompt or Skill-Powered Prompt and evolve toward agents as you add automation.
-
-When the orchestration mechanism is Agent and the platform has multiple agent offerings (e.g., Claude Code sub-agents vs. Claude Agent SDK), the model asks which offering you want to use — this determines the artifact format in the Build step.
-
-### Human Involvement
-
-The orchestration mechanism recommendation includes an involvement mode — whether a human participates during the workflow run:
+Plus an involvement mode:
 
 | Mode | Description | Determined by |
 |------|-------------|---------------|
-| **Augmented** | Human is in the loop — reviews, steers, or decides at key points during the run. | Web/desktop deployment, no scheduled execution |
-| **Automated** | AI runs solo — executes end-to-end without human involvement during the run. | Scheduled/unattended execution, CLI |
+| **Augmented** | Human in the loop — reviews, steers, or decides at key points during the run | Web/desktop deployment, no scheduled execution |
+| **Automated** | AI runs solo — executes end-to-end without human involvement | Scheduled/unattended execution, CLI |
 
-The involvement mode is determined by your architecture decisions — platform, scheduled execution needs, and which steps require human review. See the [AI Workflow Design Matrix](../workflow-design-matrix/) for how autonomy and involvement combine into six workflow archetypes.
+### Packaging
 
-:::note[Deeper architectural patterns]
-For detailed implementation blueprints (prompt chaining, routing, parallelization, orchestrator-workers, evaluator-optimizer, and autonomous agents), see [Workflow Architecture Patterns](../../patterns/workflow-architecture/).
-:::
+How the artifacts ship together:
+
+| Value | When to use |
+|---|---|
+| **Plugin** | Multiple related artifacts shipped together as a marketplace plugin (e.g., handsonai-plugins layout) |
+| **Standalone Skill** | A single skill, uploaded directly (zip for Claude.ai, single SKILL.md for code-mode platforms, single skill for ChatGPT) |
+| **Workspace Agent** | A ChatGPT Workspace Agent bundling orchestration + skills + tools (the current ChatGPT primitive; Custom GPTs are deprecated) |
+| **Loose Files** | Individual files in a project directory, no distribution wrapper |
+
+### Model Recommendation
+
+A capability tier (reasoning-heavy / fast / vision) with per-step overrides if needed. The spec includes a per-platform mapping (Claude opus/sonnet/haiku, ChatGPT gpt-5/gpt-4o/gpt-4o-mini, Gemini 2.5-pro/2.5-flash) so Build knows which concrete model to use on the target platform.
+
+### Integration Options
+
+For each tool the workflow needs, the model researches available integration options — curated MCP servers, APIs, SDKs, and CLIs — with source URLs and trade-offs. The output is platform-agnostic; Build does the per-platform setup research.
+
+**End of Layer 1.** Lightweight confirmation: "Architecture confirmed: [summary]. Moving to Decomposition. Confirm to proceed."
+
 ---
 
-:::caution[Activate plan mode now]
-You've made the key decisions — architecture, autonomy level, orchestration mechanism, and involvement mode. This is the transition point. **Activate plan mode** on your AI tool before continuing. The model will now plan the rest of the spec (per-step autonomy classification, building block mapping, skill candidates, agent blueprints) based on the decisions you've locked in. See [How to activate plan mode](#two-phases-two-modes) for platform-specific instructions.
-:::
-## Autonomy Classification
+## Layer 2 — Decomposition
 
-For each step in your Workflow Definition, classify it on the autonomy spectrum:
+For each step (or capability domain), decide which AI building block delivers it.
 
-| Level | Description | Example |
-|-------|-------------|---------|
-| **Human** | Requires human judgment, creativity, or physical action; AI cannot perform this | Final approval of a contract, in-person meeting |
-| **Deterministic** | Follows fixed rules; AI executes reliably with no decisions | Formatting a report, extracting data from a template |
-| **Guided** | AI makes bounded decisions within guardrails; human reviews at key checkpoints | Drafting an email for human review before sending |
-| **Autonomous** | AI plans and executes end-to-end, including decisions and tool use | Research agent that finds, evaluates, and summarizes sources |
+### Step-by-Step Decomposition
 
-## Building Block Mapping
+Steps are defined in the Workflow Requirements. This table adds the building-block classification and the concrete Build output for each:
 
-Map each AI-assisted step to one or more of the AI building blocks:
+| Column | Values |
+|---|---|
+| **Step** | Step ID from Workflow Requirements |
+| **Autonomy** | Human / Deterministic / Guided / Autonomous |
+| **Orchestration** | Prompt / Skill / Agent |
+| **Integration** | Block + tool + use/build tag (e.g., "MCP: Notion (use)") |
+| **Intelligence** | Model class + context source IDs + memory flag |
+| **Build Output** | One of: `New skill: S1` / `Use existing: [name]` / `New agent: A1` / `Inline prompt → Workflow Requirements Step N` / `MCP server: [name]` / `Human (no artifact)` |
+| **Human Gate?** | Yes / No (from Workflow Requirements Human Gates) |
 
-| Block | What It Is | When to Use It |
-|-------|-----------|----------------|
-| **Model** | The AI engine that processes inputs and generates outputs | When the task requires specific capabilities (reasoning, multimodal, speed) that influence model choice |
-| **Prompt** | A well-crafted instruction that tells the model what to do for this step | Every AI step needs at least a prompt |
-| **Context** | Background information, reference documents, examples, or data the model needs | When the step requires domain-specific knowledge not in the model's training |
-| **Skill** | A reusable routine — give it inputs, it follows a defined process, it produces consistent outputs | When a step has complex logic that recurs across workflows |
-| **Agent** | An autonomous AI that plans, uses tools, and executes multi-step work | When a step requires tool use, adaptive reasoning, or autonomous decisions |
-| **MCP** | A connector giving the model access to external tools, APIs, databases, or services | When a step needs to read from or write to external systems |
-| **Project** | A persistent workspace grouping prompts, context, skills, and agents | When the workflow runs frequently with the same reference materials |
-| **Memory** | Accumulated knowledge the AI retains across conversations — preferences, past decisions, learned patterns | When repeating context across workflow runs is friction, or when the AI should adapt to patterns over time |
-| **API** | Programmatic interfaces for accessing AI models and cloud services | When a step needs to be called from code, integrated into an application, or run at scale |
-| **SDK** | Frameworks and toolkits for building AI workflows in code | When a step is implemented as a code-first agent with tool use, orchestration, or multi-agent coordination |
+For outcome-driven workflows, this is replaced by a **Capability Domain Mapping** — capability domains are derived during Design (not present in the Workflow Requirements), each with integration needs, intelligence requirements, and Build Output.
 
-Also identify for each step:
+### Orchestrator Prompt Outline
 
-- **Tools and connectors** — What external tools, APIs, or integrations does this step need?
-- **Human-in-the-loop gates** — Where should a human review before the workflow continues?
+When mechanism is `Prompt` or `Skill-Powered Prompt`, the spec includes an **Orchestrator Prompt Outline** — the structural skeleton of the workflow's main prompt. It names which step invokes which skill, where PAUSE points sit (from Human Gates), and what the user provides at each gate. Build expands the outline into the full orchestrator using Step Details from the Workflow Requirements.
 
-## Skill Candidate Identification
+Omitted for `Agent` mechanism — the agent itself is the orchestrator (see Agent Configuration in Layer 3).
 
-Steps that should become skills share these characteristics:
+### Data Readiness Summary
 
-- **Reusable** — The logic appears in multiple workflows or will be run repeatedly
-- **Complex** — More than a simple instruction; involves multi-step reasoning, evaluation criteria, or domain expertise
-- **Consistent** — Needs to produce reliable, repeatable outputs every time
+Context items from the Workflow Requirements' Context Inventory flagged as `Partial` or `No` for AI Accessible — with the action needed to make each one accessible before Build runs.
 
-For each skill candidate, document enough detail for generation:
+### Recommended Implementation Order
 
-| Detail | What to capture |
-|--------|----------------|
-| **Purpose** | What the skill does in one sentence |
-| **Inputs** | What data or information the skill receives |
-| **Outputs** | What the skill produces |
-| **Decision logic** | Key rules, criteria, or evaluation frameworks |
-| **Failure modes** | What happens when inputs are missing or unexpected |
+Quick Wins → Core → Future Enhancement. Within each tier, dependencies follow the `Depends On` field of each skill.
 
-This detail enables generation of skills on any platform during the Build step.
+**End of Layer 2.** Lightweight confirmation: "Decomposition confirmed: [counts]. Moving to Component Blueprints. Confirm to proceed."
 
-## Agent Blueprints
+---
 
-When the orchestration mechanism is Agent, document each agent your workflow needs. These are platform-agnostic specifications — the model builds them into working agents during [Build](../build/). Whether the workflow needs one agent or multiple agents is decided here based on the number of distinct roles, expertise domains, and orchestration needs.
+## Layer 3 — Component Blueprints
 
-| Component | What to specify |
-|-----------|----------------|
-| **Name** | Unique agent name |
-| **Description** | Agent purpose and when it should be used |
-| **Instructions** | Mission, responsibilities, behavior, goals, tone & style, output format |
-| **Model** | Recommended model capability (reasoning-heavy, fast, etc.) |
-| **Tools** | Tools the agent can call (MCP servers, file access, web, APIs) |
+Field-level specs Build uses to generate each new skill and agent.
 
-Plus:
+### Skill Candidates (12 fields)
 
-- **Context** — What data, files, or knowledge base does the agent need access to?
-- **Goal** — What triggers this agent and what does it produce?
+For each step tagged `New skill: SN`:
 
-For **multi-agent** workflows, also document:
+| Field | Purpose |
+|---|---|
+| ID, Name, Description | Identity. Name must be lowercase-hyphenated, ≤64 chars. Description must start with "This skill should be used when..." and be ≤1024 chars — this is the verbatim text that goes into the SKILL.md frontmatter and drives auto-activation. |
+| Purpose, Covers Steps/Domains | Internal context for spec readers |
+| Inputs, Outputs | The skill's contract |
+| Decision Logic, Failure Modes | What the skill does and how it handles edge cases |
+| Required Tools, Depends On | Runtime dependencies on tools and other skills |
+| Stateful? | Memory building-block flag |
 
-- **Orchestration pattern** — Supervisor (one agent delegates), pipeline (agents in sequence), or parallel (agents work simultaneously)
-- **Agent handoffs** — What does each agent pass to the next? What format?
-- **Human review gates** — Where does a human review output before the pipeline continues?
+### Agent Configuration (13 fields, mandatory when mechanism = Agent)
 
-This agent configuration is **platform-agnostic** — it serves as a blueprint. During the Build step, the model researches your chosen platform's current tools and generates platform-appropriate agent implementations.
+For each step tagged `New agent: AN`:
 
-## Outcome-Driven Design Flow
+| Field | Purpose |
+|---|---|
+| ID, Name, Description | Identity. Description must start with "Use this agent when..." and is the verbatim text for the agent file frontmatter. |
+| Mission, Responsibilities, Output Format, Tone & Style, Constraints | The agent's behavior — decomposed into structured sub-fields, not jammed into a single "Instructions" cell |
+| Model, Memory Scope | Capability and persistence |
+| Tools, Skills | Cross-references to Integration Options entries and Skill IDs |
+| Trigger Examples | 2-3 structured examples (context → user message → expected behavior → invocation) Build uses verbatim to construct `<example>` blocks in the agent's description |
 
-When your Workflow Definition has `Definition Type: Outcome-Driven`, the Design phase takes a streamlined path:
+### Multi-Agent Configuration
 
-- **Autonomy** is Autonomous by definition — the agent system determines its own execution path
-- **Involvement mode** (Augmented vs. Automated) is still determined from the definition's Human Gates section and trigger type
-- **Orchestration** is Agent — the primary design artifact is the agent configuration
-- **Capability domain mapping** replaces per-step classification — for each domain (research, analysis, writing, etc.), the model maps integration needs, intelligence requirements, and whether the domain should become a reusable skill
-- **Evaluation criteria** are carried forward from the definition's Quality Criteria section rather than gathered from scratch
-- **Agent Configuration** becomes the primary section of the spec, with instructions drawn from the definition's Goal, Constraints, and Expected Outputs
+When more than one agent is defined, this section captures the orchestration pattern (Supervisor / Pipeline / Parallel / Network), the coordinator, the Handoff Contracts table (data passed between agents), and the Aggregation Strategy.
 
-The output is the same Design Spec format, with Capability Domain Mapping replacing the Step-by-Step Decomposition table, and an Autonomy Statement replacing the Autonomy Spectrum Summary.
+### Prerequisites and Deployment Plan
+
+Prerequisites lists platform setup, accounts, credentials, and plugin installs needed before the workflow can run. The Deployment Plan documents where each artifact lives and how it gets deployed — with a Packaging note explaining how artifacts ship together.
+
+**End of Layer 3.** Final Spec Approval Gate — the only hard gate. Review the full spec; approve to move to [Build](../build/).
+
+---
+
+## Cross-Layer Sections
+
+These sections sit outside the three layers:
+
+- **Evaluation Inputs** — pointer to the Workflow Requirements' Acceptance Criteria and Example Scenarios (not duplicated). Step 5 (Test) reads them from the Workflow Requirements directly.
+- **Deferred to Build** — explicit list of decisions intentionally left for Build (specific platform offering, exact model version, integration setup specifics)
+- **Stakeholders** (optional, organizational lens) — role swimlane and stakeholder details
+- **Self-Test Summary** — populated by the Design skill after running the Build Skill Needs Checklist; each item ✓ (passed) or ⚠️ (issue described inline). Lets you see what was verified before approving.
+
+---
 
 ## How to Use This
 
-This step is facilitated by the **`design`** AI Workflow Framework Skill. How you get it depends on your platform — see [Set Up the Skills](../skills/) for installation instructions.
+This step is facilitated by the **`design`** AI Workflow Framework Skill. How you get it depends on your platform — see [Set Up the Skills](../skills/) for installation.
 
 **Start with this prompt:**
 
 ```
-Design the AI workflow from my Workflow Definition.
+Design the AI workflow from my Workflow Requirements.
 Assess the autonomy level, recommend an orchestration mechanism, and map building blocks.
 ```
 
-Upload or paste your Workflow Definition file (`[workflow-name]-definition.md`) from the Deconstruct step when prompted. The skill runs the Design analysis and produces a Design Spec.
+Upload or paste your Workflow Requirements file (`[workflow-name]-requirements.md`) from the Deconstruct step. The skill runs the three layers in order, with lightweight confirmation between each, and produces a Design Spec.
 
 :::tip[If your AI tool doesn't support skills]
-Download the skill file from [GitHub](https://github.com/jamesgray-ai/handsonai-plugins/tree/main/plugins/handsonai/skills/design) and paste it into your system prompt or project instructions. Or use this page as a conversation guide — walk through each section in order with your AI tool.
+Download the skill file from [GitHub](https://github.com/jamesgray-ai/handsonai-plugins/tree/main/plugins/handsonai/skills/design) and paste it into your system prompt or project instructions. Or use this page as a conversation guide.
 :::
-### Two phases, two modes
 
-Design has two distinct phases that use different modes of interaction with the model:
+### Plan mode and the three layers
 
-**Phase 1: Collaborative decisions (normal conversation)**
+The Design skill works best in plan mode. The layered flow maps naturally onto how you'll work with the model:
 
-The first part of Design is a back-and-forth conversation. The model scans your Workflow Definition for known answers, confirms what it can infer, asks about anything genuinely unknown, assesses the workflow's autonomy level, recommends an orchestration mechanism and involvement mode, and you discuss and confirm. This is normal conversational mode — you're making decisions together.
-
-**Phase 2: Plan the spec (plan mode)**
-
-Once the architecture decisions, autonomy level, and orchestration mechanism are locked in, the model has everything it needs to plan the full Design Spec. This is when you **activate plan mode** — the model shifts from asking you questions to planning: classifying each step on the autonomy spectrum, mapping building blocks, identifying skill candidates, and documenting agent blueprints.
+| Layer | Mode |
+|---|---|
+| **L1 Architecture** | Conversational — discuss platform, mechanism, packaging. Quick back-and-forth. |
+| **L2 Decomposition** | The natural plan-mode entry point — start planning here. The model classifies each step and proposes Build Outputs. |
+| **L3 Component Blueprints** | Stays in plan mode — detailed field-level spec generation. |
 
 **How to activate plan mode on your platform:**
 
@@ -271,30 +248,69 @@ Once the architecture decisions, autonomy level, and orchestration mechanism are
 | **Claude Code** | Press `Shift+Tab` twice, or type `/plan` |
 | **Cursor** | Select "Plan" in the composer mode |
 | **Codex CLI** | Run with the `--plan` flag |
-| **Other AI tools** | Ask the model: *"Switch to plan mode. Based on the architecture decisions, autonomy level, and orchestration mechanism we've agreed on, plan the full Design Spec — classify each step, map building blocks, identify skill candidates, and document agent blueprints."* |
+| **Other AI tools** | Ask the model: *"Switch to plan mode. Walk me through Layers 2 and 3 of the Design — classify each step, identify skill candidates, write the component blueprints."* |
 
-After the model produces the plan, **review and approve the Design Spec** before moving on. If anything needs adjustment — a step classification, a skill candidate, an agent blueprint — now is the time. Once you approve, the model transitions to [Build (Step 4)](../build/) and begins building.
+After the model produces the spec, **review and approve at the Spec Approval Gate** before moving to Build.
+
+---
 
 ## What This Produces
 
-The Design Spec catalogs which AI building blocks each step uses — it's named after the step that produces it (Design), not the components it lists.
+The **Design Spec** is organized into the three layers above, plus cross-layer sections. The spec opens with YAML frontmatter so Build can summarize it in one read.
 
-The **Design Spec** contains:
+**Layer 1 — Architecture sections:** Execution Pattern, Architecture Decisions (with Packaging), Autonomy Spectrum Summary, Integration Options (with Source URLs), Model Recommendation (with per-platform mapping).
 
-- **Architecture approach** — No-code or Code-first, with rationale and recommendation signals
-- **Autonomy level assessment** — Deterministic, Guided, or Autonomous, with rationale for where the whole workflow sits on the spectrum
-- **Orchestration mechanism** — Prompt, Skill-Powered Prompt, or Agent, with involvement mode and reasoning
-- **Architecture decisions** — platform, tool integrations (with connector mapping), trigger/schedule implications, and any flags (browser access, infrastructure needs) — each with rationale and a constraints summary showing how they shaped the recommendations. Deployment surface, code comfort, and shareability are resolved during Build.
-- **Code-first selections** (when applicable) — specific API and SDK choices per step with justification (e.g., "Claude Agent SDK for the research agent because it needs tool use and multi-step orchestration")
-- **Scenario summary** — workflow metadata from the Workflow Definition
-- **Decomposition table** — every step with autonomy classification, decision points, failure modes, data flows, context needs, AI building block mapping, and skill candidate flags
-- **Autonomy spectrum summary** — steps grouped by classification level
-- **Skill candidates** — steps tagged for skill creation, with generation-ready detail (purpose, inputs, outputs, decision logic, failure modes)
-- **Agent blueprints** (when applicable) — platform-agnostic specification for each agent with all five core components plus context and goal
-- **Step sequence and dependencies** — sequential vs. parallel execution paths
-- **Prerequisites** — what must be in place before the workflow can run
-- **Context inventory** — every piece of context the workflow needs, with status and key contents
-- **Tools and connectors** — external integrations required
-- **Implementation order** — quick wins → semi-autonomous → complex agent steps
+**Layer 2 — Decomposition sections:** Step-by-Step Decomposition (or Capability Domain Mapping for outcome-driven), Orchestrator Prompt Outline (when mechanism is Prompt or Skill-Powered Prompt), Data Readiness Summary, Recommended Implementation Order.
 
-This Design Spec is the input for [Step 4: Build](../build/), where the model generates platform-appropriate artifacts (prompts, skills, agents, connectors) based on your orchestration mechanism and architecture decisions.
+**Layer 3 — Component Blueprint sections:** Skill Candidates (12 fields each), Agent Configuration (13 fields each; mandatory for outcome-driven), Multi-Agent Configuration (when applicable), Prerequisites, Deployment Plan.
+
+**Cross-layer sections:** Evaluation Inputs (pointer), Deferred to Build, Stakeholders (optional), Self-Test Summary (verification results).
+
+Build reads both the Design Spec and the Workflow Requirements together — the Design Spec is the architectural blueprint; the Workflow Requirements remains the canonical source for per-step content, acceptance criteria, and human gates.
+
+---
+
+## Consuming the Design Spec
+
+The Design Spec is structured for machine consumption — by the Build skill, by other AI agents, or by engineers building tooling around the spec.
+
+### Schema
+
+| Element | Format |
+|---|---|
+| **Frontmatter** | YAML. Required fields: `workflow`, `requirements_file`, `spec_version`, `definition_type`, `mechanism`, `involvement`, `platform`, `platform_mode`, `packaging`, `counts` |
+| **Stable IDs** | `S1`, `S2`, … for skills; `A1`, `A2`, … for agents; `C1`, `C2`, … for context items (in the Workflow Requirements); `E1`, `E2`, … for example scenarios (in the Workflow Requirements) |
+| **Canonical vocabulary** | Autonomy: `Human / Deterministic / Guided / Autonomous`. Mechanism: `Prompt / Skill-Powered Prompt / Agent`. Packaging: `Plugin / Standalone Skill / Workspace Agent / Loose Files`. Build Output: `New skill: SN / Use existing: [name] / New agent: AN / Inline prompt → Workflow Requirements Step N / MCP server: [name] / Human (no artifact)` |
+| **Section ordering** | Layer 1 → Layer 2 → Layer 3 → Cross-layer. Section names within each layer are fixed (consumers can locate any section by name). |
+| **Self-Test Summary** | Each Build Skill Needs Checklist item marked ✓ or ⚠️ with inline description. Lets consumers see what was verified. |
+
+### Consuming the spec standalone (without the Build skill)
+
+A capable agent (Claude Code, Codex, ChatGPT with skill support, Gemini CLI) can build the artifacts from the Design Spec alone, given access to:
+
+1. **The Workflow Requirements file** — referenced from frontmatter `requirements_file:`
+2. **The agentskills.io specification** — the open standard skill format ([agentskills.io/specification](https://agentskills.io/specification))
+3. **The target platform's agent format docs** — Claude Code's [sub-agents docs](https://code.claude.com/docs/en/sub-agents), Codex's [subagents docs](https://developers.openai.com/codex/subagents), or equivalent
+
+For best results, run Build via the framework's Build skill — it auto-resolves these via the platform registry and handles deployment.
+
+### Cross-platform portability
+
+The Design Spec is portable across platforms because every major platform (Claude Code, Claude.ai, Cowork, Codex, ChatGPT, Gemini CLI) now follows the agentskills.io standard for skills. Three practical workflows:
+
+1. **Same platform throughout** (most common) — Design on Claude Code → Build on Claude Code. Platform in the spec matches Build's runtime platform.
+2. **Design once, Build elsewhere** — Skill Candidates and Agent Configuration carry over unchanged because they're agentskills.io-compatible. Update Architecture Decisions (Platform, Packaging) and Deployment Plan when moving. Example: design on Claude Code at home, build on Codex at work.
+3. **Plan for a different target platform** — Design on Claude Code targeting ChatGPT Workspace Agents (or any other platform). Build resolves the platform-specific translation at generation time.
+
+**agentskills.io is the portability layer.** Every major platform converges on the standard, so Skill Candidates from one platform's Design Spec build cleanly on another with minimal rewriting.
+
+---
+
+## Related
+
+- **Previous step:** [Deconstruct Workflows](../deconstruct/) (Step 2) — produces the Workflow Requirements that Design consumes
+- **Next step:** [Build the Workflow](../build/) (Step 4) — generates platform artifacts from the Design Spec
+- [AI Workflow Framework](../) — the full seven-step methodology
+- [Workflow Design Matrix](../workflow-design-matrix/) — how autonomy and involvement combine into six workflow archetypes
+- [Workflow Architecture Patterns](../../patterns/workflow-architecture/) — implementation blueprints (prompt chaining, routing, orchestrator-workers, evaluator-optimizer, autonomous agents)
+- [Agents](../../agentic-building-blocks/agents/), [Skills](../../agentic-building-blocks/skills/), [Prompts](../../agentic-building-blocks/prompts/)

--- a/src/content/docs/ai-workflow-framework/examples/content-calendar-planning.md
+++ b/src/content/docs/ai-workflow-framework/examples/content-calendar-planning.md
@@ -1,6 +1,6 @@
 ---
 title: "Example: Content Calendar Planning"
-description: A complete worked example showing the framework deliverables — Workflow Definition, Design Spec, and workflow prompt — for a real content calendar planning workflow.
+description: A complete worked example showing the framework deliverables — Workflow Requirements, Design Spec, and workflow prompt — for a real content calendar planning workflow.
 ---This page walks through the complete output of running a real workflow through the [AI Workflow Framework](../..//). The workflow is **Content Calendar Planning** — a weekly process for planning and sequencing content across LinkedIn, Substack, X, and YouTube.
 
 The first four steps of the framework — Analyze, Deconstruct, Design, and Build — produced three key deliverables for this workflow. Each one is a detailed markdown document. This page summarizes what's in each and why it matters — then links to the full file on GitHub where you can read every table, every decision point, and every failure mode at full width.
@@ -9,22 +9,24 @@ The first four steps of the framework — Analyze, Deconstruct, Design, and Buil
 
 ## The Deliverables
 
-### 1. Workflow Definition (Step 2 — Deconstruct)
+### 1. Workflow Requirements (Step 2 — Deconstruct)
 
-[GitHub View full Workflow Definition on GitHub](https://github.com/jamesgray-ai/handsonai/blob/main/examples/content-calendar-planning/workflow-definition.md)
+[GitHub View full Workflow Requirements on GitHub](https://github.com/jamesgray-ai/handsonai/blob/main/examples/content-calendar-planning/workflow-requirements.md)
 
-The Workflow Definition is what [Deconstruct](../../deconstruct/) produces. What started as "I plan content on Sundays" became **10 refined steps across four phases** after the six-question deep dive.
+The Workflow Requirements is what [Deconstruct](../../deconstruct/) produces. What started as "I plan content on Sundays" became **10 refined steps across four phases** after the six-question deep dive.
 
 **What's inside:**
 
-- **Scenario metadata** — workflow name, trigger, outcome, business objective
-- **10 refined steps** organized into four phases: Input Gathering (4 steps), Planning (4 steps), Approval (1 step), Execution (1 step)
-- **Each step decomposed** with: Action, Sub-steps, Decision Points, Data In, Data Out, Context Needed, and Failure Modes
-- **Dependency map** showing which steps can run in parallel and which must be sequential
-- **Context shopping list** — 9 artifacts the workflow needs, with status (Exists / Needs Creation)
-- **Related workflows** — upstream and downstream dependencies
+- **Outcome and Metadata** — workflow name, trigger, owner, business objective, definition type
+- **Steps Overview** — a scannable numbered list of all 10 steps
+- **Step Details** — each step captured as Goal / Inputs / Outputs / Rules & Edge Cases / Context Needed
+- **Sequence** — sequential vs. parallel steps, critical path
+- **Context Inventory** — 9 artifacts the workflow needs, with stable IDs, status (Exists / Needs Creation), AI accessibility, and location
+- **Acceptance Criteria** — what good output looks like, dimensions that matter, minimum bar
+- **Example Scenarios** — representative inputs with what to look for in the output
+- **Human Gates** — where human review is required
 
-**Key insight:** Notice how each step captures not just *what* to do, but *what to do when things go wrong*. Step 1 has a fallback for when no metrics data exists. Step 2 detects an empty backlog and escalates the importance of Step 3. Step 9 limits refinement to 3 rounds to prevent endless iteration. This failure-mode thinking is what makes the workflow robust enough for AI to execute.
+**Key insight:** Notice how each step's *Rules & Edge Cases* block captures not just what to do, but what to do when things go wrong. Step 1 has a fallback for when no metrics data exists. Step 2 detects an empty backlog and escalates the importance of Step 3. Step 9 limits refinement to 3 rounds to prevent endless iteration. Capturing edge cases as first-class requirements is what makes the workflow robust enough for AI to execute.
 
 ---
 
@@ -32,7 +34,7 @@ The Workflow Definition is what [Deconstruct](../../deconstruct/) produces. What
 
 [GitHub View full Design Spec on GitHub](https://github.com/jamesgray-ai/handsonai/blob/main/examples/content-calendar-planning/design-spec.md)
 
-The Design Spec is what [Design](../../design/) produces from the Workflow Definition. It classifies each step on the autonomy spectrum, identifies which steps should become reusable skills, and recommends an implementation order.
+The Design Spec is what [Design](../../design/) produces from the Workflow Requirements. It classifies each step on the autonomy spectrum, identifies which steps should become reusable skills, and recommends an implementation order.
 
 **What's inside:**
 
@@ -72,7 +74,7 @@ A few things to take away from this example:
 - **The expansion.** "I plan content on Sundays" became 10 steps across 4 phases, with decision logic, failure modes, and a dependency map. That expansion is what makes the workflow executable by AI.
 - **The autonomy spectrum.** Not every step needs AI autonomy. Steps 1, 2, 4, and 10 are deterministic (fixed data operations). Steps 5-8 are guided (AI proposes, human decides). Steps 3 and 9 are human-led. The framework helps you see this clearly.
 - **The build order.** The Design Spec doesn't just say "build everything." It recommends starting with a prompt (pure conversation, no infrastructure needed), then layering in skills incrementally. You get value from the first run.
-- **Platform-agnostic.** The Workflow Definition and Design Spec work with any AI tool. The skills and MCP connections are implementation details that vary by platform — but the underlying logic is the same everywhere.
+- **Platform-agnostic.** The Workflow Requirements and Design Spec work with any AI tool. The skills and MCP connections are implementation details that vary by platform — but the underlying logic is the same everywhere.
 
 ---
 

--- a/src/content/docs/ai-workflow-framework/index.md
+++ b/src/content/docs/ai-workflow-framework/index.md
@@ -50,14 +50,14 @@ The audit starts by determining which lens to use — individual or organization
 
 Define *what* the business process does — every step, decision, and handoff — before deciding *how* to implement it with AI.
 
-How you enter depends on what you're starting with:
+Step 2 is the **PRD for your workflow** — clear requirements, decision rules, and edge cases that feed directly into Design. There are two paths, chosen by one question at the start: *do you know the steps, or just the outcome?*
 
-- **You know the process.** You can describe the steps, decisions, and handoffs — the model interviews you to surface hidden details and capture it all in a structured format. This is the most common path for workflows you already do manually.
-- **You have a problem, not a process.** You know what's broken or slow, but there's no defined workflow yet. The model proposes a candidate workflow for you to react to, then decomposes it collaboratively.
-- **You know the outcome, not the process.** You know what you want produced but don't want to prescribe how — the model captures your goal, constraints, quality criteria, and what the agent system needs to be good at, producing an outcome-driven definition that feeds into agent-oriented design.
-- **Compose** — you already have skills and/or sub-agents and know the workflow; the framework writes the orchestration prompt directly inside `/deconstruct` (no Workflow Definition, no Design Spec, no `/build` — the prompt is the artifact).
+- **Step-decomposed** — You can describe how the work gets done. The model interviews you to refine the steps and surface decision rules, edge cases, and the context each step needs. Each step is captured as Goal / Inputs / Outputs / Rules & Edge Cases / Context.
+- **Outcome-driven** — You know what "done" looks like but the path varies; you want an agent system to figure it out at runtime. The model captures the outcome, inputs, acceptance criteria, rules, and constraints — without prescribing steps.
 
-For the first two paths, the model uses the **six-question framework** to break down each step:
+Don't have either yet? Describe the problem you're trying to solve. The model proposes a candidate workflow and routes you into one of the two paths above.
+
+For step-decomposed workflows, the model uses the **six-question framework** as the interview scaffold to surface what belongs in each step's requirements block:
 
 1. Is this step actually multiple steps bundled together?
 2. Are there decision points, branches, or quality gates?
@@ -66,9 +66,9 @@ For the first two paths, the model uses the **six-question framework** to break 
 5. What happens when this step fails?
 6. Can the AI access, interpret, and persist the data this step needs?
 
-This is purely the *what* — it captures the process without prescribing how AI will handle it. The *how* comes in Step 3 (Design), where the Workflow Definition becomes the input for architecture decisions.
+This is purely the *what* — the workflow's requirements, with no prescription of how AI will handle it. The *how* comes in Step 3 (Design).
 
-**Deliverable:** **Workflow Definition** (`outputs/[name]-definition.md`) — either a step-decomposed breakdown (refined steps with decision points, data flows, context needs, failure modes, and a context shopping list) or an outcome-driven definition (goal, inputs, outputs, constraints, quality criteria, capability domains, and human gates).
+**Deliverable:** **Workflow Requirements** (`outputs/[name]-requirements.md`) — a PRD-style document containing Outcome, Metadata, Context Inventory, Acceptance Criteria, Example Scenarios, Human Gates, and (optional, step-decomposed) Optimization Notes, plus a middle block specific to the chosen path (Steps Overview + per-step requirements for step-decomposed, or Inputs + Rules & Constraints for outcome-driven).
 
 **Facilitated by the `deconstruct` skill.** See [Deconstruct Workflows](deconstruct/) for details and [Set Up the Skills](skills/) for installation on any supported platform.
 
@@ -78,9 +78,9 @@ This is purely the *what* — it captures the process without prescribing how AI
 
 Decide *how* the workflow should be built — before you build it.
 
-The Design step takes your Workflow Definition and produces a complete blueprint for your AI workflow. The skill confirms your platform, extracts tool integrations and constraints from your Workflow Definition, assesses the workflow's autonomy level (Deterministic, Guided, or Autonomous), recommends an orchestration mechanism (Prompt, Skill-Powered Prompt, or Agent) and involvement mode, classifies each step on the autonomy spectrum, maps AI building blocks, identifies skill candidates, and documents agent blueprints when needed. The spec must be approved before moving to Build.
+The Design step takes your Workflow Requirements and produces a complete blueprint for your AI workflow. The skill confirms your platform, extracts tool integrations and constraints from your Workflow Requirements, assesses the workflow's autonomy level (Deterministic, Guided, or Autonomous), recommends an orchestration mechanism (Prompt, Skill-Powered Prompt, or Agent) and involvement mode, classifies each step on the autonomy spectrum, maps AI building blocks, identifies skill candidates, and documents agent blueprints when needed. The spec must be approved before moving to Build.
 
-**Deliverable:** **Design Spec** (`outputs/[name]-design-spec.md`) — architecture decisions, autonomy assessment, orchestration mechanism, per-step classifications, skill candidates, agent blueprints, context inventory, and implementation order.
+**Deliverable:** **Design Spec** (`outputs/[name]-design-spec.md`) — architecture decisions, autonomy assessment, orchestration mechanism, per-step classifications, skill candidates, agent blueprints, integration options, model recommendation, Data Readiness Summary, and implementation order. References the Workflow Requirements rather than restating it.
 
 **Facilitated by the `design` skill.** See [Design Your AI Workflow](design/) for the full guide with autonomy assessment, orchestration mechanism decision flow, and output format.
 
@@ -100,9 +100,9 @@ The Build step starts with a **Prepare Context** phase — systematically resolv
 
 ### Step 5: Test the Workflow
 
-Structured testing against the evaluation criteria from Design.
+Structured testing against the Acceptance Criteria and Example Scenarios captured in the Workflow Requirements.
 
-Your first run is a test, not a deployment. The Test step walks you through a quick smoke test (does it run at all?), then a full eval suite where you run each test scenario from the Design Spec and score the output on the quality dimensions defined during Design. You also test individual building blocks in isolation and establish a baseline for future comparison.
+Your first run is a test, not a deployment. The Test step walks you through a quick smoke test (does it run at all?), then a full eval suite where you run each Example Scenario from the Workflow Requirements and score the output against the Acceptance Criteria dimensions. You also test individual building blocks in isolation and establish a baseline for future comparison.
 
 Most workflows need 2-4 iterations between Build and Test before they produce reliably good output. When something is off, the skill helps you diagnose which building block to fix and sends you back to Build with a clear target.
 

--- a/src/content/docs/ai-workflow-framework/skills.mdx
+++ b/src/content/docs/ai-workflow-framework/skills.mdx
@@ -250,7 +250,7 @@ ChatGPT should activate the Analyze skill and begin a structured interview proce
 
 #### Option 2: OpenAI Codex in a Code Editor
 
-Use **OpenAI Codex** in a code editor like Cursor or VS Code. Codex uses your existing ChatGPT login (Plus, Pro, or any paid plan), supports skills natively, and **saves output files directly to your computer** — so when a skill creates a Workflow Definition or Design Spec, you get an actual file instead of text in a chat window.
+Use **OpenAI Codex** in a code editor like Cursor or VS Code. Codex uses your existing ChatGPT login (Plus, Pro, or any paid plan), supports skills natively, and **saves output files directly to your computer** — so when a skill creates a Workflow Requirements or Design Spec, you get an actual file instead of text in a chat window.
 
 See the [**OpenAI Codex**](#openai-codex) section under Code Editors & Terminal below for setup instructions.
 
@@ -752,7 +752,7 @@ You can also invoke skills directly with slash commands like `/handsonai:analyze
 **How it works:** The agent runs seven skills across the full lifecycle:
 
 1. **Analyze** (`analyze`) — Audit your workflows, interview you about your work, and produce an opportunity report with structured candidates. If you already know which workflow to deconstruct, this step is brief.
-2. **Deconstruct** (`deconstruct`) — Interactive deep-dive that decomposes the workflow into refined steps using the 6-question framework. Produces the Workflow Definition.
+2. **Deconstruct** (`deconstruct`) — Interactive deep-dive that decomposes the workflow into refined steps using the 6-question framework. Produces the Workflow Requirements.
 3. **Design** (`design`) — Gather architecture decisions, assess workflow autonomy level, choose an orchestration mechanism and involvement mode, classify steps, map building blocks, identify skill candidates, configure agents, and produce the Design Spec.
 4. **Build** (`build`) — Resolve context needs and generate platform-appropriate artifacts (prompts, skills, agents, configs) based on the approved spec.
 5. **Test** (`test`) — Run structured evaluations against the criteria from Design, establish a quality baseline, and iterate with Build until the workflow is ready.
@@ -782,7 +782,7 @@ Files are saved to `outputs/` using kebab-case workflow names (e.g., `outputs/le
 **What you'll get:** Multiple files in `outputs/`:
 
 1. **Opportunity Report** — `ai-opportunity-report.md` — categorized opportunities with structured workflow candidates (if generated)
-2. **Workflow Definition** — `[name]-definition.md` — structured decomposition of every step
+2. **Workflow Requirements** — `[name]-requirements.md` — structured decomposition of every step
 3. **Design Spec** — `[name]-design-spec.md` — autonomy level, orchestration mechanism, per-step classifications, building block mapping, skill candidates, agent configs
 4. **Platform Artifacts** — prompts, skills, agents, and configs generated for your platform
 5. **Run Guide** — `[name]-run-guide.md` — step-by-step setup and first-run instructions
@@ -839,7 +839,7 @@ Break workflows into structured definitions.
 
 **Command:** `/handsonai:deconstruct`
 
-**What it does:** Interactively deconstructs a business workflow into a structured Workflow Definition using the 6-question framework. This is the Deconstruct step.
+**What it does:** Interactively deconstructs a business workflow into a structured Workflow Requirements using the 6-question framework. This is the Deconstruct step.
 
 **When to use it:** Use this when you want to thoroughly document a workflow's steps, decisions, data flows, and failure modes. Also useful standalone when you just need a structured breakdown of a complex process — even without planning to automate it.
 
@@ -858,7 +858,7 @@ Break workflows into structured definitions.
 5. **Propose and react** — From step 4 onward, the AI proposes a hypothesis across all six dimensions and asks "What's right, what's wrong, what am I missing?"
 6. **Map sequence** — The AI identifies sequential vs. parallel steps and the critical path
 7. **Consolidate context** — The AI presents a rolled-up "context shopping list" of every artifact the workflow needs
-8. **Generate Workflow Definition** — The AI writes the structured Workflow Definition to the output file
+8. **Generate Workflow Requirements** — The AI writes the structured Workflow Requirements to the output file
 
 **Example prompts:**
 
@@ -870,7 +870,7 @@ Break workflows into structured definitions.
     → Walks through the discovery process, probing for hidden steps
       and decision points
 
-**What you'll get:** A Workflow Definition file (`outputs/[name]-definition.md`) containing: scenario metadata, refined steps (with sub-steps, decision points, data flows, context needs, and failure modes for each), step sequence and dependencies, and a context shopping list.
+**What you'll get:** A Workflow Requirements file (`outputs/[name]-requirements.md`) — a PRD-style document containing Outcome, Metadata, Context Inventory, Acceptance Criteria, Example Scenarios, and Human Gates. The middle block depends on the path: Steps Overview + per-step requirements (Goal / Inputs / Outputs / Rules & Edge Cases / Context) for step-decomposed workflows; Inputs + Rules & Constraints for outcome-driven workflows.
 
 **Platform compatibility:** Claude Code &#10003; | Claude.ai &#10003;
 
@@ -886,15 +886,15 @@ Design your AI implementation architecture.
 
 **Command:** `/handsonai:design`
 
-**What it does:** Takes a Workflow Definition and runs the Design phase: architecture decisions, autonomy assessment, orchestration mechanism with involvement mode, per-step classification, building block mapping, skill candidates, agent configuration. Produces a Design Spec for approval.
+**What it does:** Takes a Workflow Requirements and runs the Design phase: architecture decisions, autonomy assessment, orchestration mechanism with involvement mode, per-step classification, building block mapping, skill candidates, agent configuration. Produces a Design Spec for approval.
 
-**When to use it:** Use this when you have a Workflow Definition (from the Deconstruct step) and want to design your AI workflow's architecture. The spec must be approved before moving to Build.
+**When to use it:** Use this when you have a Workflow Requirements (from the Deconstruct step) and want to design your AI workflow's architecture. The spec must be approved before moving to Build.
 
 **How it works:**
 
-1. **Load Workflow Definition** — The AI reads the Workflow Definition from `outputs/`
+1. **Load Workflow Requirements** — The AI reads the Workflow Requirements from `outputs/`
 2. **Confirm understanding** — The AI summarizes the workflow and asks you to confirm
-3. **Architecture decisions** — Confirm platform (the one question), then extract tool integrations, trigger/schedule, and constraints from the Workflow Definition and present a confirmation block
+3. **Architecture decisions** — Confirm platform (the one question), then extract tool integrations, trigger/schedule, and constraints from the Workflow Requirements and present a confirmation block
 4. **Autonomy assessment** — The AI assesses where the whole workflow sits on the autonomy spectrum (Deterministic, Guided, Autonomous)
 5. **Orchestration mechanism** — The AI recommends a mechanism (Prompt, Skill-Powered Prompt, or Agent) with an involvement mode (Augmented or Automated)
 6. **Classify each step** — Per-step autonomy level, AI building blocks, tools, human review gates
@@ -905,8 +905,8 @@ Design your AI implementation architecture.
 
 **Example prompts:**
 
-    "Design the AI workflow from my Workflow Definition"
-    → Reads the most recent Workflow Definition, runs Design,
+    "Design the AI workflow from my Workflow Requirements"
+    → Reads the most recent Workflow Requirements, runs Design,
       produces the Design Spec for approval
 
     "Design the expense-reporting workflow"
@@ -938,7 +938,7 @@ Generate platform artifacts from your approved spec.
 **How it works:**
 
 1. **Load Design Spec** — The AI reads the approved spec from `outputs/`
-2. **Prepare Context** — Resolve the Context Shopping List and Data Readiness Summary — find existing documents, create missing materials, format for AI consumption
+2. **Prepare Context** — Resolve the Context Inventory and Data Readiness Summary — find existing documents, create missing materials, format for AI consumption
 3. **Build path choice** — Choose "I'll build it" (model generates artifacts) or "I'll build it myself" (get a Construction Guide with build sequence and creation skill recommendations)
 4. **Mechanism-specific build path** — Only the steps relevant to your chosen orchestration mechanism
 5. **Discover creation tools** — The AI scans your environment for skills that can create other building blocks (e.g., skill-creator, agent-development). Presents a Creation Tools Map for confirmation — matched skills get delegated to, unmatched types are generated inline.

--- a/src/content/docs/builder-setup/notion-registry-setup.md
+++ b/src/content/docs/builder-setup/notion-registry-setup.md
@@ -95,7 +95,7 @@ Agent skills are an open standard, and many companies are already working to ado
 | Database | Purpose | Key Fields |
 |----------|---------|------------|
 | **Business Processes** | High-level business functions and their domains | Domain, LOB, Description, Guide (URL) |
-| **Workflows** | Specific workflows within each process | Status, Execution Mode, Autonomy Level, Trigger, Process Outcome, SOP (URL), Workflow Definition (URL), Design Spec (URL) |
+| **Workflows** | Specific workflows within each process | Status, Execution Mode, Autonomy Level, Trigger, Process Outcome, SOP (URL), Workflow Requirements (URL), Design Spec (URL) |
 | **AI Building Blocks** | Skills, prompts, agents, and other AI components | Asset Type, Platform, Status, Dependencies |
 | **Apps** | Connected applications and integrations | Type, Auth Type, Connection Status |
 

--- a/src/content/docs/courses/builders/week-5.md
+++ b/src/content/docs/courses/builders/week-5.md
@@ -3,15 +3,15 @@ title: Week 5 - Run the Framework End-to-End
 description: Run the AI Workflow Framework end-to-end on a real workflow — Competitive Intelligence — and ship a working skill and agent in your workspace.
 ---
 
-In Week 5 you run the AI Workflow Framework end-to-end yourself, live in class. Starting from a pre-built workflow definition, you invoke `/design`, `/build`, `/test`, and `/run` on a **Competitive Intelligence** workflow — shipping a `competitor-research` skill and `competitor-brief` agent that produce a structured brief on a real competitor. In Session 10, you'll evolve that workflow into a self-improving system.
+In Week 5 you run the AI Workflow Framework end-to-end yourself, live in class. Starting from a pre-built Workflow Requirements, you invoke `/design`, `/build`, `/test`, and `/run` on a **Competitive Intelligence** workflow — shipping a `competitor-research` skill and `competitor-brief` agent that produce a structured brief on a real competitor. In Session 10, you'll evolve that workflow into a self-improving system.
 
 ## Lesson: Ship a Workflow Using the AI Workflow Framework
 
-Run the framework end-to-end yourself in Cowork (or Claude Code — same slash commands). Starting from a pre-built workflow definition, you invoke `/design`, `/build`, `/test`, and `/run` — generating a `competitor-research` skill and `competitor-brief` agent from your approved spec, then running the workflow on a real competitor. Watch a structured context file get produced on the first run.
+Run the framework end-to-end yourself in Cowork (or Claude Code — same slash commands). Starting from a pre-built Workflow Requirements, you invoke `/design`, `/build`, `/test`, and `/run` — generating a `competitor-research` skill and `competitor-brief` agent from your approved spec, then running the workflow on a real competitor. Watch a structured context file get produced on the first run.
 
 ### Hands-on assignment
 
-**Starting point:** a pre-built workflow definition (download below).
+**Starting point:** a pre-built Workflow Requirements (download below).
 **Ending point:** a shipped skill + agent producing a brief on a real competitor.
 
 1. **`/design`** — Turn the definition into an approved Design Spec (plan mode, collaborative). See the [Design step docs](../../../ai-workflow-framework/design/).
@@ -19,11 +19,11 @@ Run the framework end-to-end yourself in Cowork (or Claude Code — same slash c
 3. **`/test`** — Validate the building blocks before trusting them with real input. See the [Test step docs](../../../ai-workflow-framework/test/).
 4. **`/run`** — Invoke the workflow on a real competitor; watch `knowledge/competitors/{name}.md` emerge. See the [Run step docs](../../../ai-workflow-framework/run/).
 
-### Download the workflow definition
+### Download the Workflow Requirements
 
 The Step 2 (Deconstruct) artifact is pre-built so we can spend Session 9 running the rest of the framework on it. Save this file into your workspace before class:
 
-<a href="/assets/courses/builders/competitive-intelligence-workflow-definition.md" download="competitive-intelligence-workflow-definition.md"><strong>Download the Competitive Intelligence — Workflow Definition (.md)</strong></a>
+<a href="/assets/courses/builders/competitive-intelligence-workflow-definition.md" download="competitive-intelligence-workflow-definition.md"><strong>Download the Competitive Intelligence — Workflow Requirements (.md)</strong></a>
 
 ### What you'll walk away with
 


### PR DESCRIPTION
## Summary

- **Deconstruct (Step 2):** Reshaped as a PRD. Two paths (step-decomposed / outcome-driven); Compose removed; **Workflow Requirements** (`outputs/[name]-requirements.md`) replaces Workflow Definition.
- **Design (Step 3):** Three-layer structure (Architecture / Decomposition / Component Blueprints) with stable IDs (S1/A1), Orchestrator Prompt Outline, Self-Test Summary, and Deployment Plan. Lightweight confirmation moments between layers.
- **Packaging values updated:** `Workspace Agent` replaces `Single GPT` / `Set of GPTs` — ChatGPT now skill-native via agentskills.io; Custom GPTs deprecated.
- **Build (Step 4):** Reads frontmatter for one-shot summarization; consumes Orchestrator Outline when present; handles Workspace Agent packaging.
- **Doc pages rewritten:** `deconstruct/index.md` teaches two paths; `design.md` teaches three layers + cross-platform portability.

## Test plan

- [x] `npm run build` clean (193 pages, no warnings, no broken links)
- [x] All 4 mirror pairs synced (`deconstruct`, `design`, `build`, `framework-agent` across `.claude/` ↔ `plugins/handsonai/`)
- [x] Two rounds of independent QA review (`feature-dev:code-reviewer`); all blocking + inconsistency findings addressed
- [ ] Run `/deconstruct` end-to-end against a fresh workflow; confirm Workflow Requirements reads PRD-shaped
- [ ] Pass that requirements file to `/design`; confirm three-layer flow with lightweight confirmation moments
- [ ] Pass the Design Spec to `/build`; confirm frontmatter parsing + Orchestrator Outline consumption work
- [ ] Spot-check Test (Step 5) reads Acceptance Criteria + Example Scenarios from Workflow Requirements

## Follow-ups (out of scope; flagged in plan)

- Platform registry update (`plugins/handsonai/registries/platform-registry.json`) — add Workspace Agents / ChatGPT skills / Claude.ai / Cowork entries with web-verified URLs
- Repo-wide audit for stale Custom GPT references in `docs/platforms/openai/`, `agentic-building-blocks/`, `use-cases/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)