### PR TITLE
Framework robustness + intuitiveness upgrades (P0+P1+P2.1/2.2/2.4)

### DIFF
--- a/plugins/handsonai/.claude-plugin/plugin.json
+++ b/plugins/handsonai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "handsonai",
   "description": "Everything you need to design, build, and document AI workflows. The AI Workflow Framework as executable Claude Code skills, plus an AI registry and feature-spec toolkit.",
-  "version": "4.0.3",
+  "version": "4.1.0",
   "author": {
     "name": "James Gray"
   },

--- a/plugins/handsonai/skills/analyze/SKILL.md
+++ b/plugins/handsonai/skills/analyze/SKILL.md
@@ -53,6 +53,8 @@ After presenting the memory scan summary (or noting no prior context), ask the u
 
 Based on gaps in your understanding (or starting from scratch), ask focused questions to build a complete picture. Use the question set for the user's chosen lens.
 
+> **Ask one question at a time — these banks are a scaffold for you, not a list to paste at the user.** Adapt to their answers, skip anything the memory scan already covered, and follow up for concrete examples. (Restated after the banks too — but apply it from the first question.)
+
 **Individual Lens — Discovery Questions**
 
 1. **Role & responsibilities** — What is your role? What are you accountable for?
@@ -86,6 +88,12 @@ Continue until you can identify at least 3 concrete opportunities — typically 
 #### Step 3 — Opportunity Analysis & Report
 
 Once you can identify at least 3 concrete, specific opportunities with enough detail to fill the card format below, produce the structured report.
+
+**Two scales you'll classify each opportunity on (plain-language — full definitions in the Appendix):**
+- **Autonomy** = how much the AI decides for itself: **Deterministic** (fixed rules) → **Guided** (decides within guardrails, you steer) → **Autonomous** (plans and adapts on its own).
+- **Involvement** = is a human in the loop *during the run*: **Augmented** (you participate as it runs) vs. **Automated** (runs solo; you review the result).
+
+**Self-check before writing each opportunity:** confirm it has a **concrete trigger** (what kicks it off) and a **tangible deliverable** (what gets produced). If either is fuzzy, ask one more question or drop the opportunity — a candidate without a clear trigger + deliverable will stall in Deconstruct (Step 2).
 
 #### Step 4 — Workflow Candidate Summary
 

--- a/plugins/handsonai/skills/build/SKILL.md
+++ b/plugins/handsonai/skills/build/SKILL.md
@@ -168,6 +168,8 @@ For each integration listed in the Design Spec's "Integration Options" section, 
    - Use WebFetch to retrieve the integration's documentation directly from its known URL or official site.
    - If no URL is known, fall back to web search to locate the integration's documentation.
 
+**Fallback ladder (never hard-fail).** Both tiers depend on network access — the registry fetch can fail and WebFetch/web search may be unavailable on some platforms. Degrade gracefully and tell the user what was degraded: **session cache** (registry already fetched this session, incl. by Design) → **model knowledge** → **web search** → **best-effort note**. If WebFetch isn't available, say so and use web search; if neither is available, generate from model knowledge and **flag the artifact format as unverified** so the user double-checks before relying on it. Never block Build because a fetch failed.
+
 Present a summary of resolved platform format requirements and integration docs to the user before proceeding.
 
 #### Step 4 — Check for Existing Skills and Instructions
@@ -195,6 +197,11 @@ For each integration listed in the spec:
 
 **Web search is used for platform availability research** — verifying setup steps, finding platform-specific guides, and confirming compatibility. Discovery of integrations themselves is already done. If the environment doesn't support web search, instruct the user to switch to a tool that does.
 
+**Write-scope pre-flight (required).** For every integration the workflow must *write* to — create drafts, apply labels, create database rows/pages, send messages, create events — verify the connector actually has **write access** before building against it. Connectors are often connected **read-only**. If a needed write scope is missing:
+- Do **not** fail silently or proceed as if it works.
+- Tell the user exactly what to reconnect/authorize (e.g., "the email connector is read-only — reconnect it with compose + labels access").
+- You may still build the artifacts, but mark the workflow **"build-complete, deploy-blocked on [integration] write access"** so Test/Run know the gap.
+
 Present the integration mapping and ask the user to confirm before generating artifacts. If any critical integration is manual-only, discuss implications for the orchestration mechanism (may need to downgrade or add human-in-the-loop steps).
 
 If the Integration Options section is missing from the spec (older format), inform the user and offer two paths: (a) Run Integration Discovery now — research available integration approaches for each tool identified in the spec's Integration Options or Step-by-Step Decomposition tables, or (b) proceed with web-search-only research for each integration need as it arises during artifact generation.
@@ -215,7 +222,7 @@ Use the spec's **Step-by-Step Decomposition Build Output column** (or **Capabili
 - `Inline prompt → Workflow Requirements Step N` → fold this step's Goal/Inputs/Outputs/Rules from the Workflow Requirements into the main orchestrator prompt
 - `MCP server: [name]` → configure the connector using the Integration Options entry
 - `Human (no artifact)` → skip; no AI artifact for this step
-- `Handled by agent` (outcome-driven only) → no separate artifact; capability is covered by the agent's Instructions
+- `Handled by orchestrator` (outcome-driven only; legacy synonym `Handled by agent`) → no separate artifact; the capability is covered by the orchestration logic (the primary loop's command/`CLAUDE.md` run section) or a sub-agent's instructions
 
 Apply the spec's **Packaging** decision to group the generated artifacts:
 - **Plugin** → assemble into a marketplace plugin directory structure (e.g., handsonai-plugins layout for Claude marketplace)
@@ -236,12 +243,20 @@ If playbook platform guides are available locally (e.g., `docs/platforms/claude/
 - Agents (Claude Code): `references/agent-spec.md`
 - Other platforms: web search
 
+> **The `references/*-spec.md` files are point-in-time snapshots, not the source of truth.** Platform schemas drift; prefer the registry/doc lookup from Step 3.6 and use these only as a last-resort fallback. If a snapshot and live docs disagree, the live docs win.
+
 **d. Apply code vs guided mode branching.** Based on the platform's `mode` from the registry (determined in Step 3.6):
 
 - **Code mode:** Generate source files in the platform's `language` (Python, TypeScript, markdown). This is the standard behavior — proceed with artifact generation as described below.
 - **Guided mode:** Generate step-by-step GUI instruction documents. For each building block, produce a document that walks the user through configuring it in the platform's interface, using the GUI documentation fetched from the registry. Include: which screens to navigate to, what fields to fill in, what settings to configure, and what to verify after each step.
 
 **e. Generate each building block.** For each building block in the spec, follow the Creation Tools Map from Step 3.5:
+
+**Field-role mapping (platform-agnostic — do NOT hardcode concrete keys).** Design collects 12 skill / 13 agent fields. Each plays one of four **roles**; place it by role, and resolve the *concrete* destination (frontmatter key name, body section) at runtime from the platform docs fetched in Step 3.6. Field names and frontmatter schemas change per platform and over time, so the framework owns only the role, never the literal key:
+- **Identity / activation** — Name, Description, Trigger Examples → the platform's identity + auto-invocation mechanism (e.g., a `description`/`name` field and example blocks — whatever the platform calls them).
+- **Instruction body** — Mission, Responsibilities, Decision Logic, Failure Modes, Output Format, Tone & Style, Constraints → the artifact's prose body/system prompt.
+- **Wiring / config** — Model, Tools, Skills, Memory Scope, Stateful? → mapped to whatever config fields the platform exposes (e.g., Stateful?/Memory Scope → the platform's memory/persistence option, by its current name).
+- **Framework-internal only** — ID, Purpose, Covers Steps/Domains, Depends On → used for sequencing and cross-references during Build; **never emitted** into the generated artifact.
 
   **If a creation skill was matched for this block type:**
 
@@ -266,6 +281,10 @@ If playbook platform guides are available locally (e.g., `docs/platforms/claude/
 1. Write the artifact to its target location from the Deployment Plan.
 2. Execute or document the deployment steps (e.g., "run `claude mcp add ...`", "upload zip via plugin marketplace", "create new GPT and paste instructions").
 3. If the target location requires user action (e.g., a manual GPT creation flow), produce a step-by-step guide tailored to the user's platform.
+
+**Confirm before mutating the user's real accounts.** Before any action that *creates or modifies data in the user's live accounts* — creating a Notion database/page, a Gmail label/draft, a calendar event, a Slack post, etc. — state the exact action and target and get explicit confirmation first. Batch related confirmations into one prompt where possible. (These are outward-facing, hard-to-reverse actions; never perform them silently as a side effect of "building.")
+
+**Never overwrite existing local files.** Before creating any local artifact — especially context files (`Status: Exists` in the Context Inventory) — check the filesystem. If the file already exists, **read and reuse it; do not overwrite** without explicit confirmation. (Context artifacts marked `Needs Creation` in the spec may already have been supplied by the user since Design.)
 
 After completing Build, summarize what was generated, where each artifact was placed, and any remaining manual deployment steps. Then tell the user: "To test the workflow, run the `test` skill (Step 5) (or say *'Test the workflow I built'*)."
 

--- a/plugins/handsonai/skills/build/references/agent-spec.md
+++ b/plugins/handsonai/skills/build/references/agent-spec.md
@@ -1,5 +1,10 @@
 # Agent Specification — Claude Code Subagent Format
 
+> **Point-in-time snapshot — fallback only.** This file is a snapshot of the Claude Code subagent
+> format and **will drift** as the platform evolves; it is NOT the source of truth. Build resolves the
+> current format at runtime from the platform registry/docs (Step 3.6) and uses this only when that
+> lookup is unavailable. If this snapshot and live docs disagree, the live docs win.
+
 When generating agents for Claude Code, follow this format exactly. Agents are single `.md` files with YAML frontmatter and a markdown body.
 
 ## File Format

--- a/plugins/handsonai/skills/build/references/skill-spec.md
+++ b/plugins/handsonai/skills/build/references/skill-spec.md
@@ -1,5 +1,10 @@
 # Skill Specification — agentskills.io Format
 
+> **Point-in-time snapshot — fallback only.** This file is a snapshot and **will drift** as platforms
+> evolve; it is NOT the source of truth. Build resolves the current format at runtime from the platform
+> registry/docs (Step 3.6) and uses this only when that lookup is unavailable. If this snapshot and live
+> docs disagree, the live docs win.
+
 When generating skills, follow this format. Skills are directories containing a `SKILL.md` file with YAML frontmatter and a markdown body. The full specification is at [agentskills.io/specification](https://agentskills.io/specification).
 
 ## File Structure

--- a/plugins/handsonai/skills/deconstruct/SKILL.md
+++ b/plugins/handsonai/skills/deconstruct/SKILL.md
@@ -29,6 +29,12 @@ Step 2 has **two paths**, mapped directly to the two ways students think about a
 
 Both paths produce a Workflow Requirements document with the same shared shell — only the middle "what does the workflow do" block differs.
 
+**Which path? (quick heuristic — share this with the user when they're unsure):**
+- Choose **Step-decomposed** if the work runs **the same way each time** and you can list the steps in order.
+- Choose **Outcome-driven** if the **path varies by input** and you'd rather define what "done" looks like plus the rules, and let the agent figure out the steps at runtime.
+
+Worked one-liners: *"Generate my weekly status report from the same three sources"* → step-decomposed (fixed steps). *"Triage whatever lands in my inbox and handle each appropriately"* → outcome-driven (the path depends on each item). Getting this right matters: the choice selects the document template the Design step parses, so a wrong pick creates rework downstream.
+
 ## Workflow
 
 1. **Scenario discovery** — Determine how the user is arriving and which path to take.
@@ -61,14 +67,14 @@ Both paths produce a Workflow Requirements document with the same shared shell �
 
 4. **Deep dive (step-decomposed only)** — Before probing the first step, briefly frame what "context" means: "As we go through each step, I'll ask about the *context* it needs. Context is any data or information the step requires to do its job — that includes databases and spreadsheets, but also documents, transcripts, emails, style guides, SOPs, or even knowledge that currently lives in someone's head. If the step needs it, it's context."
 
-   Work through each step using the 6-question framework. These six dimensions are the **interview scaffold** — they shape what to ask, not how the spec is structured. Your job is to gather enough signal across all six to write the per-step requirements block (Goal / Inputs / Outputs / Rules & Edge Cases / Context Needed) in Step 10.
+   Work through each step using the 6-question framework. **Ask one question at a time, adapt to the user's answers, and skip dimensions already well-covered — this is a scaffold for *you*, never a checklist to read aloud at the user.** These six dimensions shape what to ask, not how the spec is structured. Your job is to gather enough signal across all six to write the per-step requirements block (Goal / Inputs / Outputs / Rules & Edge Cases / Context Needed) in Step 10.
 
    - Discrete steps (is this actually multiple steps?)
    - Decision points (if/then branches, quality gates)
    - Data flows (inputs, outputs, sources, destinations)
    - Context needs (specific documents, files, reference materials)
    - Failure modes (what happens when this step fails)
-   - Context readiness (adopt a data strategist lens for each step's context inputs):
+   - Context readiness (adopt a data strategist lens for each step's context inputs — **sample these probes, don't interrogate: ask the one or two that matter for this step rather than all four every time**):
      - Access: Where does this context live today? How do you access it — is it in a system with programmatic access (database, cloud app, shared drive), or does it require manual steps (logging in, copy-pasting, reading from a screen)?
      - Interpretability: Is the context in a format AI can process? (Structured: database tables, spreadsheets, JSON. Semi-structured: emails, documents with consistent formatting. Unstructured: handwritten notes, images, proprietary formats.)
      - Persistence: Does this context need to exist as a durable artifact that AI can access across workflow runs? If it's currently "in someone's head" or communicated verbally, flag that it needs to be externalized and stored somewhere AI-accessible.
@@ -135,6 +141,12 @@ Both paths produce a Workflow Requirements document with the same shared shell �
 
 11. **Generate Workflow Requirements** — Produce the structured Workflow Requirements document and write it to the output file. See the **Output** section below for the template, writing style, and machine-readability rules.
 
+    **Self-check before finishing (so Design can parse it).** After writing, verify the file against the machine-readability rules and fix any miss before handing off:
+    - Filename is kebab-case: `outputs/[workflow-name]-requirements.md` (e.g., "Inbound Lead Triage" → `inbound-lead-triage-requirements.md`).
+    - All required headings are present and **exactly named** (no synonyms): Outcome, Metadata, Context Inventory, Acceptance Criteria, Example Scenarios, Human Gates, plus the path-specific middle (Steps Overview + Step Details + Sequence for step-decomposed; Inputs + Rules & Constraints for outcome-driven).
+    - Canonical vocabulary used exactly (Definition Type, Lens, Context Status, AI Accessible) and stable IDs present (steps `1,2,3…`; context `C1,C2…`; scenarios `E1,E2…`).
+    - If anything is off, fix it before telling the user it's ready.
+
 ### Outcome-Driven Path (Step 4-OD)
 
 When the user selects outcome-driven, run this interview instead of the step-decomposed deep dive (Steps 4–8). The outcome-driven path handles context discovery internally (question 7), so it skips straight to Step 9 (Consolidate Context) → Step 10 (Acceptance Criteria) → Step 11 (Generate) after the interview. Same interview principles apply: one question at a time, propose-and-react after the first few answers, push beyond vague answers.
@@ -143,7 +155,7 @@ When the user selects outcome-driven, run this interview instead of the step-dec
 2. **Inputs**: "What does the agent system receive to start? What triggers the work, and what materials does it have access to?"
 3. **Acceptance signals**: "What does the deliverable need to demonstrate to be considered 'good'? Examples or anti-examples are great here." (This feeds the Acceptance Criteria; Step 10 will sharpen it further.)
 4. **Rules & Constraints**: "What boundaries or guardrails apply? Things the agent must always do, must never do, or limits on scope, sources, tone, length."
-5. **Context & Data Sources**: "What external systems, data sources, documents, or reference materials should the agent system have access to?" Apply the same context readiness probing as the step-decomposed path:
+5. **Context & Data Sources**: "What external systems, data sources, documents, or reference materials should the agent system have access to?" Apply the same context readiness probing as the step-decomposed path (sample — ask the one or two probes that matter, don't run all three mechanically):
    - Access: Where does this context live today? Is it in a system with programmatic access (database, cloud app, shared drive), or does it require manual steps (logging in, copy-pasting, reading from a screen)?
    - Interpretability: Is the context in a format AI can process?
    - Persistence: Does this context need to exist as a durable artifact that AI can access across workflow runs?
@@ -152,7 +164,15 @@ When the user selects outcome-driven, run this interview instead of the step-dec
 
 **Do NOT ask about capability domains, agent count, model class, tools, or orchestration approach.** Those are Design decisions. Outcome-driven Deconstruct stays in "what" territory: outcome, inputs, acceptance criteria, rules, context, human gates.
 
-After completing the interview, proceed directly to Step 9 (Consolidate Context) → Step 10 (Acceptance Criteria) → Step 11 (Generate Workflow Requirements) using the outcome-driven output format.
+**Step 8-OD — Validate before consolidating (outcome-driven quality gate).** Step-decomposed has a Step 8 validation gate; outcome-driven needs the equivalent so a vague outcome or missing guardrails doesn't sail through to Design. Walk the definition end-to-end and present a short validation summary covering:
+   - **Outcome is bounded and singular** — one clear deliverable, not a fuzzy aspiration ("help with email" is too vague; "a drafted reply per inbound inquiry" is bounded).
+   - **Rules are sufficient** — must-do and must-never both covered; scope boundaries explicit enough to keep the agent in bounds.
+   - **Context is reachable** — every context/data source named has a known location and an access path (not "it's in my head" or a login-only portal with no plan to bridge it).
+   - **Human gates are defined** — it's clear where (if anywhere) a human reviews, and that final-review-only is a deliberate choice.
+
+   Present as: "Before I finalize, here's a quick check of your outcome-driven definition: [findings]. Which of these should we tighten?" Update based on the user's answers. If all clear, say so and proceed.
+
+After completing the interview and Step 8-OD, proceed directly to Step 9 (Consolidate Context) → Step 10 (Acceptance Criteria) → Step 11 (Generate Workflow Requirements) using the outcome-driven output format.
 
 ## Output
 

--- a/plugins/handsonai/skills/design/SKILL.md
+++ b/plugins/handsonai/skills/design/SKILL.md
@@ -24,17 +24,20 @@ Take a Workflow Requirements document (produced by Step 2 — Deconstruct) and p
 
 The Design phase is collaborative — you plan the architecture together with the user before anything gets built.
 
-**Plan Mode Prompt:** At the start of Design, prompt the user:
+**Collaboration mode — environment-aware:** At the start of Design, set expectations based on where the user is running:
 
-> "The Design phase is collaborative — we plan the architecture together before anything gets built. **Enter plan mode now** if your platform supports it (in Claude Code: `shift+tab` or `/plan`). This ensures we focus on design without accidentally generating artifacts. If plan mode isn't available, I'll collaborate through conversation — proposing, you reacting, iterating until you approve."
+> - **Claude Code (plan mode available):** "The Design phase is collaborative. **Enter plan mode now** (`shift+tab` or `/plan`) so we focus on design without writing any files yet. I'll present the full spec for your approval, and only write `outputs/[name]-design-spec.md` after you approve and exit plan mode."
+> - **Cowork (no plan mode):** "The Design phase is collaborative — we'll work through it conversationally. I'll present the full spec for your approval in chat, and only write `outputs/[name]-design-spec.md` once you say go."
 
-This is directive, not optional — plan mode is the preferred path for design collaboration.
+Plan mode is the **preferred path where available** (Claude Code); it is **not available in Cowork**, where collaboration is conversational. **Either way, never write the Design Spec file before the user approves it** (see Step 9/10).
 
 #### Step 1 — Load Workflow Requirements
 
 Read the Workflow Requirements from `outputs/[workflow-name]-requirements.md`. If the user specifies a file path, use that. Otherwise, look for the most recent Workflow Requirements in `outputs/`.
 
 Read the `Definition Type` field from the Metadata table. If `Outcome-Driven`, use the outcome-driven processing path for all subsequent steps (see **Outcome-Driven Processing Path** below). If `Step-Decomposed` (or no Definition Type field is present), use the standard step-decomposed path.
+
+**Verify the file is parseable before relying on it.** Confirm the required headings exist (Outcome, Metadata, Context Inventory, Acceptance Criteria, Example Scenarios, Human Gates, and either Steps Overview/Step Details or the outcome-driven Inputs/Rules & Constraints). If any are missing or mis-named, **say exactly which are missing** and ask the user to re-run `/deconstruct` or fix the file — don't guess at the contents.
 
 #### Step 2 — Confirm Understanding
 
@@ -176,6 +179,12 @@ If the user pushes back, discuss in plain language — never drop into the inter
 
 Single-agent vs. multi-agent is an architecture detail decided during Agent Configuration (Step 8) if Agent is selected — not a top-level choice here.
 
+**Who is the orchestrator? (read before designing any Agent workflow.)** On **Claude Code or Cowork — any platform with a primary agentic loop — the primary session IS the orchestrator.** Do **not** design a separate "orchestrator agent" file. What you build are:
+- **Orchestration logic** — captured as a command and/or a `CLAUDE.md` run section the primary loop follows (scan/classify/dispatch/label/summarize, etc.). This is not an "agent" artifact.
+- **Sub-agent(s)** — the workers the primary loop dispatches, one per unit of work (e.g., per item in a batch). Sometimes **zero** sub-agents are needed — the orchestration logic + skills are enough.
+
+The agent artifacts you generate are always the **workers the orchestrator delegates to**, never the orchestrator itself. Reserve a standalone, self-running "agent" artifact for **SDK platforms** where you deploy the agent process yourself. (This is the single most common design mistake on Claude Code: inventing an orchestrator agent when the primary loop already is one.)
+
 **Fast-track for complete Workflow Requirements:** If the Workflow Requirements + conversation context provide enough information to resolve the autonomy level, tool extraction, and step classifications, you may present those internal/technical dimensions as a single summary block instead of stepping through questions one at a time.
 
 **Platform (Step 3a) and Mechanism (Step 5) are never fast-tracked.** They are always asked or confirmed explicitly in plain language, in their own discrete confirmations, even when the answer seems obvious from earlier conversation. Non-technical users must see and approve these two choices on their own — they should not be embedded inside a larger summary block.
@@ -207,10 +216,10 @@ For step-decomposed workflows:
 
 For outcome-driven workflows, use the same playback structure with these substitutions:
 
-- **Autonomy level:** Autonomous — meaning [the agent figures out its own path based on the outcome and rules you defined]. (Outcome-driven workflows are always Autonomous by definition.)
-- **Mechanism:** Agent — [a system that decides what to do step-by-step based on context, not a fixed script].
-- Replace **Steps classified** with **Capability domains mapped** — explain in plain language ("the buckets of capability the agent needs to cover").
-- **Agent blueprint:** single agent summary, since outcome-driven workflows center on the agent.
+- **Autonomy level:** Autonomous — meaning [the system figures out its own path based on the outcome and rules you defined]. (Outcome-driven workflows are always Autonomous by definition.)
+- **Mechanism:** Agent — [the workflow is driven by an agentic loop that decides what to do based on context, not a fixed script]. On Claude Code/Cowork that loop is the **primary session (the orchestrator)** — see "Who is the orchestrator?" above.
+- Replace **Steps classified** with **Capability domains mapped** — explain in plain language ("the buckets of capability the workflow needs to cover").
+- **Agent blueprint:** summarize the **sub-agent(s) the orchestrator will dispatch** (the workers), or "None — the primary loop orchestrates directly using skills" if no sub-agent is needed. Do **not** describe a standalone orchestrator agent on Claude Code/Cowork.
 
 **Wait for explicit approval** ("yes", "looks good", "go ahead", etc.) before moving to Step 6. If the user pushes back, revise the relevant decision (which may mean reopening Step 3a or Step 5) and re-present this gate.
 
@@ -238,6 +247,12 @@ For every refined step, classify across all three building-block layers plus aut
 | **CLI** | Command-line tool | Use existing |
 
 Most integration blocks are "use existing." "Build new" applies primarily to MCP (custom data sources) and rarely to SDKs.
+
+**Plain-language gloss (for non-technical users — explain these the first time they come up):**
+- **MCP** = a plug-and-play connection to a service, no coding needed.
+- **API** = a way to talk to a service that needs a little code/setup.
+- **SDK** = a coding toolkit (most technical option).
+- **CLI** = a command you run in a terminal.
 
 **Intelligence layer blocks:**
 
@@ -308,6 +323,8 @@ After classifying every step, recommend available integration options for each t
    **Latency management:** Use judgment about when web search adds value. Well-known integrations (Google Calendar, Gmail, Slack, GitHub) don't need validation searches. Reserve web search for new or niche tools.
 
    **Precedence rule:** When web search results contradict model knowledge (e.g., model proposes an MCP server that web search reveals was deprecated), web search takes precedence. Flag the discrepancy and present only verified options.
+
+**Fallback ladder (never hard-fail).** Any of the lookups above can fail — the remote registry JSON may be unreachable, or web search may be unavailable on the platform. Degrade gracefully in this order, and tell the user what was degraded: **session cache** (registry already fetched this session) → **model knowledge** → **web search** → **best-effort note**. If you end on model-knowledge-only or best-effort, add a one-line flag like "Integration options below are unverified (registry/web unavailable) — confirm before relying on them." Never block Design because a fetch failed.
 
 **Matching semantics:** Matching is model-driven, not exact string matching. The model reads the workflow's tool needs (e.g., "Google Calendar access" from the step classification) and matches them against the `integrations` array values (e.g., `"google-calendar"`) using semantic understanding. This allows natural language tool needs to match standardized integration tags without requiring exact normalization.
 
@@ -461,20 +478,23 @@ If the user adds or adjusts anything, update the Workflow Requirements file (not
 
 If the Workflow Requirements is missing Acceptance Criteria or Example Scenarios entirely (which shouldn't happen if Deconstruct was run), pause and ask the user to run `/deconstruct` again or fill them in manually before continuing.
 
-#### Step 9 — Generate Design Spec
+#### Step 9 — Assemble Design Spec (do not write the file yet)
 
-Write to `outputs/[workflow-name]-design-spec.md` using the template below. Every section is mandatory unless marked (optional). Do not add, remove, rename, or reorder sections.
+Assemble the full Design Spec **content** using the template below — but **do not write it to disk yet**. The file is written only after the user approves it in Step 10. Every section is mandatory unless marked (optional). Do not add, remove, rename, or reorder sections. Target path (written in Step 10): `outputs/[workflow-name]-design-spec.md`.
 
-**Generation order:**
+**Why not write yet:** In Claude Code plan mode, writing files is blocked until the user approves and exits plan mode; in Cowork there is no plan mode but the same rule applies — never persist a deliverable before approval. So assemble + self-test in memory, present for approval (Step 10), then write.
 
-1. Generate all spec sections (frontmatter through Stakeholders) following the template.
-2. **Run the Build Skill Needs Checklist** (at the end of this step) to verify every required field is present and well-formed.
-3. **Write the Self-Test Summary section** as the final section of the spec. For each checklist item, mark ✓ (passed) or ⚠️ (issue — describe inline). This makes the verification visible to the user and to downstream consumers.
-4. If any checklist item failed (⚠️), fix the underlying section before writing the spec. The Self-Test Summary should ideally show all ✓ — but if a ⚠️ remains (e.g., a deliberate gap that the user accepted), it's surfaced honestly.
+**Assembly order:**
+
+1. Assemble all spec sections (frontmatter through Stakeholders) following the template — in memory.
+2. **Run the Build Skill Needs Checklist** (at the end of this step) against the assembled content to verify every required field is present and well-formed.
+3. **Assemble the Self-Test Summary section** as the final section. For each checklist item, mark ✓ (passed) or ⚠️ (issue — describe inline). This makes the verification visible to the user.
+4. If any checklist item failed (⚠️), fix the underlying section **before presenting for approval**. The Self-Test Summary should ideally show all ✓ — but if a ⚠️ remains (e.g., a deliberate gap the user accepted), surface it honestly.
+5. Carry the assembled content into Step 10 for approval. **Do not write the file in this step.**
 
 **Conditional sections to generate:**
 - `Orchestrator Prompt Outline` — only when mechanism is `Prompt` or `Skill-Powered Prompt`. Omit for `Agent`.
-- `Agent Configuration` — only when mechanism is `Agent`. (Mandatory for outcome-driven.)
+- `Agent Configuration` — whenever the design includes at least one sub-agent/agent artifact (the common case for `Agent` mechanism, including outcome-driven). Omit only if there are genuinely zero sub-agents (orchestration logic + skills only) — then set `agents: 0` and document the orchestration logic in the Deployment Plan.
 - `Multi-Agent Configuration` — only when more than one agent is defined.
 - `Stakeholders` — only for Organizational lens.
 
@@ -574,6 +594,8 @@ For each tool identified in the Decomposition table (or Capability Domain Mappin
 
 **Default capability:** [reasoning-heavy / fast / vision] — [rationale]
 
+*(Plain-language gloss for non-technical users: **reasoning-heavy** = slower but handles complex judgment/nuance; **fast** = quicker, best for simple/high-volume steps; **vision** = can read images/screenshots.)*
+
 **Per-step overrides** (optional):
 - Steps N, M: [different capability] — [rationale]
 
@@ -603,12 +625,12 @@ Column definitions:
 - **Orchestration**: Prompt / Skill / Agent
 - **Integration**: Block + tool + action tag (e.g., "MCP: Notion (use)") or "—" if none
 - **Intelligence**: Model class + context sources + memory flag (e.g., "Model: fast" or "Model: reasoning; Context: C2, C5")
-- **Build Output**: One of: `New skill: S1` (build a new skill, defined below) / `Use existing: [name]` (reference an existing skill) / `New agent: A1` (build a new agent, defined below) / `Inline prompt → Workflow Requirements Step N` (this step becomes a prompt block in the orchestrator, sourced from the named step's requirements) / `MCP server: [name]` (configure a connector) / `Human (no artifact)` (no AI artifact — human-performed)
+- **Build Output**: One of the canonical values: `New skill: S1` (build a new skill, defined below) / `Use existing: [name]` (reference an existing skill) / `New agent: A1` (build a new sub-agent, defined below) / `Inline prompt → Workflow Requirements Step N` (this step becomes a prompt block in the orchestrator, sourced from the named step's requirements) / `Handled by orchestrator` (no separate artifact — the orchestrating primary loop, or a deployed agent on SDK platforms, handles this via its own instructions; legacy synonym: `Handled by agent`) / `MCP server: [name]` (configure a connector) / `Human (no artifact)` (no AI artifact — human-performed)
 - **Human Gate?**: Yes / No (sourced from Workflow Requirements Human Gates table)
 
 ## Orchestrator Prompt Outline
 
-*Include this section only when mechanism is `Prompt` or `Skill-Powered Prompt`. Omit for `Agent` (the agent IS the orchestrator — see Agent Configuration below).*
+*Include this section only when mechanism is `Prompt` or `Skill-Powered Prompt`. Omit for `Agent` — on Claude Code/Cowork the primary loop orchestrates (capture that as orchestration logic in the Deployment Plan), and the workers are documented in Agent Configuration below.*
 
 The high-level shape of the orchestrator prompt the user runs to execute the workflow. This is not the full prompt text — it's the structural skeleton Build expands into the orchestrator. Build derives full step content from the Workflow Requirements' Step Details.
 
@@ -681,7 +703,9 @@ For each Build Output tagged `New skill: SN` above:
 | **Depends On** | [other skill IDs (S2, S3) or artifacts that must exist first, or "None"] |
 | **Stateful?** | Yes / No — does the skill maintain state across invocations? Drives Memory building-block decisions. |
 
-## Agent Configuration (mandatory when orchestration = Agent; otherwise omit)
+## Agent Configuration (include whenever ≥1 sub-agent/agent artifact is defined; otherwise omit)
+
+> Each entry documents a **worker sub-agent the orchestrator dispatches** — not the orchestrator itself. On Claude Code/Cowork the orchestrator is the primary loop (no agent file). If the design has zero sub-agents, omit this section, set `agents: 0`, and capture the orchestration logic in the Deployment Plan.
 
 For each Build Output tagged `New agent: AN` above:
 
@@ -705,9 +729,11 @@ For each Build Output tagged `New agent: AN` above:
 
 ## Multi-Agent Configuration (only when more than one agent is defined)
 
-**Orchestration Pattern:** Supervisor (one agent delegates to others) / Pipeline (agents in sequence) / Parallel (agents run concurrently) / Network (agents call each other peer-to-peer)
+**Orchestration Pattern:** Supervisor (one delegates to others) / Pipeline (agents in sequence) / Parallel (agents run concurrently) / Network (agents call each other peer-to-peer)
 
-**Coordinator:** [Agent ID that coordinates, or "Pattern-based" if no single coordinator]
+> **On Claude Code/Cowork the Supervisor is the primary loop itself — not a generated agent file.** Document the pattern, but the "coordinator" is the orchestration logic (command/`CLAUDE.md` run section), and the entries below are the **worker sub-agents** it dispatches. Prefer **one sub-agent per unit of work** (e.g., per item in a batch) over splitting by function, to keep each unit's transaction atomic and enable parallel fan-out.
+
+**Coordinator:** [Agent ID that coordinates, or "Primary loop (orchestration logic — no agent file)" on Claude Code/Cowork]
 
 **Handoff Contracts:**
 
@@ -769,7 +795,7 @@ Decisions intentionally left for Build to resolve. Build should not need to re-a
 - ✓ / ⚠️ Decomposition table complete with all step IDs from Workflow Requirements
 - ✓ / ⚠️ All Autonomy values use canonical terms (Human / Deterministic / Guided / Autonomous)
 - ✓ / ⚠️ All Integration column entries follow the `block: tool (use/build)` format
-- ✓ / ⚠️ All Build Output values use canonical forms (`New skill: SN` / `Use existing: [name]` / `New agent: AN` / `Inline prompt → Workflow Requirements Step N` / `MCP server: [name]` / `Human (no artifact)`)
+- ✓ / ⚠️ All Build Output values use canonical forms (`New skill: SN` / `Use existing: [name]` / `New agent: AN` / `Inline prompt → Workflow Requirements Step N` / `Handled by orchestrator` [legacy synonym `Handled by agent` accepted] / `MCP server: [name]` / `Human (no artifact)`)
 - ✓ / ⚠️ Packaging value uses a canonical form (`Plugin` / `Standalone Skill` / `Workspace Agent` / `Loose Files`)
 
 ### Skill Candidates
@@ -813,7 +839,7 @@ Before saving the spec, verify every item. If any is missing, go back and add it
 - [ ] Step IDs in the decomposition table match the Step IDs in the Workflow Requirements (Step 1, Step 2, …)
 - [ ] Every step uses canonical autonomy terms: Human / Deterministic / Guided / Autonomous
 - [ ] Every Integration column entry includes the block type, tool name, and use/build tag
-- [ ] Every Build Output value is one of the canonical forms (`New skill: SN`, `Use existing: [name]`, `New agent: AN`, `Inline prompt → Workflow Requirements Step N`, `MCP server: [name]`, `Human (no artifact)`)
+- [ ] Every Build Output value is one of the canonical forms (`New skill: SN`, `Use existing: [name]`, `New agent: AN`, `Inline prompt → Workflow Requirements Step N`, `Handled by orchestrator` [legacy synonym `Handled by agent` accepted], `MCP server: [name]`, `Human (no artifact)`)
 - [ ] Every `New skill: SN` reference has a matching Skill Candidates entry with the SN ID
 - [ ] Every `New agent: AN` reference has a matching Agent Configuration entry with the AN ID
 - [ ] Every Skill Candidate has all 12 fields: ID, Name, Description, Purpose, Covers Steps, Inputs, Outputs, Decision Logic, Failure Modes, Required Tools, Depends On, Stateful?
@@ -832,11 +858,11 @@ Before saving the spec, verify every item. If any is missing, go back and add it
 - [ ] Deferred to Build section lists what Build will resolve at generation time
 - [ ] Self-Test Summary section is present at the end of the spec, with each item marked ✓ (passed) or ⚠️ (issue — described inline)
 
-#### Step 10 — Spec Approval Gate
+#### Step 10 — Spec Approval Gate, then write the file
 
-**This is a hard gate. Do not proceed without explicit approval.**
+**This is a hard gate. Do not write the spec file or proceed without explicit approval.**
 
-Present a summary of the Design Spec:
+Present a summary of the assembled (not-yet-written) Design Spec:
 
 > "Here's the Design Spec summary:
 >
@@ -846,15 +872,18 @@ Present a summary of the Design Spec:
 > - **Integration options:** [count] tools with recommended integration approaches
 > - **Implementation order:** [brief summary]
 >
-> The full spec is saved to `outputs/[workflow-name]-design-spec.md`.
+> The full spec is **ready for approval** — I'll save it to `outputs/[workflow-name]-design-spec.md` once you approve.
 >
-> **Do you approve this spec?** I won't generate any artifacts until you confirm. If you want changes, tell me what to adjust and I'll revise."
+> **Do you approve this spec?** I won't write the file or generate any artifacts until you confirm. If you want changes, tell me what to adjust and I'll revise."
 
-Loop if the user requests changes — revise the spec and re-present for approval.
+If the user requests changes, **revise the assembled content in memory**, re-run the self-test, and re-present — still without writing the file.
 
-After the user approves, instruct them to **exit plan mode** if they entered it at the start of Design:
+**Only after explicit approval:**
+1. **Write the spec** to `outputs/[workflow-name]-design-spec.md`. (In Claude Code, this is the point where the user exits plan mode so the write can happen; in Cowork, write directly.)
+2. Then tell the user:
 
-> "Spec approved. **Exit plan mode now** (in Claude Code: `shift+tab` or `/plan`) so artifacts can be generated in the Build phase."
+> - **Claude Code:** "Spec approved and saved to `outputs/[workflow-name]-design-spec.md`. If you're in plan mode, **exit now** (`shift+tab` or `/plan`) so the Build phase can generate artifacts."
+> - **Cowork:** "Spec approved and saved to `outputs/[workflow-name]-design-spec.md`."
 >
 > "To build the workflow, run the `build` skill (Step 4) (or say *'Build the workflow from my Design Spec'*)."
 
@@ -867,6 +896,8 @@ When the Workflow Requirements has `Definition Type: Outcome-Driven`, the follow
 **Step 4 (Autonomy Assessment):** State as fact: "This is an outcome-driven workflow — autonomy is **Autonomous** by definition. The agent system determines its own execution path."
 
 **Step 5 (Orchestration Mechanism):** State as fact: "Orchestration is **Agent**." Still determine the involvement mode (Augmented/Automated) from the definition's Human Gates section and trigger type. Still ask the platform sub-choice if the platform has multiple agent offerings.
+
+**On Claude Code/Cowork, "Agent" mechanism does NOT mean "build an orchestrator agent file."** It means the workflow is driven by an agentic loop — and that loop is the **primary session**. The artifacts you produce are the orchestration logic (command/`CLAUDE.md` run section) plus the **sub-agent(s)** the primary loop dispatches (see "Who is the orchestrator?" in Step 5). Carry this into Capability Domain Mapping and Agent Configuration below.
 
 **Step 6 (Classify Each Step) → Capability Domain Mapping:** Replace per-step classification with capability domain mapping.
 
@@ -882,7 +913,9 @@ Same Integration Discovery and Skill Discovery processes apply, operating on cap
 
 **Step 7 (Skill Candidates):** Same field structure — identify which capability domains should become skills. Each skill candidate uses the full 12-field Skill Candidate block (with Covers Domains in place of Covers Steps).
 
-**Step 8 (Agent Configuration):** This becomes the primary section. Agent Configuration is **mandatory** (not optional) for outcome-driven workflows. Document the agent(s) with all 13 standard fields, drawing Description, Mission, Responsibilities, Output Format, and Constraints from the Workflow Requirements' Outcome, Rules & Constraints, and Acceptance Criteria.
+**Step 8 (Agent Configuration):** This is usually the primary blueprint section. Agent Configuration documents the **sub-agent(s) the orchestrator dispatches** — the workers — using all 13 standard fields, drawing Description, Mission, Responsibilities, Output Format, and Constraints from the Workflow Requirements' Outcome, Rules & Constraints, and Acceptance Criteria.
+
+**Mandatory-but-with-an-exception:** document at least one agent **whenever the design includes a sub-agent/agent artifact** (the common case). A valid outcome-driven design on a primary-loop platform (Claude Code/Cowork) may have **zero sub-agents** — just orchestration logic (command/`CLAUDE.md` run section) + skills. In that case record `agents: 0` in the frontmatter counts and document the orchestration logic in the Deployment Plan / Orchestrator notes instead — **do not invent a sub-agent to satisfy the field.** Never document the orchestrator (the primary loop) as an agent artifact.
 
 **Step 8b (Verify Evaluation Inputs):** Same as step-decomposed — confirm Acceptance Criteria and Example Scenarios in the Workflow Requirements are complete; do not duplicate.
 
@@ -900,22 +933,22 @@ Replace the `## Step-by-Step Decomposition` section with:
 | Domain | Description | Integration (use/build) | Intelligence | Build Output |
 |--------|-------------|------------------------|--------------|--------------|
 
-**Build Output values:** Same canonical forms as the step-decomposed table (`New skill: SN`, `Use existing: [name]`, `New agent: AN`, etc.). For outcome-driven workflows, expect most domains to map to either `New skill: SN` (if the agent should delegate to a reusable skill) or `Handled by agent` (if the agent handles the domain inline with its own instructions).
+**Build Output values:** Same canonical forms as the step-decomposed table (`New skill: SN`, `Use existing: [name]`, `New agent: AN`, etc.). For outcome-driven workflows, expect most domains to map to either `New skill: SN` (the orchestrator/sub-agent delegates to a reusable skill) or `Handled by orchestrator` (the orchestrating primary loop — or a deployed agent on SDK platforms — handles the domain inline via its own instructions; legacy synonym: `Handled by agent`).
 
 ### Autonomy Statement
 
 This is an outcome-driven workflow. Autonomy is Autonomous — the agent system determines its own execution path based on the Outcome, Inputs, Rules & Constraints, and Acceptance Criteria defined in the Workflow Requirements.
 ```
 
-Skill Candidates use the same 12-field block (with `Covers Domains` instead of `Covers Steps`). Agent Configuration is **mandatory** for outcome-driven specs.
+Skill Candidates use the same 12-field block (with `Covers Domains` instead of `Covers Steps`). Agent Configuration documents the **sub-agent(s) the orchestrator dispatches** and is included whenever the design has ≥1 sub-agent (the common case). A primary-loop design with **zero sub-agents** (orchestration logic + skills only) is valid: set `agents: 0` and document the orchestration logic in the Deployment Plan instead. Never document the primary-loop orchestrator as an agent artifact.
 
 **Build Skill Needs Checklist modifications for outcome-driven:**
 
 Use the full step-decomposed checklist with these substitutions:
 - Replace "Step-by-Step Decomposition" with "Capability Domain Mapping"
 - Replace "Step IDs match Workflow Requirements Step IDs" with "Capability Domains are derived from Workflow Requirements (not restated from a section that doesn't exist there)"
-- Replace "Inline prompt → Workflow Requirements Step N" Build Output value with "Handled by agent"
-- Agent Configuration is mandatory (not optional)
+- Replace "Inline prompt → Workflow Requirements Step N" Build Output value with "Handled by orchestrator" (accept legacy "Handled by agent" as a synonym)
+- Agent Configuration is included whenever ≥1 sub-agent is defined; a zero-sub-agent design (orchestration logic + skills only) is valid with `agents: 0`. Never document the primary-loop orchestrator as an agent.
 
 All other checklist items apply unchanged.
 
@@ -931,11 +964,11 @@ The spec is organized into three layered groups:
 
 - **Layer 1 — Architecture:** Execution Pattern, Architecture Decisions (with Packaging), Autonomy Spectrum Summary, Integration Options (with Source URLs), Model Recommendation (with per-platform mapping)
 - **Layer 2 — Decomposition:** Step-by-Step Decomposition (with Build Output column) — or Capability Domain Mapping for outcome-driven — Orchestrator Prompt Outline (when mechanism is Prompt or Skill-Powered Prompt), Data Readiness Summary, Recommended Implementation Order
-- **Layer 3 — Component Blueprints:** Skill Candidates (12 fields each), Agent Configuration (optional, mandatory for outcome-driven; 13 fields each), Multi-Agent Configuration (when applicable), Prerequisites, Deployment Plan
+- **Layer 3 — Component Blueprints:** Skill Candidates (12 fields each), Agent Configuration (included whenever ≥1 sub-agent is defined — the common case for Agent/outcome-driven; documents the worker sub-agent(s), never the primary-loop orchestrator; 13 fields each), Multi-Agent Configuration (when applicable), Prerequisites, Deployment Plan
 
 **Cross-layer sections:** Evaluation Inputs (pointer to Workflow Requirements), Deferred to Build, Stakeholders (optional), Self-Test Summary (results of the Build Skill Needs Checklist).
 
-For outcome-driven workflows: Step-by-Step Decomposition is replaced by Capability Domain Mapping; Autonomy Spectrum Summary is replaced by an Autonomy Statement; Orchestrator Prompt Outline is omitted (the agent IS the orchestrator); Agent Configuration is mandatory.
+For outcome-driven workflows: Step-by-Step Decomposition is replaced by Capability Domain Mapping; Autonomy Spectrum Summary is replaced by an Autonomy Statement; Orchestrator Prompt Outline is omitted (on Claude Code/Cowork the **primary loop is the orchestrator** — captured as orchestration logic, not an agent file); Agent Configuration documents the worker sub-agent(s) and is included whenever ≥1 is defined (a zero-sub-agent design — orchestration logic + skills only — is valid with `agents: 0`).
 
 ## Guidelines
 

--- a/plugins/handsonai/skills/run/SKILL.md
+++ b/plugins/handsonai/skills/run/SKILL.md
@@ -101,6 +101,16 @@ The Build phase produced GUI instruction documents rather than deployable code a
 
 **D. What to do next** — How to modify the configuration later, share with team members (if the platform supports it), when to revisit and update, change management notes for organizational workflows.
 
+**Section E — Running it in a fresh or scheduled session (include in all variants).**
+
+A workflow that worked while you were building it can fail the first time it runs in a *new* or *unattended* session, because that environment doesn't inherit this one's setup. State these as **requirements the run environment must satisfy** — and let the model fill in the concrete commands/clicks for the user's specific platform at runtime (per the Design Principle, do **not** hardcode platform commands in this skill):
+
+- **Artifacts must be loadable in the run environment.** On platforms where project-local artifacts auto-load, the workflow is available to any session opened in that project — nothing to reinstall. On others, the artifacts must be installed/imported first. (Model: state the concrete mechanism for the user's platform.)
+- **Connectors are authorized per session/environment, and it doesn't carry over.** Every connector the workflow uses must be authorized **in the session/context that actually runs it** — authorizing it elsewhere (or in this build session) does not transfer. Include a "verify connectors are connected before the first real run" check. (Model: supply the platform's concrete verification step.)
+- **Unattended/scheduled runs need pre-granted permissions and non-interactive credentials.** A scheduled or headless run can't answer interactive permission prompts, so tool permissions must be pre-granted and credentials must be non-interactive. Present this as a prerequisite checklist. (Model: supply the platform's concrete scheduling + headless mechanism.)
+
+Frame this as requirements + a placeholder the model fills with the platform's actual steps — never hardcoded commands in the skill itself.
+
 Present the Run Guide directly in the conversation. Also save it to `outputs/[workflow-name]-run-guide.md` so the user has a reference they can follow later or share with teammates.
 
 ## Outputs
@@ -111,6 +121,8 @@ Plain-language guide for getting the workflow running. Three variants:
 - **Model-built:** Artifact inventory, step-by-step setup instructions tailored to the user's platform, a guided first-run test with sample input, and next steps for ongoing use and team sharing.
 - **Manual build:** Construction Guide with artifact list, build sequence with platform-specific format guidance, first-run test, and next steps.
 - **Guided-mode:** Instruction walkthrough, step-by-step GUI setup guide, first-run test, and next steps.
+
+All variants also include **Section E — Running it in a fresh or scheduled session** (artifact loading, per-session connector authorization, and prerequisites for unattended/scheduled runs), written as platform-agnostic requirements the model resolves to concrete steps at runtime.
 
 ## Guidelines
 

--- a/plugins/handsonai/skills/test/SKILL.md
+++ b/plugins/handsonai/skills/test/SKILL.md
@@ -19,13 +19,25 @@ Read the Design Spec (including Evaluation Criteria) to understand what was buil
 
 One representative input, manual check: does the workflow run end-to-end and produce something reasonable? This is a sanity check before systematic evaluation — catch showstoppers early.
 
+### 2.5 Integration pre-flight (enables partial testing)
+
+Before the eval suite, check each integration the scenarios will exercise for the access it needs (read vs. write). Connectors are often **read-only** or unauthorized, which would block steps like creating a draft, writing a CRM row, or sending a message.
+
+- If everything needed is available → run the full eval suite (Step 3).
+- If any **write path is blocked** → **don't abort.** Switch to **partial test**: run and score every step that *can* run (classification, content generation, any readable/writable integrations), and **simulate** the blocked steps (produce the would-be output without performing the live action). Clearly mark which steps were **simulated/skipped and why**, and report the result as *"logic verified; deployment blocked on [integration] write access"* rather than a pass or a fail.
+
+This distinguishes "the workflow logic is wrong" from "an integration isn't authorized yet" — two very different fixes.
+
 ### 3. Run eval suite
 
 Execute each test scenario from the Evaluation Criteria (defined in Design). For each scenario:
 
-- Run the workflow with the scenario's input
-- Score output on each eval dimension (1–5 scale)
+- Run the workflow with the scenario's input (full or partial per the pre-flight above)
+- Score output on each eval dimension (1–5 scale); score only the steps that actually ran
 - Note specific issues with concrete examples
+- Note any steps that were **simulated/skipped** (don't let a simulated step count as a pass)
+
+**Live-system test data caution.** A real test writes real artifacts to the user's accounts (rows, drafts, events). Prefer a clearly-marked test record, tell the user exactly what was created and where, and offer to clean it up afterward.
 
 Guide the user through scoring with plain-language prompts:
 
@@ -67,6 +79,7 @@ For each problem identified in the eval, map it to which building block to adjus
 Based on eval scores across all scenarios:
 
 - **Ready** — scores meet the minimum quality bar defined in the spec → proceed to the `run` skill (Step 6)
+- **Logic-ready, deploy-blocked** — the logic passes in partial testing but one or more write integrations are unauthorized. Name the blocker and what to authorize; the user fixes access, then re-runs the blocked steps before going to Run. (Not a code defect — don't loop back to Build for it.)
 - **Not ready** — document specific adjustments needed, return to the `build` skill (Step 4), then re-test
 
 ## Output
@@ -77,9 +90,11 @@ Include an eval scorecard with this format:
 
 - **Scenarios tested** — list each scenario with its input description
 - **Scores per dimension** — table of scenario × dimension scores (1–5)
+- **Steps simulated/skipped (and why)** — any steps not run live (e.g., blocked integration), so a partial test is never mistaken for a full pass
+- **Integration / environment status** — which integrations were live vs. simulated, and the environment tested in (so a later Improve regression compares like-for-like and doesn't read "an integration got fixed" as "the workflow improved")
 - **Issues identified** — specific problems with concrete examples and diagnosed building block
 - **Baseline established** — summary scores to use as regression reference in Step 7
-- **Overall readiness assessment** — Ready or Not Ready, with rationale
+- **Overall readiness assessment** — Ready / Not Ready / **Logic-ready, deploy-blocked** (with the blocking integration named), with rationale
 
 ## Guidelines
 


### PR DESCRIPTION
## Context

Grounded in an end-to-end run of the framework (deconstruct → design → build → test → run) on a real "Inbound Lead Triage" workflow, plus a close read of the skill source. Goal: make the framework **more robust** (fewer silent failures / dead ends) and **more intuitive for non-technical students**. Targets **both Claude Code and Cowork** (Cowork has no plan mode).

Each change traces to friction observed live or a contradiction found by an adversarial verification pass.

## P0 — fixes for friction hit live

- **design:** environment-aware approval — never write the spec before the user approves (plan mode in Claude Code; conversational in Cowork). Spec is assembled + self-tested in memory, presented for approval, then written.
- **design:** the **primary loop IS the orchestrator** on Claude Code/Cowork — build sub-agent(s) (or zero), never a separate orchestrator-agent file. Reconciled the outcome-driven "Agent Configuration mandatory" framing so it documents worker sub-agents and allows a valid zero-sub-agent design (`agents: 0`).
- **build:** write-scope pre-flight (catch read-only connectors); confirm before mutating real accounts (Notion DBs, Gmail labels, etc.); never overwrite existing local files.
- **test:** partial/dry-run path when an integration is blocked — score what runs, label simulated/skipped steps, add a "Logic-ready, deploy-blocked" outcome and live-data caution.
- **run:** platform-agnostic "Running it in a fresh or scheduled session" section (artifact loading, per-session connector auth, unattended permissions) — written as requirements, not hardcoded commands.

## P1 — robustness / consistency

- Unify canonical **Build Output** vocab across all 6 locations (`Handled by orchestrator`; legacy `Handled by agent` accepted as synonym).
- **Role-based** (not key-based) field classification in build; mark `skill-spec.md` / `agent-spec.md` as point-in-time snapshots (platform schemas drift; resolve at runtime).
- Explicit registry/web-fetch **fallback ladder** in design + build (never hard-fail; flag degraded results).
- Outcome-driven **validation gate (Step 8-OD)** + Analyze opportunity self-check (trigger + deliverable).
- Output **filename/heading hygiene** self-checks so downstream parsing doesn't break silently.

## P2 — intuitiveness

- Point-of-use plain-language glossary (MCP/API/SDK/CLI, model tiers, autonomy/involvement).
- Step-decomposed vs. outcome-driven **path heuristic** with worked examples.
- "One question at a time / sample, don't interrogate" framing before the question banks.

## Scope

P0 + P1 + P2.1/P2.2/P2.4. **Deferred:** P2.3 (worked-example files), Build Step 3.5 overhead, deeper Improve-step robustness, registry permission-scope metadata.

## Files

8 files, +162/−45 — all under `plugins/handsonai/skills/` (`analyze`, `build` + references, `deconstruct`, `design`, `run`, `test`).

## Verification

Contradiction sweep clean: no leftover "agent IS the orchestrator" / "mandatory for outcome-driven"; all Build Output enumerations carry the unified vocab; plan-mode "directive, not optional" removed; Step 10 says "ready for approval," not "saved."

🤖 Generated with [Claude Code](https://claude.com/claude-code)