### PR TITLE
Make feature PRDs testable & traceable for agentic build (plugin 5.0.1)

### DIFF
--- a/examples/client-onboarding-tracker/guided-intake-flow-prd.md
+++ b/examples/client-onboarding-tracker/guided-intake-flow-prd.md
@@ -25,52 +25,52 @@ The guided intake flow solves this by giving clients a structured, step-by-step 
 
 ## User Stories & Acceptance Criteria
 
-### Story 1: Step-by-step information collection
+### US-1 — Step-by-step information collection
 
 **As a** new client, **I want to** provide my information through a guided, multi-step flow **so that** I know exactly what's needed and can complete it without confusion.
 
 **Acceptance Criteria:**
-1. `[MUST]` Intake is divided into logical steps: company info, primary contact details, project goals, timeline and constraints, and billing setup
-2. `[MUST]` Each step shows only the fields relevant to that step — no overwhelming single-page form
-3. `[MUST]` Required fields are clearly marked; optional fields explain why providing them is helpful
-4. `[MUST]` Client can see which step they're on and how many remain (e.g., "Step 3 of 5")
-5. `[SHOULD]` Each step includes a brief explanation of why the information is needed
+1. `AC-1.1` `[MUST]` Intake is divided into logical steps: company info, primary contact details, project goals, timeline and constraints, and billing setup
+2. `AC-1.2` `[MUST]` Each step shows only the fields relevant to that step — no overwhelming single-page form
+3. `AC-1.3` `[MUST]` Required fields are clearly marked; optional fields explain why providing them is helpful
+4. `AC-1.4` `[MUST]` Client can see which step they're on and how many remain (e.g., "Step 3 of 5")
+5. `AC-1.5` `[SHOULD]` Each step includes a brief explanation of why the information is needed
 
-### Story 2: Progress persistence
+### US-2 — Progress persistence
 
 **As a** new client, **I want to** save my progress and come back later **so that** I don't have to complete everything in one sitting.
 
 **Acceptance Criteria:**
-1. `[MUST]` Progress is automatically saved after each step is completed
-2. `[MUST]` When a client returns, they resume from where they left off — not from the beginning
-3. `[MUST]` A confirmation message shows when progress is saved (e.g., "Your progress has been saved. You can close this tab and come back anytime.")
-4. `[SHOULD]` Incomplete intake flows are retained for at least 30 days before being archived
+1. `AC-2.1` `[MUST]` Progress is automatically saved after each step is completed
+2. `AC-2.2` `[MUST]` When a client returns, they resume from where they left off — not from the beginning
+3. `AC-2.3` `[MUST]` A confirmation message shows when progress is saved (e.g., "Your progress has been saved. You can close this tab and come back anytime.")
+4. `AC-2.4` `[SHOULD]` Incomplete intake flows are retained for at least 30 days before being archived
 
-### Story 3: Intake status visibility for account managers
+### US-3 — Intake status visibility for account managers
 
 **As an** account manager, **I want to** see which step each client is on in the intake flow **so that** I can proactively reach out to clients who are stuck.
 
 **Acceptance Criteria:**
-1. `[MUST]` Account manager view shows a list of all assigned clients with their current intake step
-2. `[MUST]` Clients are sortable by status: not started, in progress, completed, stalled
-3. `[MUST]` "Stalled" is defined as no activity for 48+ hours while intake is incomplete
-4. `[SHOULD]` Clicking a client shows their completed steps and the specific step where they stopped
+1. `AC-3.1` `[MUST]` Account manager view shows a list of all assigned clients with their current intake step
+2. `AC-3.2` `[MUST]` Clients are sortable by status: not started, in progress, completed, stalled
+3. `AC-3.3` `[MUST]` "Stalled" is defined as no activity for 48+ hours while intake is incomplete
+4. `AC-3.4` `[SHOULD]` Clicking a client shows their completed steps and the specific step where they stopped
 
-### Story 4: Intake completion and handoff
+### US-4 — Intake completion and handoff
 
 **As a** new client, **I want to** receive a clear confirmation when I've completed intake **so that** I know what happens next and who to expect to hear from.
 
 **Acceptance Criteria:**
-1. `[MUST]` Completion screen shows a summary of all submitted information
-2. `[MUST]` Client can review and edit any section before final submission
-3. `[MUST]` After submission, client sees a "What happens next" message explaining the next steps in onboarding
-4. `[MUST]` Account manager is notified immediately when a client completes intake
-5. `[COULD]` Client receives a confirmation email with a copy of their submitted information
+1. `AC-4.1` `[MUST]` Completion screen shows a summary of all submitted information
+2. `AC-4.2` `[MUST]` Client can review and edit any section before final submission
+3. `AC-4.3` `[MUST]` After submission, client sees a "What happens next" message explaining the next steps in onboarding
+4. `AC-4.4` `[MUST]` Account manager is notified immediately when a client completes intake
+5. `AC-4.5` `[COULD]` Client receives a confirmation email with a copy of their submitted information
 
 ### Global Acceptance Criteria
-1. `[MUST]` Analytics events fire at each step transition to track drop-off rates per step
-2. `[MUST]` All intake data is validated before advancing to the next step
-3. `[SHOULD]` Intake flow loads within 2 seconds on a standard broadband connection
+1. `AC-G.1` `[MUST]` Analytics events fire at each step transition to track drop-off rates per step
+2. `AC-G.2` `[MUST]` All intake data is validated before advancing to the next step
+3. `AC-G.3` `[SHOULD]` Intake flow loads within 2 seconds on a standard broadband connection
 
 ## Scope
 
@@ -99,22 +99,47 @@ The account manager status view is a simple list endpoint that aggregates intake
 
 Step-transition events are sent to the analytics pipeline on each step completion and on final submission, giving us per-step drop-off data from day one.
 
+## Data & Validation
+
+**Fields:**
+
+| Field | Type | Required | Rules / limits |
+|-------|------|----------|----------------|
+| Company name | text | yes | 1–120 chars |
+| Industry | enum | yes | From the standard industry list |
+| Primary contact name | text | yes | 1–80 chars |
+| Primary contact email | email | yes | Valid email format; used for all intake notifications |
+| Primary contact phone | text | no | E.164 format if provided |
+| Project goals | text | yes | 1–2,000 chars |
+| Target start date | date | no | Must be today or later |
+| Budget range | enum | no | From the predefined budget bands |
+| Billing contact email | email | yes (billing step) | Valid email format |
+
+**State transitions** (intake status):
+- `not started` → `in progress` when the client completes Step 1
+- `in progress` → `stalled` when no activity for 48+ hours while incomplete
+- `in progress` / `stalled` → `completed` when the client submits the final step
+
+**Cross-field & business rules:**
+- A step cannot be advanced until all required fields on it pass validation
+- Billing contact email may match the primary contact email (no uniqueness requirement)
+
 ## Non-Functional Requirements
 
-- **Performance:** Each step transition (save + load next) completes in under 1 second. Intake flow initial load under 2 seconds.
-- **Accessibility:** WCAG 2.1 AA compliance — keyboard navigable, screen reader compatible, sufficient color contrast on all form elements.
-- **Compatibility:** Mobile-responsive — clients may complete intake on their phone. Supports latest two versions of Chrome, Safari, Firefox, and Edge.
-- **Reliability:** Auto-save must not silently fail. If a save fails, the client sees an error message and can retry.
+- **Performance:** `NFR-1` `[MUST]` Each step transition (save + load next) completes in under 1 second at p95; intake flow initial load completes in under 2 seconds on a standard broadband connection.
+- **Accessibility:** `NFR-2` `[MUST]` All form elements meet WCAG 2.1 AA — keyboard navigable, screen-reader compatible, sufficient color contrast (verify: axe DevTools, zero critical violations).
+- **Compatibility:** `NFR-3` `[MUST]` Fully usable on mobile (single-column, 44px+ touch targets) and on the latest two versions of Chrome, Safari, Firefox, and Edge.
+- **Reliability:** `NFR-4` `[MUST]` Auto-save never fails silently — a failed save surfaces an error message with a retry option.
 
 ## Error States
 
-| Scenario | Expected Behavior |
-|----------|-------------------|
-| Invalid input on a required field | Inline validation message appears below the field. Step does not advance until corrected. |
-| Auto-save fails (network error) | Toast notification: "Unable to save. Check your connection and try again." Retry button available. |
-| Session timeout (inactive 60+ minutes) | Client is prompted to re-authenticate. Progress up to the last completed step is preserved. |
-| Client navigates away mid-step | Unsaved fields on the current step are lost. Completed steps are preserved. Browser shows "unsaved changes" warning. |
-| Intake link accessed after completion | Client sees their submitted summary in read-only mode with a message: "Your intake is complete." |
+| ID | Scenario | Expected Behavior | Priority |
+|----|----------|-------------------|----------|
+| `ERR-1` | Invalid input on a required field | Inline validation message appears below the field. Step does not advance until corrected. | `[MUST]` |
+| `ERR-2` | Auto-save fails (network error) | Toast notification: "Unable to save. Check your connection and try again." Retry button available. | `[MUST]` |
+| `ERR-3` | Session timeout (inactive 60+ minutes) | Client is prompted to re-authenticate. Progress up to the last completed step is preserved. | `[MUST]` |
+| `ERR-4` | Client navigates away mid-step | Unsaved fields on the current step are lost. Completed steps are preserved. Browser shows "unsaved changes" warning. | `[SHOULD]` |
+| `ERR-5` | Intake link accessed after completion | Client sees their submitted summary in read-only mode with a message: "Your intake is complete." | `[MUST]` |
 
 ## Success Metrics & Instrumentation
 
@@ -155,24 +180,44 @@ Step-transition events are sent to the analytics pipeline on each step completio
 ## Verification
 
 ### Happy path
-1. Open the intake flow as a new client
-2. Complete Step 1 (company info) — verify progress saves and step indicator shows "Step 1 of 5" then advances to Step 2
-3. Close the browser tab and reopen the intake link — verify you resume at Step 2
-4. Complete all remaining steps — verify the completion summary shows all submitted data
-5. Edit one field on the summary screen and re-submit — verify the change is saved
-6. Verify account manager view shows the client as "completed"
-7. Verify analytics events were recorded for each step transition
+1. Open the intake flow as a new client; complete Step 1 (company info) — progress saves, step indicator shows "Step 1 of 5", then advances to Step 2 within 1s. _(AC-1.1, AC-1.2, AC-1.4, AC-2.1, AC-2.3, NFR-1)_
+2. Confirm required fields are marked and each step explains why the info is needed. _(AC-1.3, AC-1.5)_
+3. Close the browser tab and reopen the intake link — you resume at Step 2, not the beginning. _(AC-2.2)_
+4. Complete all remaining steps — the completion summary shows all submitted data; data was validated before each advance. _(AC-4.1, AC-G.2)_
+5. Edit one field on the summary screen and re-submit — the change is saved. _(AC-4.2)_
+6. Submit the final step — a "What happens next" message appears and the account manager is notified immediately. _(AC-4.3, AC-4.4)_
+7. Open the account manager view — the client shows as "completed", list is sortable by status. _(AC-3.1, AC-3.2)_
+8. Verify analytics events fired for each step transition. _(AC-G.1)_
+9. Re-open the completed intake link — it shows the submitted summary in read-only mode. _(ERR-5)_
 
 ### Edge case: Stalled client detection
 1. Start intake as a new client — complete Step 1 only
 2. Wait 48+ hours (or simulate time passage in test)
-3. Check account manager view — verify client shows as "stalled" with last activity on Step 1
+3. Check account manager view — client shows as "stalled" with last activity on Step 1; clicking shows where they stopped. _(AC-3.3, AC-3.4)_
 
-### Edge case: Network failure during save
-1. Complete Step 1 with network connectivity
-2. Disable network before completing Step 2
-3. Attempt to advance — verify error toast appears with retry option
-4. Re-enable network and retry — verify step saves successfully
+### Edge case: Network failure and invalid input during save
+1. Enter an invalid value in a required field and attempt to advance — inline validation appears and the step does not advance. _(ERR-1)_
+2. Complete Step 1 with network connectivity, then disable network before completing Step 2
+3. Attempt to advance — error toast appears with a retry option (no silent failure). _(ERR-2, NFR-4)_
+4. Re-enable network and retry — the step saves successfully
+
+### Edge case: Session timeout
+1. Start intake, complete Step 1, then remain inactive for 60+ minutes
+2. Return and attempt to continue — client is prompted to re-authenticate; progress up to the last completed step is preserved. _(ERR-3)_
+
+### Non-functional checks
+1. Run axe DevTools on each step and the summary screen — zero critical violations; tab through every field and submit using the keyboard only. _(NFR-2)_
+2. Complete a full intake on a phone (single-column, 44px+ touch targets) and on the latest two versions of Chrome, Safari, Firefox, and Edge. _(NFR-3)_
+
+## Definition of Done
+
+- [ ] All `[MUST]` criteria pass: AC-1.1–1.4, AC-2.1–2.3, AC-3.1–3.3, AC-4.1–4.4, AC-G.1–G.2, NFR-1–4, ERR-1–3, ERR-5
+- [ ] Every `[MUST]` criterion is covered by a verification step that has been run
+- [ ] Build / CI passes
+- [ ] NFR thresholds measured and met: step transition <1s p95, initial load <2s, WCAG 2.1 AA (axe clean), no silent auto-save failures
+- [ ] All five `intake.*` analytics events fire and are visible in the analytics pipeline
+- [ ] Mobile and the latest two versions of Chrome, Safari, Firefox, Edge verified
+- [ ] Step copy and "What happens next" content reviewed and in place
 
 ## Open Questions
 

--- a/examples/client-onboarding-tracker/task-assignment-engine-prd.md
+++ b/examples/client-onboarding-tracker/task-assignment-engine-prd.md
@@ -20,51 +20,51 @@ This feature eliminates the guesswork. When a client completes intake, the syste
 
 ## User Stories & Acceptance Criteria
 
-### Story 1: Automatic task creation on intake completion
+### US-1 — Automatic task creation on intake completion
 
 **As an** account manager, **I want** onboarding tasks to be automatically created when a client completes intake **so that** I don't have to manually set up a task list for every new client.
 
 **Acceptance Criteria:**
-1. `[MUST]` When a client submits the final step of the intake flow, the system creates all onboarding tasks defined in the active task template
-2. `[MUST]` Each created task has a title, description, assigned team member, and deadline
-3. `[MUST]` Tasks are created within 30 seconds of intake completion
-4. `[MUST]` The account manager who owns the client relationship is notified that tasks have been created
-5. `[SHOULD]` Task creation is idempotent — if the intake completion event fires twice, duplicate tasks are not created
+1. `AC-1.1` `[MUST]` When a client submits the final step of the intake flow, the system creates all onboarding tasks defined in the active task template
+2. `AC-1.2` `[MUST]` Each created task has a title, description, assigned team member, and deadline
+3. `AC-1.3` `[MUST]` Tasks are created within 30 seconds of intake completion
+4. `AC-1.4` `[MUST]` The account manager who owns the client relationship is notified that tasks have been created
+5. `AC-1.5` `[SHOULD]` Task creation is idempotent — if the intake completion event fires twice, duplicate tasks are not created
 
-### Story 2: Role-based task routing
+### US-2 — Role-based task routing
 
 **As a** team member, **I want** tasks to be assigned to me based on my role **so that** I only receive tasks I'm qualified to handle.
 
 **Acceptance Criteria:**
-1. `[MUST]` Each task type is mapped to a specific role (e.g., "welcome call" routes to account manager, "technical setup" routes to implementation specialist)
-2. `[MUST]` Tasks are only assigned to team members with the matching role
-3. `[SHOULD]` The role-to-task mapping is configurable by an admin without code changes
-4. `[COULD]` A task type can be mapped to multiple roles (e.g., either an account manager or a senior CSM can handle a welcome call)
+1. `AC-2.1` `[MUST]` Each task type is mapped to a specific role (e.g., "welcome call" routes to account manager, "technical setup" routes to implementation specialist)
+2. `AC-2.2` `[MUST]` Tasks are only assigned to team members with the matching role
+3. `AC-2.3` `[SHOULD]` The role-to-task mapping is configurable by an admin without code changes
+4. `AC-2.4` `[COULD]` A task type can be mapped to multiple roles (e.g., either an account manager or a senior CSM can handle a welcome call)
 
-### Story 3: Availability-based assignment
+### US-3 — Availability-based assignment
 
 **As a** team lead, **I want** tasks to be distributed based on team members' current workload **so that** no one person is overwhelmed while others sit idle.
 
 **Acceptance Criteria:**
-1. `[MUST]` When multiple team members share the same role, the system assigns the task to the team member with the fewest open onboarding tasks
-2. `[MUST]` A team member can be marked as "unavailable" (e.g., out of office), and the system skips them during assignment
-3. `[SHOULD]` If two team members have equal workload, either may be assigned (no specific tiebreaker required for MVP)
-4. `[COULD]` Team members can set a maximum concurrent task limit
+1. `AC-3.1` `[MUST]` When multiple team members share the same role, the system assigns the task to the team member with the fewest open onboarding tasks
+2. `AC-3.2` `[MUST]` A team member can be marked as "unavailable" (e.g., out of office), and the system skips them during assignment
+3. `AC-3.3` `[SHOULD]` If two team members have equal workload, either may be assigned (no specific tiebreaker required for MVP)
+4. `AC-3.4` `[COULD]` Team members can set a maximum concurrent task limit
 
-### Story 4: Deadline assignment
+### US-4 — Deadline assignment
 
 **As an** account manager, **I want** each task to have an automatic deadline **so that** the team knows when each step needs to be completed and clients aren't left waiting.
 
 **Acceptance Criteria:**
-1. `[MUST]` Each task type has a configurable SLA (e.g., "welcome call" = 24 hours, "account configuration" = 48 hours)
-2. `[MUST]` Deadlines are calculated from the time of intake completion
-3. `[MUST]` Deadlines are visible on each task to the assigned team member
-4. `[SHOULD]` SLA durations are configurable per task template by an admin
+1. `AC-4.1` `[MUST]` Each task type has a configurable SLA (e.g., "welcome call" = 24 hours, "account configuration" = 48 hours)
+2. `AC-4.2` `[MUST]` Deadlines are calculated from the time of intake completion
+3. `AC-4.3` `[MUST]` Deadlines are visible on each task to the assigned team member
+4. `AC-4.4` `[SHOULD]` SLA durations are configurable per task template by an admin
 
 ### Global Acceptance Criteria
-1. `[MUST]` All task assignments are logged with timestamp, assigned team member, and reason for assignment (role match + workload)
-2. `[MUST]` If no team member is available for a given role, the task is assigned to the team lead for that role and flagged for attention
-3. `[SHOULD]` Assignment logic is deterministic — same inputs produce the same assignment (for debugging and audit)
+1. `AC-G.1` `[MUST]` All task assignments are logged with timestamp, assigned team member, and reason for assignment (role match + workload)
+2. `AC-G.2` `[MUST]` If no team member is available for a given role, the task is assigned to the team lead for that role and flagged for attention
+3. `AC-G.3` `[SHOULD]` Assignment logic is deterministic — same inputs produce the same assignment (for debugging and audit)
 
 ## Scope
 
@@ -98,20 +98,45 @@ The task assignment engine has three components:
 
 The engine is event-driven: Feature 1's intake completion triggers task creation. Tasks are stored in a `tasks` table with foreign keys to the client and assigned team member.
 
+## Data & Validation
+
+**Fields:**
+
+| Field | Type | Required | Rules / limits |
+|-------|------|----------|----------------|
+| Task title | text | yes | From the task template; 1–120 chars |
+| Task description | text | yes | From the task template |
+| Assigned team member | reference (user) | yes (or fallback) | Must hold the task's required role; unassigned only on invalid mapping (ERR-3) |
+| Required role | enum | yes | From the team's defined role list |
+| Deadline | datetime | yes | Computed as intake completion time + task SLA |
+| SLA duration | duration | yes (on template) | Positive; configured per task type |
+| Team member availability | enum | yes (on user) | `available` / `unavailable` |
+| Assignment reason | text | yes (on log) | Role match + workload at assignment time |
+
+**State transitions** (task lifecycle relevant to this feature):
+- (none) → `assigned` on creation when an eligible team member exists
+- (none) → `fallback_assigned` (flagged "needs attention") when no eligible member is available
+- (none) → `unassigned` when the role mapping references a role with no members (ERR-3)
+
+**Cross-field & business rules:**
+- A task is assigned to the least-loaded available member holding the required role
+- Deadlines are always derived from SLA + intake completion time, never set manually at creation
+- All tasks for one intake are created in a single transaction — all or none (NFR-2)
+
 ## Non-Functional Requirements
 
-- **Performance:** All tasks for a single intake completion are created and assigned within 30 seconds. The assignment logic itself should complete in under 2 seconds — the remainder is event propagation and database writes.
-- **Reliability:** Task creation must be transactional — either all tasks for an intake are created, or none are. Partial task creation is not acceptable.
-- **Scalability:** Must handle concurrent intake completions without race conditions in workload-based assignment (use row-level locking or optimistic concurrency on the task count query).
+- **Performance:** `NFR-1` `[MUST]` All tasks for a single intake completion are created and assigned within 30 seconds; the assignment logic itself completes in under 2 seconds (remainder is event propagation and DB writes).
+- **Reliability:** `NFR-2` `[MUST]` Task creation is transactional — either all tasks for an intake are created, or none are. Partial task creation never occurs.
+- **Scalability:** `NFR-3` `[MUST]` Concurrent intake completions produce no race conditions in workload-based assignment (row-level locking or optimistic concurrency on the task-count query); verify with a concurrent-completion load test.
 
 ## Error States
 
-| Scenario | Expected Behavior |
-|----------|-------------------|
-| No available team member for a role | Task is assigned to the team lead for that role. Task is flagged with a "needs attention" indicator. |
-| Intake completion event fires twice (duplicate) | Second event is ignored — task creation is idempotent based on client ID + intake submission timestamp. |
-| Invalid role mapping (task template references a role with no team members) | Task is created but left unassigned. Admin is notified via system alert. Assignment retries when a team member with that role is added. |
-| Database transaction fails during task creation | All tasks for that intake are rolled back. Event is re-queued for retry (max 3 attempts). Account manager is notified if all retries fail. |
+| ID | Scenario | Expected Behavior | Priority |
+|----|----------|-------------------|----------|
+| `ERR-1` | No available team member for a role | Task is assigned to the team lead for that role. Task is flagged with a "needs attention" indicator. | `[MUST]` |
+| `ERR-2` | Intake completion event fires twice (duplicate) | Second event is ignored — task creation is idempotent based on client ID + intake submission timestamp. | `[MUST]` |
+| `ERR-3` | Invalid role mapping (task template references a role with no team members) | Task is created but left unassigned. Admin is notified via system alert. Assignment retries when a team member with that role is added. | `[SHOULD]` |
+| `ERR-4` | Database transaction fails during task creation | All tasks for that intake are rolled back. Event is re-queued for retry (max 3 attempts). Account manager is notified if all retries fail. | `[MUST]` |
 
 ## Success Metrics & Instrumentation
 
@@ -150,25 +175,42 @@ The engine is event-driven: Feature 1's intake completion triggers task creation
 ## Verification
 
 ### Happy path
-1. Configure task templates: "Welcome call" (account manager role, 24h SLA), "Technical setup" (implementation specialist, 48h SLA)
+1. Configure task templates: "Welcome call" (account manager role, 24h SLA), "Technical setup" (implementation specialist, 48h SLA). _(AC-2.1, AC-4.1)_
 2. Mark at least two account managers as available, with different open task counts
-3. Complete a client intake flow (Feature 1)
-4. Verify tasks are created within 30 seconds
-5. Verify "Welcome call" is assigned to the account manager with fewer open tasks
-6. Verify "Technical setup" is assigned to an implementation specialist
-7. Verify deadlines match the configured SLAs calculated from intake completion time
-8. Verify assignment audit log contains entries for each task with role, assignee, and workload reason
+3. Complete a client intake flow (Feature 1) — all template tasks are created within 30 seconds, each with title, description, assignee, and deadline; the owning account manager is notified. _(AC-1.1, AC-1.2, AC-1.3, AC-1.4, NFR-1)_
+4. Verify "Welcome call" is assigned to the account manager with fewer open tasks. _(AC-3.1)_
+5. Verify "Technical setup" is assigned to an available implementation specialist (unavailable members are skipped). _(AC-2.2, AC-3.2)_
+6. Verify deadlines are visible on each task and match the configured SLAs calculated from intake completion time. _(AC-4.2, AC-4.3)_
+7. Verify the assignment audit log contains an entry for each task with role, assignee, and workload reason. _(AC-G.1)_
 
 ### Edge case: No available team member
 1. Mark all implementation specialists as unavailable
 2. Complete a client intake flow
-3. Verify "Technical setup" is assigned to the team lead and flagged for attention
+3. Verify "Technical setup" is assigned to the team lead and flagged for attention. _(AC-G.2, ERR-1)_
 4. Verify a `task.fallback_assigned` event is logged
 
 ### Edge case: Duplicate intake completion event
 1. Complete a client intake flow
 2. Manually re-fire the intake completion event for the same client
-3. Verify no duplicate tasks are created
+3. Verify no duplicate tasks are created. _(AC-1.5, ERR-2)_
+
+### Edge case: Transaction failure
+1. Inject a database failure mid-creation for one intake
+2. Verify all tasks for that intake are rolled back (no partial set) and the event is re-queued for retry. _(NFR-2, ERR-4)_
+
+### Edge case: Concurrent intake completions
+1. Fire intake completion for several clients simultaneously (load test) while multiple team members share the same role
+2. Verify assignment is race-free — each task counts toward workload exactly once, no member is assigned past the least-loaded rule, and creation+assignment stays within the 30s threshold. _(NFR-3)_
+
+## Definition of Done
+
+- [ ] All `[MUST]` criteria pass: AC-1.1–1.4, AC-2.1–2.2, AC-3.1–3.2, AC-4.1–4.3, AC-G.1–G.2, NFR-1–3, ERR-1, ERR-2, ERR-4
+- [ ] Every `[MUST]` criterion is covered by a verification step that has been run
+- [ ] Build / CI passes
+- [ ] NFR thresholds measured and met: tasks created+assigned <30s, assignment logic <2s, concurrent completions race-free under load test, creation is transactional
+- [ ] All four `task*` analytics events fire and are visible where consumed
+- [ ] Task template seed data defined with the CS team and loaded
+- [ ] User model role + availability fields migrated without conflict
 
 ## Open Questions
 

--- a/plugins/handsonai/.claude-plugin/plugin.json
+++ b/plugins/handsonai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "handsonai",
   "description": "Everything you need to design, build, and document AI workflows. The AI Workflow Framework as executable Claude Code skills, plus an AI registry and feature-spec toolkit.",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "author": {
     "name": "James Gray"
   },

--- a/plugins/handsonai/skills/writing-feature-prds/SKILL.md
+++ b/plugins/handsonai/skills/writing-feature-prds/SKILL.md
@@ -72,9 +72,9 @@ Ask the user these questions to understand the feature:
 1. **What feature are you building?** (one sentence)
 2. **What problem does it solve?** (why does this need to exist?)
 3. **Who are the users?** (user type for user stories)
-4. **What should happen?** (key behaviors/requirements)
+4. **What should happen?** (key behaviors/requirements — and if the feature collects or stores data, what are the fields and their validation rules?)
 5. **What is explicitly NOT part of this feature?** (scope boundaries — prevents scope creep)
-6. **Are there performance, security, or accessibility requirements?** (e.g., response time targets, auth requirements, WCAG compliance). If the user says "nothing special," that's fine — note defaults and move on.
+6. **Are there performance, security, or accessibility requirements?** Push for *concrete, measurable* targets — "response under 1s at p95," "WCAG 2.1 AA," "auth required on every write" — because these become testable NFRs. If the user says "nothing special," record an explicit baseline (e.g., "page loads under 3s") rather than leaving it silent — an untestable NFR is no NFR.
 7. **What should happen when things go wrong?** (error states — invalid input, network failure, missing data, permission denied). If this is a simple feature, a brief answer is fine.
 8. **Does this change existing behavior, data, or URLs?** (migration needs — if yes, we'll need a migration and rollback plan). If no, skip the Migration section in the PRD.
 9. **What does this depend on?** (other features, data sources, APIs, tools that must exist first). If nothing, skip the Dependencies section.
@@ -102,34 +102,34 @@ Why this feature needs to exist. What problem it solves. Include quantification 
 
 ## User Stories & Acceptance Criteria
 
-### Story 1: [Short title]
+### US-1 — [Short title]
 **As a** [user type], **I want** [goal] **so that** [benefit].
 
 **Acceptance Criteria:**
-1. `[MUST]` [Yes/no verifiable statement]
-2. `[MUST]` [Another verifiable statement]
-3. `[SHOULD]` [A desirable but non-blocking criterion]
+1. `AC-1.1` `[MUST]` [Yes/no verifiable statement]
+2. `AC-1.2` `[MUST]` [Another verifiable statement]
+3. `AC-1.3` `[SHOULD]` [A desirable but non-blocking criterion]
 
 > *Example:*
-> ### Story 1: Email verification on signup
+> ### US-1 — Email verification on signup
 > **As a** new user, **I want** to verify my email during signup **so that** my account is secured and I receive important notifications.
 >
 > **Acceptance Criteria:**
-> 1. `[MUST]` Verification email is sent within 30 seconds of form submission
-> 2. `[MUST]` Clicking the verification link activates the account and redirects to the dashboard
-> 3. `[MUST]` Unverified accounts cannot access workspace features
-> 4. `[SHOULD]` "Resend verification" button is available on the pending screen
-> 5. `[COULD]` Verification link includes the user's name in the email greeting
+> 1. `AC-1.1` `[MUST]` Verification email is sent within 30 seconds of form submission
+> 2. `AC-1.2` `[MUST]` Clicking the verification link activates the account and redirects to the dashboard
+> 3. `AC-1.3` `[MUST]` Unverified accounts cannot access workspace features
+> 4. `AC-1.4` `[SHOULD]` "Resend verification" button is available on the pending screen
+> 5. `AC-1.5` `[COULD]` Verification link includes the user's name in the email greeting
 
-### Story 2: [Short title]
+### US-2 — [Short title]
 **As a** [user type], **I want** [goal] **so that** [benefit].
 
 **Acceptance Criteria:**
-1. `[MUST]` [Yes/no verifiable statement]
+1. `AC-2.1` `[MUST]` [Yes/no verifiable statement]
 
 ### Global Acceptance Criteria
 _Criteria that apply across all stories (e.g., performance, accessibility). Omit if none._
-1. `[MUST]` [Yes/no verifiable statement]
+1. `AC-G.1` `[MUST]` [Yes/no verifiable statement]
 
 ## Scope
 
@@ -142,30 +142,44 @@ _Criteria that apply across all stories (e.g., performance, accessibility). Omit
 ## Approach
 High-level technical approach and key design decisions. Keep this brief — detailed implementation planning happens in plan mode.
 
-## Non-Functional Requirements
-_Include only categories that are relevant to this feature. Omit categories that don't apply._
+## Data & Validation
+_Omit for features with no meaningful data model (static pages, copy-only changes). For anything that collects, stores, or validates data, specify the shape and rules so the build matches intent. This is still **what**, not **how** — describe fields and rules, not table schemas or column types in SQL._
 
-- **Performance:** [Response time targets, throughput requirements, resource limits]
-- **Security:** [Authentication, authorization, data protection, input validation]
-- **Accessibility:** [WCAG level, keyboard navigation, screen reader support]
-- **Scalability:** [Expected load, growth projections, scaling approach]
-- **Reliability:** [Uptime targets, graceful degradation, retry behavior]
-- **Compatibility:** [Browsers, devices, OS versions, API versions]
+**Fields:**
+
+| Field | Type | Required | Rules / limits |
+|-------|------|----------|----------------|
+| [field name] | [text / number / email / date / enum / …] | [yes / no] | [format, min/max, allowed values, uniqueness] |
+
+**State transitions** _(only if the feature moves through states):_
+- [State A] → [State B] when [condition]
+
+**Cross-field & business rules:** [Rules not captured per-field — e.g., "end date must be after start date"; "at least one contact method required"]
+
+## Non-Functional Requirements
+_Each NFR is a testable statement, just like an acceptance criterion: an ID, a priority tag, and a **concrete, measurable threshold** — plus how to verify it where the method isn't obvious. Include only relevant categories. If the feature truly has no special requirement in a category, record an explicit baseline (e.g., "page loads under 3s") rather than vague prose or silence. "Fast" and "secure" are not testable; "under 1s at p95" and "all inputs server-side validated" are._
+
+- **Performance:** `NFR-1` `[MUST]` [Concrete threshold — e.g., "Each request completes in under 500ms at p95 under normal load"]
+- **Security:** `NFR-2` `[MUST]` [e.g., "All user input is validated server-side; auth required on every write endpoint"]
+- **Accessibility:** `NFR-3` `[SHOULD]` [e.g., "Meets WCAG 2.1 AA — verify with axe DevTools, zero critical violations"]
+- **Scalability:** [e.g., "Handles 1,000 concurrent users with no degradation below the performance threshold"]
+- **Reliability:** [e.g., "Failed writes retry once after 5s; surface an error to the user if still failing"]
+- **Compatibility:** [e.g., "Works on the latest two versions of Chrome, Safari, Firefox, and Edge"]
 
 ## Error States
-_What should happen when things go wrong? Cover the most likely failure scenarios._
+_What should happen when things go wrong? Cover the most likely failure scenarios. Each row is a testable expectation — give it an ID and a priority. Every `[MUST]` error behavior must be covered by a step in the Verification section._
 
-| Scenario | Expected Behavior |
-|----------|-------------------|
-| [Error scenario 1] | [What the user sees/what happens] |
-| [Error scenario 2] | [What the user sees/what happens] |
+| ID | Scenario | Expected Behavior | Priority |
+|----|----------|-------------------|----------|
+| `ERR-1` | [Error scenario 1] | [What the user sees/what happens] | `[MUST]` |
+| `ERR-2` | [Error scenario 2] | [What the user sees/what happens] | `[MUST]` |
 
 > *Example:*
-> | Scenario | Expected Behavior |
-> |----------|-------------------|
-> | Invalid email format entered | Inline validation message: "Please enter a valid email address." Form does not submit. |
-> | Verification link expired (>24h) | Landing page shows "Link expired" with a "Resend verification" button. |
-> | Email delivery fails | System retries once after 5 minutes. If still failed, logs error and shows "Didn't receive it?" prompt. |
+> | ID | Scenario | Expected Behavior | Priority |
+> |----|----------|-------------------|----------|
+> | `ERR-1` | Invalid email format entered | Inline validation message: "Please enter a valid email address." Form does not submit. | `[MUST]` |
+> | `ERR-2` | Verification link expired (>24h) | Landing page shows "Link expired" with a "Resend verification" button. | `[MUST]` |
+> | `ERR-3` | Email delivery fails | System retries once after 5 minutes. If still failed, logs error and shows "Didn't receive it?" prompt. | `[SHOULD]` |
 
 ## Success Metrics & Instrumentation
 _How will you know this feature is working? Define what to measure and when to evaluate._
@@ -204,7 +218,29 @@ Constraints the implementation must respect — technical boundaries, convention
 - [Constraint 3 — e.g., "Must not introduce new runtime dependencies"]
 
 ## Verification
-Step-by-step instructions to verify the feature works end-to-end after implementation. Cover the happy path and at least one error/edge case.
+Step-by-step instructions to verify the feature works end-to-end after implementation. Cover the happy path and at least one error/edge case. Annotate each step with the criteria IDs it verifies, in parentheses — e.g. `_(AC-1.2, NFR-1)_`.
+
+**Coverage rule:** Every `[MUST]` criterion — story AC, Global AC, NFR, and Error State — must be covered by at least one verification step. This is what lets an agent (and you) confirm nothing required ships untested.
+
+> *Example:*
+> ### Happy path
+> 1. Submit the signup form with a valid email → verification email arrives within 30s. _(AC-1.1)_
+> 2. Click the verification link → account activates and redirects to the dashboard. _(AC-1.2)_
+> 3. Before verifying, attempt to open a workspace page → access is blocked. _(AC-1.3)_
+>
+> ### Edge case: invalid input
+> 1. Enter a malformed email → inline error appears, form does not submit. _(ERR-1)_
+
+## Definition of Done
+_The gate for calling this feature complete — every box checked before it ships. This is the feature-specific complement to the verification steps above._
+
+- [ ] All `[MUST]` acceptance criteria pass (story, Global, NFR, Error State)
+- [ ] Every `[MUST]` criterion is covered by a verification step that has actually been run
+- [ ] Build / CI passes
+- [ ] NFR thresholds are measured and met (not assumed)
+- [ ] Instrumentation events fire and are visible where they're consumed
+- [ ] Migration and rollback executed and tested (if the Migration section applies)
+- [ ] Docs / changelog updated (if applicable)
 
 ## Open Questions
 - [Any unresolved decisions or questions]
@@ -241,8 +277,18 @@ Each user story gets its own acceptance criteria directly beneath it. This keeps
 - A story without acceptance criteria is incomplete
 - If a single requirement covers all stories (e.g., "Page loads in under 2 seconds"), place it in the **Global Acceptance Criteria** subsection after the last story
 
+**Stable IDs (you assign these as you draft — the author never hand-maintains them):**
+- **User stories:** `US-1`, `US-2`, … — give each story its own ID on the heading, not just a title.
+- **Story acceptance criteria:** `AC-<story#>.<n>` — e.g. `AC-1.1` is the first criterion of `US-1`. The story number is baked into the ID so every criterion visibly traces to its story.
+- **Global acceptance criteria:** `AC-G.1`, `AC-G.2`, …
+- **Non-functional requirements:** `NFR-1`, `NFR-2`, …
+- **Error states:** `ERR-1`, `ERR-2`, …
+
+**ID stability rule:** IDs are permanent. When adding stories or criteria later, append new numbers — **never renumber existing ones**, because plans, tests, and the GitHub issue reference them. If a story or criterion is dropped, retire its number rather than reusing it.
+
 **Acceptance criteria rules:**
 - Use numbered list (not checkboxes)
+- Lead each criterion with its ID, then its priority tag (e.g. `AC-1.1` `[MUST]` …)
 - Write yes/no verifiable statements
 - Tag each criterion with priority: `[MUST]` (required for launch), `[SHOULD]` (important but not blocking), or `[COULD]` (nice to have, build if time permits)
 - Focus on *what*, not *how*
@@ -262,14 +308,18 @@ Check for:
 
 1. **Story-criteria alignment** — Is every user story covered by at least one acceptance criterion? Is there an acceptance criterion that doesn't map to any story? (Orphaned criteria signal possible scope creep.)
 2. **Testability** — Can each acceptance criterion be verified with a specific command, URL visit, or observable output? If not, make it more concrete.
-3. **Scope boundaries** — Are the "Out of Scope" items specific enough to reject future feature requests? Would a new team member know where this feature stops?
-4. **Edge cases** — What happens with empty inputs, unauthorized users, network failures, or concurrent actions?
-5. **Verification completeness** — Does the Verification section cover the happy path AND at least one error case?
-6. **Open questions** — Are all open questions truly unresolved, or can any be decided now?
-7. **Non-functional requirements** — Are performance, security, and accessibility needs captured? Even a simple "no special requirements" is better than silence.
-8. **Dependencies** — Are all prerequisites listed? Would someone picking this up cold know what needs to exist first?
-9. **Instrumentation** — Are success metrics defined with specific events to track? Can you actually measure whether this feature worked?
-10. **Migration needs** — If existing behavior changes, is there a migration plan and rollback strategy? Are URL redirects needed?
+3. **Testable NFRs** — Does each non-functional requirement have a concrete, measurable threshold and a priority tag? Reject vague prose ("fast," "secure") — replace with numbers and conditions.
+4. **Verification coverage** — Is every `[MUST]` criterion (story AC, Global AC, NFR, Error State) covered by at least one verification step? List any `[MUST]` with no covering step — those are untested-by-design.
+5. **ID integrity** — Does every story (`US-n`) and criterion have a unique ID? Are IDs unchanged from any prior draft of this PRD? (Renumbering breaks downstream references.)
+6. **Scope boundaries** — Are the "Out of Scope" items specific enough to reject future feature requests? Would a new team member know where this feature stops?
+7. **Edge cases** — What happens with empty inputs, unauthorized users, network failures, or concurrent actions? Is each likely failure captured as an `ERR-n` row with a testable expected behavior?
+8. **Verification completeness** — Does the Verification section cover the happy path AND at least one error case?
+9. **Open questions** — Are all open questions truly unresolved, or can any be decided now?
+10. **Dependencies** — Are all prerequisites listed? Would someone picking this up cold know what needs to exist first?
+11. **Instrumentation** — Are success metrics defined with specific events to track? Can you actually measure whether this feature worked?
+12. **Migration needs** — If existing behavior changes, is there a migration plan and rollback strategy? Are URL redirects needed?
+13. **Data & validation** — If the feature stores or validates data, are the fields, types, required/optional status, and validation rules specified? (Omit only if there's no real data model.)
+14. **Definition of Done** — Is the completion gate filled in and consistent with the `[MUST]` criteria and NFR thresholds?
 
 Iterate with the user until the PRD is solid.
 
@@ -279,15 +329,27 @@ Iterate with the user until the PRD is solid.
 
 Once the PRD is finalized, create a GitHub issue to track the feature. A GitHub issue is a to-do item in your project that links back to the PRD so you can track progress, leave comments, and close it when the feature ships.
 
+Write the issue body to a temporary file and create the issue with `--body-file` (the body now contains a multi-line checklist, which inline `--body` mangles):
+
 ```bash
-gh issue create --title "[Feature] Feature Name" --label "type:feature" --body "..."
+gh issue create --title "[Feature] Feature Name" --label "type:feature" --body-file issue-body.md
 ```
 
 The issue body should include:
 - Link to the PRD file
 - Summary of the feature
-- Key acceptance criteria (can reference PRD for full list)
+- **A checklist of every `[MUST]` criterion** (story AC, Global AC, NFR, Error State), each with its ID, so build and test progress is trackable as checkboxes that tie back to the PRD. `[SHOULD]`/`[COULD]` criteria stay in the PRD; the issue tracks what's required to ship.
 - **If this feature belongs to an epic:** Reference the epic issue (e.g., "Part of #XX") so the feature is linked to the bigger picture
+
+Use this shape for the checklist:
+
+```markdown
+## Acceptance Criteria — MUST (build/test tracking)
+- [ ] AC-1.1 Verification email is sent within 30 seconds of form submission
+- [ ] AC-1.2 Clicking the verification link activates the account and redirects to the dashboard
+- [ ] NFR-1 Each request completes in under 500ms at p95 under normal load
+- [ ] ERR-1 Invalid email shows an inline error; the form does not submit
+```
 
 ---
 

--- a/plugins/handsonai/skills/writing-feature-prds/references/workflow-checklist.md
+++ b/plugins/handsonai/skills/writing-feature-prds/references/workflow-checklist.md
@@ -7,37 +7,45 @@ Quick reference for the feature PRD workflow.
 - [ ] Ask: What feature? What problem? Who are users? What should happen? What's NOT in scope?
 - [ ] Ask: NFRs? Error states? Migration needs? Dependencies? Success metrics?
 - [ ] Create PRD at `specs/[feature-name]-prd.md` (or repo-conventional location)
-- [ ] Write user stories with acceptance criteria paired directly beneath each story
+- [ ] Write user stories (`US-n`) with acceptance criteria paired directly beneath each story
+- [ ] Assign stable IDs: `US-n`, `AC-n.m`, `AC-G.n`, `NFR-n`, `ERR-n` (append, never renumber)
 - [ ] Tag each criterion as `[MUST]` / `[SHOULD]` / `[COULD]`
 - [ ] Add Scope section (In Scope / Out of Scope)
 - [ ] Add Approach (high-level technical strategy)
-- [ ] Add Non-Functional Requirements (if applicable)
-- [ ] Add Error States table (if applicable)
+- [ ] Add Data & Validation (fields, types, required, rules) if the feature stores/validates data
+- [ ] Add Non-Functional Requirements as testable statements with concrete thresholds (if applicable)
+- [ ] Add Error States table with ID + Priority columns (if applicable)
 - [ ] Add Success Metrics & Instrumentation
 - [ ] Add Dependencies & Prerequisites (if applicable)
 - [ ] Add Migration & Rollback (if changing existing behavior)
 - [ ] Add UI/UX Requirements (if user-facing)
 - [ ] Add Design Constraints
-- [ ] Add Verification section (happy path + at least one error case)
+- [ ] Add Verification section, annotating each step with the criteria IDs it covers (happy path + at least one error case)
+- [ ] Add Definition of Done (completion gate covering MUST criteria, build, NFR thresholds, instrumentation)
 - [ ] Add Future Considerations (if ideas surfaced during discovery)
 
 ## Phase 2: Stress-Test
 
 - [ ] Story-criteria alignment: every story has AC, no orphaned criteria
 - [ ] Testability: each criterion maps to a specific command, URL, or output
+- [ ] Testable NFRs: each NFR has a concrete threshold + priority (no vague prose)
+- [ ] Verification coverage: every `[MUST]` (AC, Global, NFR, Error) covered by ≥1 verification step
+- [ ] ID integrity: every `US-n`/criterion ID is unique and unchanged from prior drafts
 - [ ] Scope boundaries: "Out of Scope" items are specific enough to reject requests
-- [ ] Edge cases: empty inputs, unauthorized users, failures
+- [ ] Edge cases: empty inputs, unauthorized users, failures — each captured as a testable `ERR-n`
 - [ ] Verification completeness: happy path + error case covered
+- [ ] Data & validation: fields, types, required status, and rules specified (if data-bearing)
+- [ ] Definition of Done: gate filled in and consistent with MUST criteria + NFR thresholds
 - [ ] Open questions: resolve any that can be decided now
-- [ ] Non-functional requirements: performance, security, accessibility captured
 - [ ] Dependencies: all prerequisites listed
 - [ ] Instrumentation: success metrics defined with events to track
 - [ ] Migration: rollback plan exists if changing existing behavior
 
 ## Phase 3: Create Issue
 
-- [ ] Run: `gh issue create --title "[Feature] Name" --label "type:feature"`
+- [ ] Run: `gh issue create --title "[Feature] Name" --label "type:feature" --body-file issue-body.md`
 - [ ] Link to PRD file in issue body
+- [ ] Include a checklist of every `[MUST]` criterion (with IDs) for build/test tracking
 - [ ] Note the issue number
 
 ## Phase 4: Handoff
@@ -50,6 +58,7 @@ Quick reference for the feature PRD workflow.
 ## Acceptance Criteria Rules
 
 - Numbered list (not checkboxes)
+- Lead with a stable ID (`AC-n.m`), then the priority tag
 - Yes/no verifiable statements
 - Tagged with `[MUST]` / `[SHOULD]` / `[COULD]` priority
 - Focus on *what*, not *how*


### PR DESCRIPTION
## Summary

Strengthens the `writing-feature-prds` skill so its PRD output is robust for an agentic coding agent that **plans, builds, and tests** from it — and so every statement (functional *and* non-functional) is testable and trackable in GitHub.

## Changes

**`SKILL.md` + `references/workflow-checklist.md`:**
- **Stable requirement IDs** — `US-n` (stories), `AC-n.m` / `AC-G.n` (criteria), `NFR-n`, `ERR-n`, with a no-renumber stability rule. Auto-assigned by the skill, so PM/business authors never hand-maintain them.
- **Testable NFRs** — rewritten as `[MUST]`/`[SHOULD]` statements with concrete thresholds (no more vague prose like "fast").
- **Error states** — gain `ID` + `Priority` columns; each row is a testable expectation.
- **Verification ↔ criteria coverage** — each verification step is annotated with the criteria IDs it covers, plus a rule that every `[MUST]` must be covered by a step.
- **Data & Validation** (new, optional) — fields, types, required status, rules, state transitions for data-bearing features.
- **Definition of Done** (new) — a completion gate (MUST criteria pass, build green, NFR thresholds measured, instrumentation live).
- **GitHub issue** — body becomes a checklist of every `[MUST]` criterion (via `--body-file`) for build/test tracking.
- Phase 1 questions and Phase 2 stress-test extended accordingly.

**Example PRDs** (`examples/client-onboarding-tracker/`) — both converted to the new format and verified to satisfy the `[MUST]` coverage rule.

## Verification

- `npm run build` ✓ (194 pages, no errors)
- Mechanical coverage check: every `[MUST]` criterion in both examples is covered by a verification step ✓ (caught and fixed gaps during review)
- No leftover old-format artifacts; no duplicate IDs; section ordering consistent ✓
- Plugin bumped `5.0.0 → 5.0.1` (PATCH, existing-skill update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)