### PR TITLE
Design skill: reusability, naming, and robustness hardening (spec 2.4, plugin v6.0.3)

### DIFF
--- a/plugins/handsonai/.claude-plugin/plugin.json
+++ b/plugins/handsonai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "handsonai",
   "description": "Everything you need to design, build, and document AI workflows. The AI Workflow Framework as executable Claude Code skills, plus an AI registry and feature-spec toolkit.",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "author": {
     "name": "James Gray"
   },

--- a/plugins/handsonai/skills/build/SKILL.md
+++ b/plugins/handsonai/skills/build/SKILL.md
@@ -33,7 +33,8 @@ Read the workflow's manifest (`outputs/[workflow-name]/workflow.yaml`) to locate
 Confirm you've loaded both by summarizing: workflow name, orchestration mechanism, involvement mode, packaging, counts (steps, skills, agents, integrations), and that the Workflow Requirements was loaded.
 
 **Spec version compatibility:**
-- `spec_version: 2.3` (current) → current format; mechanism vocabulary is `Prompt | Skill-Powered Workflow | Agent`; proceed.
+- `spec_version: 2.4` (current) → current format; mechanism vocabulary is `Prompt | Skill-Powered Workflow | Agent`; agents carry a Failure Modes field; proceed.
+- `spec_version: 2.3` → same structure minus the agent Failure Modes field — treat it as empty and derive error handling from the agent's Constraints plus the Workflow Requirements' fallback behavior; proceed.
 - `spec_version: 2.2` → same structure, but the middle mechanism is named by its legacy value `Skill-Powered Prompt` — treat it as `Skill-Powered Workflow` everywhere; proceed.
 - `spec_version: 2.1` → same structure minus Safety & Permissions and using legacy flat paths; proceed, and apply the safety defaults from Step 5's write-scope pre-flight in place of the missing section.
 - `spec_version: 2.0` → older format without layer grouping or Orchestrator Outline; proceed (Build's fallback derives the orchestrator from Workflow Requirements directly).
@@ -282,7 +283,7 @@ If playbook platform guides are available locally (e.g., `docs/platforms/claude/
   0. Verify the matched skill is actually invocable in this session (it appears in the available-skills list or its SKILL.md resolves on disk). If it isn't, say so and fall back to inline generation for this block — don't attempt an invocation that will fail.
   1. Invoke it via the Skill tool, passing the building block's full spec from the Design Spec:
      - **For skills (S1, S2, …):** all 12 fields from the Skill Candidates entry — ID, Name, Description, Purpose, Covers Steps/Domains, Inputs, Outputs, Decision Logic, Failure Modes, Required Tools, Depends On, Stateful?
-     - **For agents (A1, A2, …):** all 13 fields from the Agent Configuration entry — ID, Name, Description, Mission, Responsibilities, Output Format, Tone & Style, Constraints, Model, Memory Scope, Tools, Skills, Trigger Examples. If multi-agent, also pass the relevant Handoff Contracts and the Orchestration Pattern.
+     - **For agents (A1, A2, …):** all 14 fields from the Agent Configuration entry — ID, Name, Description, Mission, Responsibilities, Output Format, Tone & Style, Constraints, Failure Modes, Model, Memory Scope, Tools, Skills, Trigger Examples. Map Failure Modes into the generated agent body as an error-handling section (absent in specs ≤ 2.3 — treat as empty). If multi-agent, also pass the relevant Handoff Contracts and the Orchestration Pattern.
      - The artifact format requirements resolved in Step 3.6 (or the fallback reference if Step 3.6 did not resolve a format)
      - Whether platform-specific extensions should be applied (based on Architecture Decisions and Packaging)
      - This context: "This building block comes from an approved Design Spec (AI Workflow Framework, Step 3 Design). The intent, name, description, inputs, outputs, decision logic, and failure modes are already defined. Use this as your starting context."

--- a/plugins/handsonai/skills/design/SKILL.md
+++ b/plugins/handsonai/skills/design/SKILL.md
@@ -123,6 +123,7 @@ Present a single confirmation block:
 - No-code platform + no built-in connectors → cap at Skill-Powered Workflow
 - Scheduled trigger + platform doesn't support unattended runs → flag infrastructure needed
 - State which extracted facts influenced the autonomy assessment and orchestration mechanism recommendation
+- **Capability check:** when a design decision depends on a platform capability (agent files, skills, memory, scheduled/unattended runs), check the platform's entry in the cached registry — the presence or absence of capability keys (`agent`, `skill`, `memory`, `project`) signals support. If a needed key is absent or you're uncertain, do a single targeted web check **now** rather than shipping a spec Build can't honor; record it in Deferred to Build only if genuinely deferrable.
 
 **Packaging is determined later, in Step 5.** Once the mechanism is selected, Step 5 proposes a Packaging value based on platform and mechanism (e.g., single skill → Standalone Skill; agent + skills on ChatGPT → Workspace Agent). Do not ask about Packaging during Step 3 — it depends on Step 5's mechanism decision.
 
@@ -182,11 +183,7 @@ This question is **always asked or confirmed explicitly in plain language** — 
 >
 > Which shape works for you?"
 
-Use `AskUserQuestion` with three options (recommended first, marked "(Recommended)"). Option labels:
-
-- **Reusable skill** — Saved instructions you trigger by name. Best for workflows you'll run repeatedly.
-- **Step-by-step prompt** — Copy-paste instructions you run yourself. Best for one-off workflows, no setup.
-- **Agent** — AI drives the whole thing end-to-end. Best when it should run on a schedule or make decisions on its own.
+Use `AskUserQuestion` with three options whose labels mirror the three shapes above (one-line versions of the same descriptions), recommended option first and marked "(Recommended)".
 
 If the user pushes back, discuss in plain language — never drop into the internal jargon (`Prompt` / `Skill-Powered Workflow` / `Agent`) when talking to them.
 
@@ -360,16 +357,18 @@ For goal-driven: `**[Tool] access needed (Domains: X, Y):**`
 > **[Tool] access needed ([Steps N, M / Domains: X, Y]):**
 >
 > **Curated (recommended):**
-> | Block | Option | Trade-off |
-> |-------|--------|-----------|
-> | MCP | [Name] MCP | Easiest — plug-and-play |
-> | CLI | [Name] CLI | Good for automation/scripting |
+> | Block | Option | Source URL | Trade-off |
+> |-------|--------|-----------|-----------|
+> | MCP | [Name] MCP | [URL] | Easiest — plug-and-play |
+> | CLI | [Name] CLI | [URL] | Good for automation/scripting |
 >
 > **Also available:**
-> | Block | Option | Trade-off |
-> |-------|--------|-----------|
-> | API | [Name] REST API | Most flexible, more code |
-> | SDK | [Name] Client Library | Best DX for code-heavy builds |
+> | Block | Option | Source URL | Trade-off |
+> |-------|--------|-----------|-----------|
+> | API | [Name] REST API | [URL] | Most flexible, more code |
+> | SDK | [Name] Client Library | [URL] | Best DX for code-heavy builds |
+>
+> (Capture the Source URL during discovery — the spec's Integration Options section requires at least one per tool; never backfill or fabricate URLs at assembly time.)
 >
 > *Recommendation: [block] for [rationale]*
 
@@ -394,7 +393,7 @@ For every step classified as needing a **Skill** in Step 6, search for existing 
 
 **Search order:**
 
-1. **Local skills** — Search the user's own `.claude/skills/`, plugin skills directories, and any project-level skill directories. These are pre-vetted and can be recommended directly.
+1. **Local skills and prior workflows** — Search the user's own `.claude/skills/`, plugin skills directories, and any project-level skill directories. Also read the workspace `REGISTRY.md` (if present) and the Skill Candidates sections of prior workflows' `outputs/*/design-spec.md` — skills the user built for earlier workflows are prime reuse candidates. All of these are pre-vetted and can be recommended directly.
 
 2. **External registries** — Read the `skill-registries` list from the platform registry (same local-first resolution and session cache as Integration Discovery above: plugin-local copy at `${CLAUDE_PLUGIN_ROOT}/registries/platform-registry.json` first, remote fetch for standalone installs).
 
@@ -435,6 +434,7 @@ For each step (or capability domain, for goal-driven workflows) that needs a ski
 > | Source | Skill | Status |
 > |--------|-------|--------|
 > | Local | `coaching-prep-notes-assembly` (your plugin) | Pre-vetted — include? |
+> | Registry | `summarizing-transcripts` (from your `weekly-review` workflow) | Pre-vetted — include? |
 > | skills.sh | `markdown-document-builder` by @community | Requires review — [link] |
 > | Web search | `doc-formatter` on GitHub | Requires review — [link] |
 > | None found | Build new | Fallback |
@@ -449,11 +449,15 @@ For steps where Skill Discovery (Step 6b) found an existing skill, skip to the n
 
 This step only applies to steps tagged **"build new"** in Step 6b. Tag those steps that should become skills.
 
-**Draft, then confirm — do not interview field-by-field.** You have already read the Workflow Requirements and run the whole design conversation; that contains almost everything these fields need. For each skill candidate, **draft all 12 fields yourself**, present the completed blueprint for correction ("Here's my draft of the [name] skill — what's wrong or missing?"), and ask direct questions only for fields you genuinely cannot infer (typically Decision Logic details, Failure Mode preferences, or constraints the user hasn't voiced). Never walk a user through 12 questions per skill. The 12 fields (field-by-field format in `references/spec-template.md`):
+**Draft, then confirm — do not interview field-by-field.** You have already read the Workflow Requirements and run the whole design conversation; that contains almost everything these fields need. For each skill candidate, **draft all 12 fields yourself**, present the completed blueprint for correction ("Here's my draft of the [name] skill — what's wrong or missing?"), and ask direct questions only for fields you genuinely cannot infer (typically Decision Logic details, Failure Mode preferences, or constraints the user hasn't voiced). Never walk a user through 12 questions per skill.
+
+**Scope each skill as a reusable capability, not a workflow fragment.** Name it for the capability in gerund or verb-object form (`summarizing-transcripts`, `formatting-prep-notes` — never `step-3-helper` or `[workflow-name]-part-2`); avoid vague names (`helper`, `utils`, `documents`) and the reserved words `anthropic`/`claude`. Write Inputs as parameters, not hardcoded references to this workflow's files, so the skill still works when invoked outside this workflow. Check that no name collides with a skill found in Step 6b — a duplicate name silently shadows the existing one. Only the orchestrator skill carries the workflow's name; every component skill is capability-named.
+
+The 12 fields (field-by-field format in `references/spec-template.md`):
 
 - **ID** — stable skill ID (S1, S2, …)
-- **Name** — lowercase-hyphenated, ≤64 chars, no consecutive hyphens; matches the skill directory name
-- **Description** — ≤1024 chars, MUST start with "This skill should be used when..." — verbatim text for the SKILL.md frontmatter; drives auto-activation
+- **Name** — lowercase-hyphenated, ≤64 chars, no consecutive hyphens; matches the skill directory name; capability-named per the scoping rule above
+- **Description** — ≤1024 chars, MUST start with "This skill should be used when..." — verbatim text for the SKILL.md frontmatter; drives auto-activation. Write in **third person** (never "I" or "you" as the actor), and name the **concrete trigger contexts and keywords** a user would actually say (tool names, file types, task verbs) plus what the skill does — a vague description kills auto-activation. Where confusion with a sibling skill is likely, add a "Do not use for…" clause
 - **Purpose** — one-sentence internal summary for the spec reader
 - **Covers Steps / Domains** — which step IDs (or capability domains) this skill spans
 - **Inputs** — what the skill receives
@@ -464,27 +468,30 @@ This step only applies to steps tagged **"build new"** in Step 6b. Tag those ste
 - **Depends On** — other skill IDs (S2, S3) or artifacts that must exist first, or "None"
 - **Stateful?** — Yes / No, does the skill maintain state across invocations? Drives Memory building-block decisions.
 
+**Consolidation sweep (before presenting blueprints — no user question):** sweep the candidate list once. **Merge** candidates that are the same capability applied at different steps into one skill with multiple Covers Steps entries (the step-decomposed mirror of the goal-driven altitude rule). **Split** any candidate whose Decision Logic spans two unrelated capabilities — each skill should excel at one thing. Note each merge/split in one line when presenting the blueprints.
+
 #### Step 8 — Agent Configuration
 
-(When orchestration mechanism is Agent.) **Same draft-then-confirm approach as Step 7:** draft all 13 fields for each agent from the requirements and conversation, present the completed configuration for correction, and interview only for what you cannot infer (typically Tone & Style and Constraints). The 13 fields (field-by-field format in `references/spec-template.md`):
+(When orchestration mechanism is Agent.) **Same draft-then-confirm approach as Step 7:** draft all 14 fields for each agent from the requirements and conversation, present the completed configuration for correction, and interview only for what you cannot infer (typically Tone & Style and Constraints). The 14 fields (field-by-field format in `references/spec-template.md`):
 
 | Field | What to specify |
 |-----------|----------------|
 | **ID** | Stable agent ID (A1, A2, …) |
 | **Name** | Unique agent name (lowercase-hyphenated, matches the agent filename without extension) |
-| **Description** | ≤1024 chars, MUST start with "Use this agent when..." — verbatim text for the agent file frontmatter; drives invocation |
+| **Description** | ≤1024 chars, MUST start with "Use this agent when..." — verbatim text for the agent file frontmatter; drives invocation. Third person; name the concrete trigger contexts and keywords that should route work to this agent |
 | **Mission** | One-sentence primary purpose |
 | **Responsibilities** | Bulleted list of what the agent does once invoked |
-| **Output Format** | Structured description of what the agent's output should look like |
+| **Output Format** | Structured description of what the agent's output should look like. For workers dispatched by an orchestrator, this is the **handoff contract** — prefer a structured summary over free prose |
 | **Tone & Style** | Voice and register (e.g., "concise, technical, no hedging") |
-| **Constraints** | Must-not-dos, scope boundaries, source restrictions |
+| **Constraints** | Must-not-dos, scope boundaries, source restrictions. For Autonomous agents, include a bound on iterations/actions per run (Build maps it to `maxTurns` or the platform equivalent) |
+| **Failure Modes** | Condition → action, one per line — including what the agent returns to its orchestrator when it cannot complete (mirrors the skill blueprint field) |
 | **Model** | Capability tier: reasoning-heavy / fast / vision |
-| **Memory Scope** | user / project / local / none — cross-session learning scope. **Heuristic:** default `none`; choose memory only when the workflow genuinely benefits from cross-run state (tracking an entity over time, learned user preferences). **Avoid memory for research/freshness workflows** — stale recall becomes a liability when each run should re-gather current data. When the "learning" should be human-visible/editable, prefer a curated **context file** over opaque agent memory. |
-| **Tools** | External tools the agent needs (reference Integration Options entries by tool name) |
+| **Memory Scope** | user / project / local / none — cross-session learning scope. **Heuristic:** default `none`; choose memory only when the workflow genuinely benefits from cross-run state (tracking an entity over time, learned user preferences). **Avoid memory for research/freshness workflows** — stale recall becomes a liability when each run should re-gather current data. When the "learning" should be human-visible/editable, prefer a curated **context file** over opaque agent memory. If the platform's registry entry has no `memory` capability key, choose `none` or a context file. |
+| **Tools** | External tools the agent needs (reference Integration Options entries by tool name). **Least privilege:** list only tools the Responsibilities require — a read/analyze agent gets no write tools — and stay consistent with the Step 5b write-access findings |
 | **Skills** | Skill IDs the agent has access to (S1, S2, …) |
 | **Trigger Examples** | 2-3 structured examples (context → user message → expected behavior → invocation) — Build uses these verbatim as `<example>` blocks in the description |
 
-The build skill maps these to platform-specific fields at runtime (e.g., "reasoning-heavy" → `opus` on Claude Code, trigger examples → `<example>` blocks).
+The build skill maps these to platform-specific fields at runtime (e.g., "reasoning-heavy" → the platform's current top reasoning model, which Build resolves via web search at generation time; trigger examples → `<example>` blocks).
 
 For multi-agent: orchestration pattern, agent handoffs, human review gates — see the Multi-Agent Configuration section in `references/spec-template.md`.
 
@@ -520,7 +527,7 @@ Assemble the full Design Spec **content** following the template — but **do no
 
 **This is a hard gate. Do not write the spec file or proceed without explicit approval.**
 
-Present a summary of the assembled (not-yet-written) Design Spec:
+Present a summary of the assembled (not-yet-written) Design Spec. When the spec defines more than 3 component blueprints (skills + agents), open the summary with a one-line-per-blueprint recap (ID, name, purpose) so the user sees the full component inventory before approving:
 
 > "Here's the Design Spec summary:
 >

--- a/plugins/handsonai/skills/design/references/goal-driven-path.md
+++ b/plugins/handsonai/skills/design/references/goal-driven-path.md
@@ -29,7 +29,7 @@ Same Integration Discovery and Skill Discovery processes apply, operating on cap
 
 **Step 7 (Skill Candidates):** Same field structure — identify which capability domains should become skills. Each skill candidate uses the full 12-field Skill Candidate block (with Covers Domains in place of Covers Steps).
 
-**Step 8 (Agent Configuration):** This is usually the primary blueprint section. Agent Configuration documents the **sub-agent(s) the orchestrator dispatches** — the workers — using all 13 standard fields, drawing Description, Mission, Responsibilities, Output Format, and Constraints from the Workflow Requirements' Goal, Rules & Constraints, and Acceptance Criteria.
+**Step 8 (Agent Configuration):** This is usually the primary blueprint section. Agent Configuration documents the **sub-agent(s) the orchestrator dispatches** — the workers — using all 14 standard fields, drawing Description, Mission, Responsibilities, Output Format, and Constraints from the Workflow Requirements' Goal, Rules & Constraints, and Acceptance Criteria.
 
 **Mandatory-but-with-an-exception:** document at least one agent **whenever the design includes a sub-agent/agent artifact** (the common case). A valid goal-driven design on a primary-loop platform (Claude Code/Cowork) may have **zero sub-agents** — just orchestration logic (an orchestrator skill and/or `CLAUDE.md` run section) + skills. In that case record `agents: 0` in the frontmatter counts and document the orchestration logic in the Deployment Plan / Orchestrator notes instead — **do not invent a sub-agent to satisfy the field.** Never document the orchestrator (the primary loop) as an agent artifact.
 

--- a/plugins/handsonai/skills/design/references/self-test-checklist.md
+++ b/plugins/handsonai/skills/design/references/self-test-checklist.md
@@ -4,8 +4,10 @@ Run this checklist against the assembled Design Spec content **before** presenti
 
 ## Structure
 
-- [ ] **Frontmatter** is present with workflow, requirements_file, spec_version (`2.3`), definition_type, mechanism, involvement, platform, platform_mode, packaging, and counts
+- [ ] **Frontmatter** is present with workflow, requirements_file, spec_version (`2.4`), definition_type, mechanism, involvement, platform, platform_mode, packaging, and counts
+- [ ] Frontmatter `counts` match the body — `skills` = number of Skill Candidate entries, `agents` = number of Agent Configuration entries, `integrations` = number of Integration Options tools
 - [ ] **Source** section names the Workflow Requirements file path (`outputs/[workflow-name]/requirements.md`)
+- [ ] All mandatory template sections are present in template order (Execution Pattern, Architecture Decisions, Autonomy Spectrum Summary [or Autonomy Statement], Safety & Permissions, Integration Options, Model Recommendation, Decomposition table, Data Readiness Summary, Recommended Implementation Order, Prerequisites, Deployment Plan, Evaluation Inputs, Deferred to Build, Self-Test Summary — plus conditional sections per their rules)
 - [ ] `Architecture Decisions` table has Lens, Platform, Platform Mode, Orchestration, Involvement, Packaging, and Trigger rows
 - [ ] Every step in the decomposition table has separate Orchestration, Integration, Intelligence, and Build Output columns
 - [ ] Step IDs in the decomposition table match the Step IDs in the Workflow Requirements (Step 1, Step 2, …)
@@ -18,14 +20,16 @@ Run this checklist against the assembled Design Spec content **before** presenti
 
 - [ ] Every `New skill: SN` reference has a matching Skill Candidates entry with the SN ID
 - [ ] Every Skill Candidate has all 12 fields: ID, Name, Description, Purpose, Covers Steps, Inputs, Outputs, Decision Logic, Failure Modes, Required Tools, Depends On, Stateful?
-- [ ] Every Skill Candidate's Name conforms to format rules (lowercase-hyphen, ≤64 chars, no consecutive hyphens)
-- [ ] Every Skill Candidate's Description starts with "This skill should be used when..." and is ≤1024 chars
+- [ ] Every Skill Candidate's Name conforms to format rules (lowercase-hyphen, ≤64 chars, no consecutive hyphens) and is capability-named, not workflow-coupled — except the orchestrator skill, which takes the workflow name
+- [ ] Every Skill Candidate's Description starts with "This skill should be used when...", is ≤1024 chars, is third-person, and names at least two concrete trigger keywords/contexts
+- [ ] No two Skill Candidates describe the same capability at different steps (parallel applications are one skill with multiple Covers Steps entries)
 
 ## Agent Configuration
 
 - [ ] Every `New agent: AN` reference has a matching Agent Configuration entry with the AN ID
-- [ ] Every Agent Configuration has all 13 fields: ID, Name, Description, Mission, Responsibilities, Output Format, Tone & Style, Constraints, Model, Memory Scope, Tools, Skills, Trigger Examples
-- [ ] Every Agent Configuration's Description starts with "Use this agent when..." and is ≤1024 chars
+- [ ] Every Agent Configuration has all 14 fields: ID, Name, Description, Mission, Responsibilities, Output Format, Tone & Style, Constraints, Failure Modes, Model, Memory Scope, Tools, Skills, Trigger Examples
+- [ ] Every Agent Configuration's Description starts with "Use this agent when...", is ≤1024 chars, is third-person, and names concrete trigger keywords/contexts
+- [ ] Every Agent Configuration's Tools list is consistent with Safety & Permissions (least privilege — no write tool on an agent whose Responsibilities are read-only)
 - [ ] If more than one agent is defined, Multi-Agent Configuration section is present with Orchestration Pattern, Coordinator, Handoff Contracts, and Aggregation Strategy
 
 ## Cross-references

--- a/plugins/handsonai/skills/design/references/spec-template.md
+++ b/plugins/handsonai/skills/design/references/spec-template.md
@@ -18,7 +18,7 @@ For **goal-driven** workflows, apply the template substitutions in `references/g
 ---
 workflow: [kebab-case name]
 requirements_file: outputs/[workflow-name]/requirements.md
-spec_version: 2.3
+spec_version: 2.4
 definition_type: Step-Decomposed | Goal-Driven
 mechanism: Prompt | Skill-Powered Workflow | Agent
 involvement: Augmented | Automated
@@ -71,7 +71,7 @@ The spec is organized into three layers that build on each other:
 **Packaging values:**
 - **Plugin** — Multiple related artifacts shipped together (e.g., handsonai-plugins marketplace plugin, set of `.claude/` files distributed via marketplace).
 - **Standalone Skill** — A single skill, uploaded directly (e.g., zip uploaded to Claude.ai, single SKILL.md in `.claude/skills/`, Codex skill in `.agents/skills/`, ChatGPT skill).
-- **Workspace Agent** — A ChatGPT Workspace Agent that bundles orchestration + skills + tools as a unit. (Custom GPTs are deprecated; Workspace Agents are the current ChatGPT primitive.)
+- **Workspace Agent** — A ChatGPT Workspace Agent that bundles orchestration + skills + tools as a unit. (Build re-verifies the platform's current primitive at generation time.)
 - **Loose Files** — Individual files in a project directory, no distribution layer.
 
 ## Autonomy Spectrum Summary
@@ -124,12 +124,7 @@ For each tool identified in the Decomposition table (or Capability Domain Mappin
 **Per-step overrides** (optional):
 - Steps N, M: [different capability] — [rationale]
 
-**Per-platform mapping** (Build resolves at generation time):
-- Claude Code / Claude.ai / Cowork: `opus` (reasoning-heavy) / `sonnet` (balanced) / `haiku` (fast)
-- ChatGPT / Codex: `gpt-5` or `o3` (reasoning-heavy) / `gpt-4o` (balanced) / `gpt-4o-mini` (fast)
-- Gemini: `gemini-2.5-pro` (reasoning-heavy) / `gemini-2.5-flash` (fast)
-
-(These mappings are guidance; Build verifies current model names via web search before generating.)
+**Per-platform mapping:** resolved by Build at generation time — Build verifies the current model names for the chosen platform via web search. Record only capability tiers here (reasoning-heavy / balanced / fast / vision); never write specific model IDs into the spec, they go stale.
 
 ---
 
@@ -216,9 +211,9 @@ For each Build Output tagged `New skill: SN` above:
 | Field | Detail |
 |---|---|
 | **ID** | S1 |
-| **Name** | [lowercase-hyphenated, ≤64 chars, no consecutive hyphens; matches the skill directory name] |
-| **Description** | [≤1024 chars; MUST start with "This skill should be used when..." — this is the literal description that goes into the SKILL.md frontmatter and drives auto-activation on Claude.ai, Cowork, and code-mode platforms] |
-| **Purpose** | [one-sentence internal summary — for the Design Spec reader, not the skill description] |
+| **Name** | [lowercase-hyphenated, ≤64 chars, no consecutive hyphens; matches the skill directory name. Capability-named in gerund/verb-object form, not workflow-coupled (only the orchestrator skill takes the workflow name); no collision with skills found in Skill Discovery] |
+| **Description** | [≤1024 chars; MUST start with "This skill should be used when..." — this is the literal description that goes into the SKILL.md frontmatter and drives auto-activation on Claude.ai, Cowork, and code-mode platforms. Third person; names concrete trigger contexts/keywords (tool names, file types, task verbs) plus what the skill does] |
+| **Purpose** | [one-sentence internal summary — for the Design Spec reader, not the skill description. Note whether the skill is reusable beyond this workflow] |
 | **Covers Steps / Domains** | [list of Step IDs, or capability domain names for goal-driven] |
 | **Inputs** | [name — description, one per line; "type" is the expected user-provided value description, not a strict type system] |
 | **Outputs** | [what the skill produces] |
@@ -240,15 +235,16 @@ For each Build Output tagged `New agent: AN` above:
 |---|---|
 | **ID** | A1 |
 | **Name** | [lowercase-hyphenated, matches the agent filename without extension] |
-| **Description** | [≤1024 chars; MUST start with "Use this agent when..." — this is the literal description that goes into the agent file frontmatter and drives invocation. Include 2-3 `<example>` blocks (see Trigger Examples field below) inline at the end.] |
+| **Description** | [≤1024 chars; MUST start with "Use this agent when..." — this is the literal description that goes into the agent file frontmatter and drives invocation. Third person; names concrete trigger contexts/keywords. Include 2-3 `<example>` blocks (see Trigger Examples field below) inline at the end.] |
 | **Mission** | [one-sentence primary purpose] |
 | **Responsibilities** | [bulleted list of what the agent does once invoked] |
-| **Output Format** | [structured description of what the agent's output should look like — sections, fields, format constraints] |
+| **Output Format** | [structured description of what the agent's output should look like — sections, fields, format constraints. For orchestrator-dispatched workers this is the handoff contract: prefer a structured summary over free prose] |
 | **Tone & Style** | [voice/register, e.g., "concise, technical, no hedging"] |
-| **Constraints** | [must-not-dos, scope boundaries, source restrictions] |
+| **Constraints** | [must-not-dos, scope boundaries, source restrictions. For Autonomous agents, include an iterations/actions-per-run bound — Build maps it to `maxTurns` or the platform equivalent] |
+| **Failure Modes** | [condition → action, one per line — including what the agent returns to its orchestrator when it cannot complete] |
 | **Model** | [capability tier: reasoning-heavy / fast / vision] |
-| **Memory Scope** | user / project / local / none — controls cross-session learning (Claude Code agent format supports this; on other platforms, document the equivalent). **Heuristic:** default `none`; use memory only for genuine cross-run state (tracking an entity over time, learned user preferences); **avoid it for research/freshness workflows** where stale recall misleads; when the "learning" should be human-visible/editable, prefer a curated **context file** over opaque memory. |
-| **Tools** | [external tools needed — reference Integration Options entries by tool name] |
+| **Memory Scope** | user / project / local / none — controls cross-session learning (Claude Code agent format supports this; on other platforms, document the equivalent). **Heuristic:** default `none`; use memory only for genuine cross-run state (tracking an entity over time, learned user preferences); **avoid it for research/freshness workflows** where stale recall misleads; when the "learning" should be human-visible/editable, prefer a curated **context file** over opaque memory. If the platform registry entry has no `memory` capability key, choose `none` or a context file. |
+| **Tools** | [external tools needed — reference Integration Options entries by tool name. **Least privilege:** only tools the Responsibilities require (read/analyze agents get no write tools), consistent with the Safety & Permissions write-access findings] |
 | **Skills** | [Skill IDs the agent has access to — S1, S2, …] |
 | **Trigger Examples** | [2-3 structured examples, each: context → user message → expected agent behavior → invocation. Build uses these verbatim to construct the `<example>` blocks in the agent's description field.] |
 
@@ -264,7 +260,7 @@ For each Build Output tagged `New agent: AN` above:
 
 | From → To | Trigger | Data Passed | Format |
 |---|---|---|---|
-| A1 → A2 | [when A1 finishes / when condition X] | [what data passes] | [format / schema description] |
+| A1 → A2 | [when A1 finishes / when condition X] | [what data passes] | [format / schema description — must match the sending agent's Output Format field] |
 
 **Aggregation Strategy:** [How results combine if parallel or network — last-writer-wins, merge, supervisor-decides, etc. Write "N/A" for Pipeline.]
 

--- a/src/content/docs/ai-workflow-framework/design.md
+++ b/src/content/docs/ai-workflow-framework/design.md
@@ -122,7 +122,7 @@ How the artifacts ship together:
 
 ### Model Recommendation
 
-A capability tier (reasoning-heavy / fast / vision) with per-step overrides if needed. The spec includes a per-platform mapping (Claude opus/sonnet/haiku, ChatGPT gpt-5/gpt-4o/gpt-4o-mini, Gemini 2.5-pro/2.5-flash) so Build knows which concrete model to use on the target platform.
+A capability tier (reasoning-heavy / balanced / fast / vision) with per-step overrides if needed. The spec records only the tier — Build resolves the concrete model name for the target platform via web search at generation time, so specs never carry model IDs that go stale.
 
 ### Integration Options
 
@@ -191,23 +191,24 @@ For each step tagged `New skill: SN`:
 
 | Field | Purpose |
 |---|---|
-| ID, Name, Description | Identity. Name must be lowercase-hyphenated, ≤64 chars. Description must start with "This skill should be used when..." and be ≤1024 chars — this is the verbatim text that goes into the SKILL.md frontmatter and drives auto-activation. |
+| ID, Name, Description | Identity. Name must be lowercase-hyphenated, ≤64 chars, and capability-named (gerund/verb-object like `summarizing-transcripts`, never workflow-coupled — only the orchestrator skill takes the workflow name). Description must start with "This skill should be used when...", be ≤1024 chars, be written in third person, and name concrete trigger keywords — this is the verbatim text that goes into the SKILL.md frontmatter and drives auto-activation. |
 | Purpose, Covers Steps/Domains | Internal context for spec readers |
 | Inputs, Outputs | The skill's contract |
 | Decision Logic, Failure Modes | What the skill does and how it handles edge cases |
 | Required Tools, Depends On | Runtime dependencies on tools and other skills |
 | Stateful? | Memory building-block flag |
 
-### Agent Configuration (13 fields, mandatory when mechanism = Agent)
+### Agent Configuration (14 fields, mandatory when mechanism = Agent)
 
 For each step tagged `New agent: AN`:
 
 | Field | Purpose |
 |---|---|
 | ID, Name, Description | Identity. Description must start with "Use this agent when..." and is the verbatim text for the agent file frontmatter. |
-| Mission, Responsibilities, Output Format, Tone & Style, Constraints | The agent's behavior — decomposed into structured sub-fields, not jammed into a single "Instructions" cell |
+| Mission, Responsibilities, Output Format, Tone & Style, Constraints | The agent's behavior — decomposed into structured sub-fields, not jammed into a single "Instructions" cell. For orchestrator-dispatched workers, Output Format is the handoff contract; for Autonomous agents, Constraints includes an iterations-per-run bound. |
+| Failure Modes | Condition → action, one per line — including what the agent returns to its orchestrator when it cannot complete (mirrors the skill blueprint field) |
 | Model, Memory Scope | Capability and persistence. Memory defaults to `none`; use it only for genuine cross-run state (tracking an entity, learned preferences), and avoid it for research/freshness workflows where stale recall misleads — prefer a curated context file when the learning should stay human-visible. |
-| Tools, Skills | Cross-references to Integration Options entries and Skill IDs |
+| Tools, Skills | Cross-references to Integration Options entries and Skill IDs. Tools follow least privilege — only what the Responsibilities require. |
 | Trigger Examples | 2-3 structured examples (context → user message → expected behavior → invocation) Build uses verbatim to construct `<example>` blocks in the agent's description |
 
 ### Multi-Agent Configuration
@@ -312,7 +313,7 @@ The **Design Spec** is organized into the three layers above, plus cross-layer s
 
 **Layer 2 — Decomposition sections:** Step-by-Step Decomposition (or Capability Domain Mapping for goal-driven), Orchestrator Prompt Outline (when mechanism is Prompt or Skill-Powered Workflow), Data Readiness Summary, Recommended Implementation Order.
 
-**Layer 3 — Component Blueprint sections:** Skill Candidates (12 fields each), Agent Configuration (13 fields each; mandatory for goal-driven), Multi-Agent Configuration (when applicable), Prerequisites, Deployment Plan.
+**Layer 3 — Component Blueprint sections:** Skill Candidates (12 fields each), Agent Configuration (14 fields each; mandatory for goal-driven), Multi-Agent Configuration (when applicable), Prerequisites, Deployment Plan.
 
 **Cross-layer sections:** Evaluation Inputs (pointer), Deferred to Build, Stakeholders (optional), Self-Test Summary (verification results).
 

--- a/src/content/docs/ai-workflow-framework/examples/worked-example.md
+++ b/src/content/docs/ai-workflow-framework/examples/worked-example.md
@@ -261,7 +261,7 @@ The complete Design Spec:
 ---
 workflow: weekly-status-report
 requirements_file: outputs/weekly-status-report/requirements.md
-spec_version: 2.3
+spec_version: 2.4
 definition_type: Step-Decomposed
 mechanism: Skill-Powered Workflow
 involvement: Augmented


### PR DESCRIPTION
## Summary

Comprehensive review of the Design skill (Step 3) focused on how it creates skills and agents — grounded in fresh research on Anthropic skill-authoring best practices, the agentskills.io spec, Claude Code subagent guidance, and 2025–26 multi-agent orchestration patterns.

**Confirmed strong (unchanged):** requirements.md as canonical source with verified headings; two hard approval gates + draft-then-confirm blueprints; Integration/Skill Discovery research chains with web-search precedence; orchestrator-vs-worker guidance.

**Fixed in this PR:**
- **Reuse across workflows** — Skill Discovery now reads `REGISTRY.md` and prior workflows' design specs (previously Design wrote the registry but never read it)
- **Reusable-capability scoping** — new skills get gerund/verb-object capability names (never workflow-coupled), parameterized inputs, and a collision check; only the orchestrator skill takes the workflow name
- **Description quality** — third person + concrete trigger keywords required (the things that actually drive auto-activation)
- **Agent blueprint hardening** — new **Failure Modes** field (14 fields, `spec_version: 2.4`), least-privilege Tools tied to the Safety & Permissions pass, iteration bound for Autonomous agents, Output Format framed as the orchestrator handoff contract
- **Consolidation sweep** — merge/split pass over skill candidates before blueprints are presented
- **Platform capability check** — registry capability keys consulted before shipping capability-dependent decisions
- **Checklist hardening** — section-presence and frontmatter-counts validation; Source URL captured during discovery (was required by the template but missing from the discovery presentation)
- **No hard-coded model IDs** — spec template and public docs now record capability tiers only; Build resolves current model names via web search

**Build coordination:** Build accepts `spec_version: 2.4` and tolerates 2.3 specs (agent Failure Modes treated as empty). Zero new user-facing questions; the two hard gates stay at two.

Plugin bumped to v6.0.3 (patch). After merge: rebuild skill ZIPs and release `handsonai-plugins` v6.0.3 (push that repo last, per sync protocol).

## Verification
- `npm run build` passes (195 pages)
- Consistency sweep: all field counts (12/14) and `spec_version` literals agree across design SKILL.md, the three reference files, build SKILL.md, and public docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)