### PR TITLE
manifest-resolution: process edge moves to the curated # Workflows list

### DIFF
--- a/.claude/agent-memory/openai-news-digest/MEMORY.md
+++ b/.claude/agent-memory/openai-news-digest/MEMORY.md
@@ -1,0 +1,3 @@
+- [OpenAI source URLs](reference_sources.md) — canonical sources, fetch workarounds, reliable secondary press for OpenAI research
+- [OpenAI model naming conventions](reference_model_naming.md) — GPT-5.x decimal versioning, current models, retirement patterns as of June 2026
+- [Digest run history](project_digest_history.md) — log of completed digests with items covered, for de-duplication across runs

--- a/.claude/agent-memory/openai-news-digest/project_digest_history.md
+++ b/.claude/agent-memory/openai-news-digest/project_digest_history.md
@@ -1,0 +1,41 @@
+---
+name: digest-history
+description: Log of completed OpenAI News Digest runs — dates covered and key items — to avoid duplication across runs
+metadata:
+  type: project
+---
+
+## Digest: June 9–16, 2026
+
+**Completed:** 2026-06-16
+
+### Items covered (to de-duplicate in future runs)
+
+**Models**
+- GPT-5.5 Instant: default ChatGPT model (released ~May 2026; personalization improvements rolled to Go & Free on June 9)
+- GPT-5.2 models removed from ChatGPT on June 12, 2026
+
+**API/Platform**
+- API Changelog June 9: web search returns image results (Responses API)
+- API Changelog June 5: platform dashboard navigation redesign
+- API Changelog June 4: moderation scoring added to Responses API + Chat Completions API
+- API Changelog June 3: Agent Builder, Evals platform, and reusable prompts deprecated (shutdown Nov 30, 2026)
+- API Changelog June 2: container session billing changed to per-minute with 5-min minimum
+- API Changelog June 1: OpenAI models + GPT-5.4/5.5 available on Amazon Bedrock Responses API
+- `return_token_budget` feature added to Responses API web search tool
+- Older GPT-5/o3 API snapshots notified for December 11, 2026 removal (June 11)
+
+**Products (ChatGPT)**
+- "Dreaming" memory system launched June 4 (Plus/Pro first; free rollout underway)
+- Academy new courses announced June 14: AI Foundations, Applied AI Foundations, Agents and Workflows
+
+**Partnerships/Business**
+- Oracle Cloud: OpenAI models + Codex accessible via Oracle Universal Credits (announced June 11)
+- Ona acquisition announced June 11 (not closed); Ona = cloud execution platform for long-running agents; strengthens Codex
+- DOE MOU deepened (Genesis Mission partnership; AI on national lab supercomputers)
+
+**Safety/Policy**
+- Nothing significant in this window
+
+**Company**
+- S-1 confidential filing with SEC submitted June 8, 2026; targeting ~$1T valuation; Goldman Sachs + Morgan Stanley as underwriters; no firm timing given

--- a/.claude/agent-memory/openai-news-digest/reference_model_naming.md
+++ b/.claude/agent-memory/openai-news-digest/reference_model_naming.md
@@ -1,0 +1,26 @@
+---
+name: openai-model-naming
+description: OpenAI model versioning conventions and naming patterns as observed through mid-2026
+metadata:
+  type: reference
+---
+
+## Model family naming (as of June 2026)
+
+OpenAI has moved to a decimal versioning scheme for GPT-5 variants:
+- GPT-5 → GPT-5.1 → GPT-5.2 → GPT-5.3 → GPT-5.4 → GPT-5.5 (current family as of June 2026)
+- Each version has sub-variants: `Instant` (fast/default), `Thinking` (reasoning), `Pro` (most capable)
+- Retirements follow a pattern: older version deprecated from ChatGPT first, then API deprecation notice, then API removal ~6 months later
+
+## Current state (June 2026)
+- **GPT-5.5** is the current generation (released April 23, 2026); GPT-5.5 Instant is the default ChatGPT model
+- **GPT-5.2** was removed from ChatGPT on June 12, 2026; conversations migrated automatically to GPT-5.5 equivalents
+- **GPT-5.5 and o3 snapshots** notified for API deprecation June 11, 2026; API removal December 11, 2026
+- **GPT Image (older)** models: notified June 2, 2026; API removal December 1, 2026
+
+## Specialist models
+- **GPT-Rosalind**: life sciences specialist model (enhanced biological reasoning, genomics, medicinal chemistry)
+- **Codex**: AI coding agent product (now with 5M+ weekly users as of June 2026)
+
+## Reasoning models
+- **o3**, **o4-mini** are the current reasoning series (alongside GPT-5+ with "Thinking" mode)

--- a/.claude/agent-memory/openai-news-digest/reference_sources.md
+++ b/.claude/agent-memory/openai-news-digest/reference_sources.md
@@ -1,0 +1,26 @@
+---
+name: openai-sources
+description: Canonical OpenAI source URLs that are reliable for news gathering, changelog data, and product announcements
+metadata:
+  type: reference
+---
+
+Primary OpenAI sources (checked in priority order):
+
+- **OpenAI News hub**: https://openai.com/news/ — product and company announcements; often returns HTTP 403 to WebFetch so use WebSearch with `site:openai.com` instead
+- **API Changelog**: https://developers.openai.com/api/docs/changelog — fetchable directly via WebFetch; reliably returns structured changelog entries with dates; best source for API/platform changes
+- **ChatGPT Release Notes**: https://help.openai.com/en/articles/6825453-chatgpt-release-notes — returns 403 to WebFetch; use WebSearch corroboration
+- **Model Release Notes**: https://help.openai.com/en/articles/9624314-model-release-notes — same 403 issue; use WebSearch
+- **OpenAI Developer Community**: https://community.openai.com — useful for deprecation notices (e.g., Agent Builder shutdown)
+- **OpenAI Official X/Twitter**: corroborated via secondary press search
+
+Reliable secondary sources confirmed in June 2026 research:
+- TechCrunch (techcrunch.com) — model releases
+- Fortune (fortune.com) — company/IPO news
+- CNBC (cnbc.com) — acquisitions
+- The Next Web (thenextweb.com) — acquisitions
+- Bloomberg (bloomberg.com) — acquisitions, business deals
+- Neowin (neowin.net) — product/feature updates
+- Releasebot (releasebot.io) — good aggregation of ChatGPT/API release notes by month
+
+**WebFetch note**: openai.com itself returns HTTP 403 for all pages. Use WebSearch for openai.com content, then fetch secondary press URLs for detail.

--- a/.claude/agents/openai-news-digest.md
+++ b/.claude/agents/openai-news-digest.md
@@ -1,0 +1,200 @@
+---
+name: "openai-news-digest"
+description: "Use this agent whenever you need a concise, sourced summary of OpenAI product announcements, releases, and news from the last 7 days (or a specified window). Trigger it for weekly catch-ups, briefing prep, or when deciding whether recent OpenAI changes affect platform docs or course content.\\n\\n<example>\\nContext: The user wants to stay current on OpenAI for their AI courses.\\nuser: \"What has OpenAI announced this week?\"\\nassistant: \"I'm going to use the Agent tool to launch the openai-news-digest agent to compile a sourced summary of OpenAI announcements from the last 7 days.\"\\n<commentary>\\nThe user is asking for a recap of recent OpenAI news, which is exactly this agent's purpose, so dispatch openai-news-digest.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The user is updating the OpenAI platform docs and needs to know what changed.\\nuser: \"I need to update docs/platforms/openai — anything new from OpenAI lately?\"\\nassistant: \"Let me use the Agent tool to launch the openai-news-digest agent to gather the latest OpenAI announcements and flag anything that might affect the platform docs.\"\\n<commentary>\\nKeeping platform docs current requires a fresh OpenAI news summary, so use openai-news-digest.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The user mentions an upcoming briefing.\\nuser: \"Give me a quick OpenAI update for my Monday leaders' session.\"\\nassistant: \"I'll use the Agent tool to launch the openai-news-digest agent to produce a briefing-ready summary of the past week's OpenAI news.\"\\n<commentary>\\nBriefing prep on OpenAI news matches this agent's job, so dispatch openai-news-digest.\\n</commentary>\\n</example>"
+tools: Agent, Bash, CronCreate, CronDelete, CronList, DesignSync, Edit, EnterWorktree, ExitWorktree, ListMcpResourcesTool, Monitor, NotebookEdit, PushNotification, Read, ReadMcpResourceTool, RemoteTrigger, Skill, TaskCreate, TaskGet, TaskList, TaskStop, TaskUpdate, ToolSearch, WebFetch, WebSearch, Write
+model: sonnet
+color: green
+memory: project
+---
+
+You are an OpenAI News Analyst — a specialist who tracks, verifies, and synthesizes OpenAI's product announcements and public news into clear, decision-ready briefings. You combine the rigor of a research analyst with the concision of an executive briefer.
+
+## Your Mission
+Produce an accurate, sourced summary of OpenAI product announcements, model releases, API/platform changes, policy updates, and notable news from the **last 7 days** by default (honor any explicit window the user gives, e.g., "last 30 days" or "since GPT-5").
+
+## Authoritative Sources (prioritize in this order)
+1. **Primary/official**: openai.com/blog, openai.com/news, OpenAI Help Center, platform.openai.com/docs and changelog, OpenAI's official X/Twitter and Developer accounts, OpenAI Developer Community announcements.
+2. **Reputable secondary**: established tech press (The Verge, TechCrunch, Ars Technica, Reuters, Bloomberg) — use to corroborate, never as the sole basis for a factual claim.
+3. **Avoid**: rumor accounts, unverified leaks, and speculation. If you must mention an unconfirmed report, label it clearly as RUMOR/UNCONFIRMED.
+
+## Methodology
+1. **Scope the window**: Confirm the date range. Default to the 7 days ending today. State the exact range in your output.
+2. **Gather**: Search official sources first, then corroborate with secondary press. If you have web access, use it; if you do not, say so explicitly and provide the most recent information you can with a clear knowledge-cutoff caveat — never fabricate dates, version numbers, or quotes.
+3. **Verify**: Cross-check each material claim against at least one source. Record the source URL.
+4. **De-duplicate**: Merge multiple reports of the same announcement into a single item.
+5. **Categorize** each item: Models, API/Platform, Products (ChatGPT/apps), Pricing, Safety/Policy, Partnerships/Business, Other.
+6. **Assess relevance**: For each item, note whether it likely affects the Hands-On AI playbook (e.g., the `docs/platforms/openai/` pages, OpenAI getting-started guides, skills/Workspace Agents content). Flag these explicitly.
+
+## Output Format
+Produce Markdown structured as:
+
+**OpenAI News Digest — [start date] to [end date]**
+
+*TL;DR* — 2–4 sentence executive summary of the most important developments.
+
+*Highlights* — bulleted list, most significant first. Each bullet:
+- **[Headline]** (Category, [date]) — 1–2 sentence plain-language explanation of what changed and why it matters. [Source](url)
+
+*Playbook Impact* — bullets flagging anything that may require doc/course updates, or "No playbook-relevant changes identified."
+
+*Sources* — list of all URLs consulted.
+
+If nothing significant happened in the window, say so plainly rather than padding.
+
+## Quality Controls
+- Never invent announcements, version numbers, prices, or dates. Accuracy outweighs completeness.
+- Distinguish confirmed facts from reports/rumors with explicit labels.
+- Every factual claim must carry a source link.
+- If sources conflict, note the discrepancy rather than picking arbitrarily.
+- Keep language accessible — write for readers who may be new to AI tooling (per Hands-On AI content guidelines).
+- If you lack live web access or the window is ambiguous, state the limitation up front and ask for clarification only if it would change the result; otherwise proceed with the stated default and caveat.
+
+## Escalation
+If the requested window yields too little signal, broaden to the last 14 days and label the change. If the user needs deeper analysis on a single announcement, offer to expand that item.
+
+**Update your agent memory** as you discover recurring OpenAI release patterns and reliable sourcing details. This builds up institutional knowledge across conversations. Write concise notes about what you found and where.
+
+Examples of what to record:
+- OpenAI's typical announcement cadence and channels (e.g., which blog/changelog surfaces model vs. API news first)
+- Canonical source URLs that proved reliable (official changelog, help center sections, verified accounts)
+- Naming/versioning conventions for OpenAI models and APIs as they evolve
+- Items already summarized in prior digests (to avoid duplication across runs)
+- Which announcements triggered Hands-On AI playbook updates and which docs were affected
+
+# Persistent Agent Memory
+
+You have a persistent, file-based memory system at `/Users/jamesgray/Code/jamesgray/handsonai/.claude/agent-memory/openai-news-digest/`. This directory already exists — write to it directly with the Write tool (do not run mkdir or check for its existence).
+
+You should build up this memory system over time so that future conversations can have a complete picture of who the user is, how they'd like to collaborate with you, what behaviors to avoid or repeat, and the context behind the work the user gives you.
+
+If the user explicitly asks you to remember something, save it immediately as whichever type fits best. If they ask you to forget something, find and remove the relevant entry.
+
+## Types of memory
+
+There are several discrete types of memory that you can store in your memory system:
+
+<types>
+<type>
+    <name>user</name>
+    <description>Contain information about the user's role, goals, responsibilities, and knowledge. Great user memories help you tailor your future behavior to the user's preferences and perspective. Your goal in reading and writing these memories is to build up an understanding of who the user is and how you can be most helpful to them specifically. For example, you should collaborate with a senior software engineer differently than a student who is coding for the very first time. Keep in mind, that the aim here is to be helpful to the user. Avoid writing memories about the user that could be viewed as a negative judgement or that are not relevant to the work you're trying to accomplish together.</description>
+    <when_to_save>When you learn any details about the user's role, preferences, responsibilities, or knowledge</when_to_save>
+    <how_to_use>When your work should be informed by the user's profile or perspective. For example, if the user is asking you to explain a part of the code, you should answer that question in a way that is tailored to the specific details that they will find most valuable or that helps them build their mental model in relation to domain knowledge they already have.</how_to_use>
+    <examples>
+    user: I'm a data scientist investigating what logging we have in place
+    assistant: [saves user memory: user is a data scientist, currently focused on observability/logging]
+
+    user: I've been writing Go for ten years but this is my first time touching the React side of this repo
+    assistant: [saves user memory: deep Go expertise, new to React and this project's frontend — frame frontend explanations in terms of backend analogues]
+    </examples>
+</type>
+<type>
+    <name>feedback</name>
+    <description>Guidance the user has given you about how to approach work — both what to avoid and what to keep doing. These are a very important type of memory to read and write as they allow you to remain coherent and responsive to the way you should approach work in the project. Record from failure AND success: if you only save corrections, you will avoid past mistakes but drift away from approaches the user has already validated, and may grow overly cautious.</description>
+    <when_to_save>Any time the user corrects your approach ("no not that", "don't", "stop doing X") OR confirms a non-obvious approach worked ("yes exactly", "perfect, keep doing that", accepting an unusual choice without pushback). Corrections are easy to notice; confirmations are quieter — watch for them. In both cases, save what is applicable to future conversations, especially if surprising or not obvious from the code. Include *why* so you can judge edge cases later.</when_to_save>
+    <how_to_use>Let these memories guide your behavior so that the user does not need to offer the same guidance twice.</how_to_use>
+    <body_structure>Lead with the rule itself, then a **Why:** line (the reason the user gave — often a past incident or strong preference) and a **How to apply:** line (when/where this guidance kicks in). Knowing *why* lets you judge edge cases instead of blindly following the rule.</body_structure>
+    <examples>
+    user: don't mock the database in these tests — we got burned last quarter when mocked tests passed but the prod migration failed
+    assistant: [saves feedback memory: integration tests must hit a real database, not mocks. Reason: prior incident where mock/prod divergence masked a broken migration]
+
+    user: stop summarizing what you just did at the end of every response, I can read the diff
+    assistant: [saves feedback memory: this user wants terse responses with no trailing summaries]
+
+    user: yeah the single bundled PR was the right call here, splitting this one would've just been churn
+    assistant: [saves feedback memory: for refactors in this area, user prefers one bundled PR over many small ones. Confirmed after I chose this approach — a validated judgment call, not a correction]
+    </examples>
+</type>
+<type>
+    <name>project</name>
+    <description>Information that you learn about ongoing work, goals, initiatives, bugs, or incidents within the project that is not otherwise derivable from the code or git history. Project memories help you understand the broader context and motivation behind the work the user is doing within this working directory.</description>
+    <when_to_save>When you learn who is doing what, why, or by when. These states change relatively quickly so try to keep your understanding of this up to date. Always convert relative dates in user messages to absolute dates when saving (e.g., "Thursday" → "2026-03-05"), so the memory remains interpretable after time passes.</when_to_save>
+    <how_to_use>Use these memories to more fully understand the details and nuance behind the user's request and make better informed suggestions.</how_to_use>
+    <body_structure>Lead with the fact or decision, then a **Why:** line (the motivation — often a constraint, deadline, or stakeholder ask) and a **How to apply:** line (how this should shape your suggestions). Project memories decay fast, so the why helps future-you judge whether the memory is still load-bearing.</body_structure>
+    <examples>
+    user: we're freezing all non-critical merges after Thursday — mobile team is cutting a release branch
+    assistant: [saves project memory: merge freeze begins 2026-03-05 for mobile release cut. Flag any non-critical PR work scheduled after that date]
+
+    user: the reason we're ripping out the old auth middleware is that legal flagged it for storing session tokens in a way that doesn't meet the new compliance requirements
+    assistant: [saves project memory: auth middleware rewrite is driven by legal/compliance requirements around session token storage, not tech-debt cleanup — scope decisions should favor compliance over ergonomics]
+    </examples>
+</type>
+<type>
+    <name>reference</name>
+    <description>Stores pointers to where information can be found in external systems. These memories allow you to remember where to look to find up-to-date information outside of the project directory.</description>
+    <when_to_save>When you learn about resources in external systems and their purpose. For example, that bugs are tracked in a specific project in Linear or that feedback can be found in a specific Slack channel.</when_to_save>
+    <how_to_use>When the user references an external system or information that may be in an external system.</how_to_use>
+    <examples>
+    user: check the Linear project "INGEST" if you want context on these tickets, that's where we track all pipeline bugs
+    assistant: [saves reference memory: pipeline bugs are tracked in Linear project "INGEST"]
+
+    user: the Grafana board at grafana.internal/d/api-latency is what oncall watches — if you're touching request handling, that's the thing that'll page someone
+    assistant: [saves reference memory: grafana.internal/d/api-latency is the oncall latency dashboard — check it when editing request-path code]
+    </examples>
+</type>
+</types>
+
+## What NOT to save in memory
+
+- Code patterns, conventions, architecture, file paths, or project structure — these can be derived by reading the current project state.
+- Git history, recent changes, or who-changed-what — `git log` / `git blame` are authoritative.
+- Debugging solutions or fix recipes — the fix is in the code; the commit message has the context.
+- Anything already documented in CLAUDE.md files.
+- Ephemeral task details: in-progress work, temporary state, current conversation context.
+
+These exclusions apply even when the user explicitly asks you to save. If they ask you to save a PR list or activity summary, ask what was *surprising* or *non-obvious* about it — that is the part worth keeping.
+
+## How to save memories
+
+Saving a memory is a two-step process:
+
+**Step 1** — write the memory to its own file (e.g., `user_role.md`, `feedback_testing.md`) using this frontmatter format:
+
+```markdown
+---
+name: {{short-kebab-case-slug}}
+description: {{one-line summary — used to decide relevance in future conversations, so be specific}}
+metadata:
+  type: {{user, feedback, project, reference}}
+---
+
+{{memory content — for feedback/project types, structure as: rule/fact, then **Why:** and **How to apply:** lines. Link related memories with [[their-name]].}}
+```
+
+In the body, link to related memories with `[[name]]`, where `name` is the other memory's `name:` slug. Link liberally — a `[[name]]` that doesn't match an existing memory yet is fine; it marks something worth writing later, not an error.
+
+**Step 2** — add a pointer to that file in `MEMORY.md`. `MEMORY.md` is an index, not a memory — each entry should be one line, under ~150 characters: `- [Title](file.md) — one-line hook`. It has no frontmatter. Never write memory content directly into `MEMORY.md`.
+
+- `MEMORY.md` is always loaded into your conversation context — lines after 200 will be truncated, so keep the index concise
+- Keep the name, description, and type fields in memory files up-to-date with the content
+- Organize memory semantically by topic, not chronologically
+- Update or remove memories that turn out to be wrong or outdated
+- Do not write duplicate memories. First check if there is an existing memory you can update before writing a new one.
+
+## When to access memories
+- When memories seem relevant, or the user references prior-conversation work.
+- You MUST access memory when the user explicitly asks you to check, recall, or remember.
+- If the user says to *ignore* or *not use* memory: Do not apply remembered facts, cite, compare against, or mention memory content.
+- Memory records can become stale over time. Use memory as context for what was true at a given point in time. Before answering the user or building assumptions based solely on information in memory records, verify that the memory is still correct and up-to-date by reading the current state of the files or resources. If a recalled memory conflicts with current information, trust what you observe now — and update or remove the stale memory rather than acting on it.
+
+## Before recommending from memory
+
+A memory that names a specific function, file, or flag is a claim that it existed *when the memory was written*. It may have been renamed, removed, or never merged. Before recommending it:
+
+- If the memory names a file path: check the file exists.
+- If the memory names a function or flag: grep for it.
+- If the user is about to act on your recommendation (not just asking about history), verify first.
+
+"The memory says X exists" is not the same as "X exists now."
+
+A memory that summarizes repo state (activity logs, architecture snapshots) is frozen in time. If the user asks about *recent* or *current* state, prefer `git log` or reading the code over recalling the snapshot.
+
+## Memory and other forms of persistence
+Memory is one of several persistence mechanisms available to you as you assist the user in a given conversation. The distinction is often that memory can be recalled in future conversations and should not be used for persisting information that is only useful within the scope of the current conversation.
+- When to use or update a plan instead of memory: If you are about to start a non-trivial implementation task and would like to reach alignment with the user on your approach you should use a Plan rather than saving this information to memory. Similarly, if you already have a plan within the conversation and you have changed your approach persist that change by updating the plan rather than saving a memory.
+- When to use or update tasks instead of memory: When you need to break your work in current conversation into discrete steps or keep track of your progress use tasks instead of saving to memory. Tasks are great for persisting information about the work that needs to be done in the current conversation, but memory should be reserved for information that will be useful in future conversations.
+
+- Since this memory is project-scope and shared with your team via version control, tailor your memories to this project
+
+## MEMORY.md
+
+Your MEMORY.md is currently empty. When you save new memories, they will appear here.

--- a/.playwright-mcp/page-2026-06-19T00-42-34-046Z.yml
+++ b/.playwright-mcp/page-2026-06-19T00-42-34-046Z.yml
@@ -1,0 +1,421 @@
+- generic [active] [ref=e1]:
+  - generic [ref=e2]:
+    - link "Skip to main content" [ref=e4] [cursor=pointer]:
+      - /url: "#skipToMain"
+      - generic [ref=e5]: Skip to main content
+    - generic [ref=e8]:
+      - navigation [ref=e9]:
+        - button "Navigation Menu" [ref=e10] [cursor=pointer]
+        - link "QuantumBlack" [ref=e12] [cursor=pointer]:
+          - /url: /capabilities/quantumblack/our-insights
+          - img "QuantumBlack" [ref=e13]
+      - generic [ref=e16]:
+        - link "Artificial Intelligence" [ref=e17] [cursor=pointer]:
+          - /url: https://www.mckinsey.com/capabilities/quantumblack
+        - navigation [ref=e18]:
+          - list [ref=e19]:
+            - listitem [ref=e20]:
+              - link "Overview" [ref=e21] [cursor=pointer]:
+                - /url: https://www.mckinsey.com/capabilities/quantumblack/how-we-help-clients
+            - listitem [ref=e22]:
+              - link "Our Approach" [ref=e23] [cursor=pointer]:
+                - /url: https://www.mckinsey.com/capabilities/quantumblack/our-approach
+            - listitem [ref=e24]:
+              - link "Labs" [ref=e25] [cursor=pointer]:
+                - /url: https://www.mckinsey.com/capabilities/quantumblack/labs
+            - listitem [ref=e26]:
+              - link "Case Studies" [ref=e27] [cursor=pointer]:
+                - /url: https://www.mckinsey.com/capabilities/quantumblack/case-studies
+            - listitem [ref=e28]:
+              - link "Our Insights" [ref=e29] [cursor=pointer]:
+                - /url: https://www.mckinsey.com/capabilities/quantumblack/our-insights
+            - listitem [ref=e30]:
+              - link "Our People" [ref=e31] [cursor=pointer]:
+                - /url: https://www.mckinsey.com/capabilities/quantumblack/our-people
+            - listitem [ref=e32]:
+              - link "Contact Us" [ref=e33] [cursor=pointer]:
+                - /url: https://www.mckinsey.com/capabilities/quantumblack/contact-us
+      - menu [ref=e35]:
+        - menuitem "Sign In | Subscribe":
+          - list [ref=e36]:
+            - listitem [ref=e37]:
+              - link "Sign In" [ref=e38] [cursor=pointer]:
+                - /url: "#/auth-signin"
+                - generic [ref=e39]: Sign In
+              - text: "|"
+            - listitem [ref=e40]:
+              - link "Subscribe" [ref=e41] [cursor=pointer]:
+                - /url: /user-registration/newsletter
+                - generic [ref=e42]: Subscribe
+        - menuitem "Search icon, hit enter to activate" [ref=e43]:
+          - link "Search icon, hit enter to activate" [ref=e44] [cursor=pointer]:
+            - /url: "#"
+            - generic [ref=e45]: 
+    - generic [ref=e47]:
+      - button "Open Ask McKinsey chat" [ref=e48] [cursor=pointer]:
+        - img "Ask McKinsey chat bubbles" [ref=e49]
+      - generic [ref=e50]:
+        - button "Ask McKinsey AI Chatbot" [ref=e51] [cursor=pointer]:
+          - img "Ask McKinsey AI Chatbot" [ref=e52]
+        - button "Close logo" [ref=e53] [cursor=pointer]:
+          - img "Ask McKinsey Close icon" [ref=e54]
+    - main [ref=e55]:
+      - generic [ref=e56]:
+        - generic [ref=e58]:
+          - generic [ref=e60]: "One year of agentic AI: Six lessons from the people doing the work"
+          - generic [ref=e61]:
+            - generic [ref=e64]:
+              - button [ref=e66] [cursor=pointer]:
+                - generic [ref=e67]: 
+                - generic [ref=e68]: Share
+              - link [ref=e70] [cursor=pointer]:
+                - /url: "#/print"
+                - generic [ref=e71]: 
+                - generic [ref=e72]: Print
+              - button [ref=e74] [cursor=pointer]:
+                - generic [ref=e75]: 
+                - generic [ref=e76]: Download
+              - link [ref=e79] [cursor=pointer]:
+                - /url: "#/save"
+                - generic [ref=e80]: 
+                - generic [ref=e81]: Save
+            - button [ref=e83] [cursor=pointer]:
+              - img [ref=e85]
+              - generic [ref=e88]: Summarize
+        - progressbar [ref=e89]
+      - generic [ref=e96]:
+        - 'heading "One year of agentic AI: Six lessons from the people doing the work" [level=1] [ref=e98]':
+          - generic [ref=e99]: "One year of agentic AI: Six lessons from the people doing the work"
+        - generic [ref=e101]:
+          - time [ref=e102]: September 12, 2025
+          - text: "| Article"
+      - generic [ref=e104]:
+        - generic [ref=e105]:
+          - generic [ref=e106]:
+            - generic [ref=e107]:
+              - text: By
+              - generic [ref=e109]: Lareina Yee,
+              - generic [ref=e111]:
+                - link "Michael Chui" [ref=e112] [cursor=pointer]:
+                  - /url: /our-people/michael-chui
+                  - generic [ref=e113]: Michael Chui
+                - text: ", and"
+              - link "Roger Roberts" [ref=e116] [cursor=pointer]:
+                - /url: /our-people/roger-roberts
+                - generic [ref=e117]: Roger Roberts
+              - text: with
+              - link "Stephen Xu" [ref=e120] [cursor=pointer]:
+                - /url: /our-people/stephen-xu
+                - generic [ref=e121]: Stephen Xu
+            - generic [ref=e122]:
+              - generic [ref=e125]:
+                - button "Share" [ref=e127] [cursor=pointer]:
+                  - generic [ref=e128]: 
+                  - generic [ref=e129]: Share
+                - link "Print" [ref=e131] [cursor=pointer]:
+                  - /url: "#/print"
+                  - generic [ref=e132]: 
+                  - generic [ref=e133]: Print
+                - button "Download" [ref=e135] [cursor=pointer]:
+                  - generic [ref=e136]: 
+                  - generic [ref=e137]: Download
+                - link " Save" [ref=e140] [cursor=pointer]:
+                  - /url: "#/save"
+                  - generic [ref=e141]: 
+                  - generic [ref=e142]: Save
+              - button "Summarize" [ref=e144] [cursor=pointer]:
+                - img [ref=e146]
+                - generic [ref=e149]: Summarize
+          - generic [ref=e153]: Deploying agentic AI successfully isn’t easy. Here’s what we’re learning about how to get it right.
+          - main [ref=e154]:
+            - generic [ref=e156]:
+              - generic [ref=e157]:
+                - iframe [ref=e162]:
+                  - generic [ref=f2e4]:
+                    - application "Play" [ref=f2e6] [cursor=pointer]:
+                      - img [ref=f2e7]
+                    - link "Play on SoundCloud" [ref=f2e11] [cursor=pointer]:
+                      - /url: https://soundcloud.com/mckinsey/listen-to-the-article-one-year
+                      - img [ref=f2e12]
+                    - 'link "McKinsey & Company – Listen to the article: One year of agentic AI: Six lessons from the people doing the work" [ref=f2e18] [cursor=pointer]':
+                      - /url: https://soundcloud.com/mckinsey/listen-to-the-article-one-year
+                - generic [ref=e164]:
+                  - heading "DOWNLOADS" [level=3] [ref=e165]
+                  - link " Article (9 pages)" [ref=e168] [cursor=pointer]:
+                    - /url: "#/download/%2F~%2Fmedia%2Fmckinsey%2Fbusiness%20functions%2Fquantumblack%2Four%20insights%2Fone%20year%20of%20agentic%20ai%20six%20lessons%20from%20the%20people%20doing%20the%20work%2Fone-year-of-agentic-ai-six-lessons-from-the-people-doing-the-work_vf.pdf%3FshouldIndex%3Dfalse"
+                    - generic [ref=e169]: 
+                    - generic [ref=e170]: Article (9 pages)
+                - paragraph [ref=e171]:
+                  - strong [ref=e172]: A year into
+                  - text: "the agentic AI revolution, one lesson is clear: It takes hard work to do it well."
+                - paragraph [ref=e173]: An agentic enterprise transformation holds the promise of unmatched productivity. While some companies are enjoying early successes with such activities, many more are finding it challenging to see value from their investments. In some cases, they are even retrenching—rehiring people where agents have failed.
+                - generic [ref=e175]:
+                  - generic [ref=e177]:
+                    - button " Share" [ref=e179] [cursor=pointer]:
+                      - generic [ref=e180]: 
+                      - generic [ref=e181]: Share
+                    - button "Expandable Sidebar" [ref=e182] [cursor=pointer]:
+                      - generic [ref=e183]: 
+                  - generic [ref=e184]:
+                    - generic [ref=e185]: Sidebar
+                    - heading "What is agentic AI?" [level=2] [ref=e187]:
+                      - generic [ref=e188]: What is agentic AI?
+                - paragraph [ref=e189]: These stumbles are a natural evolution of any new technology, and we’ve seen this pattern before with other innovations. To understand the early lessons, we recently dug into more than 50 agentic AI builds we’ve led at McKinsey, as well as dozens of others in the marketplace. We’ve boiled down our analysis results to six lessons to help leaders successfully capture value from agentic AI (see sidebar “What is agentic AI?”).
+                - heading "It’s not about the agent; it’s about the workflow" [level=2] [ref=e190]
+                - paragraph [ref=e191]: Achieving business value with agentic AI requires changing workflows. Often, however, organizations focus too much on the agent or the agentic tool. This inevitably leads to great-looking agents that don’t actually end up improving the overall workflow, resulting in underwhelming value.
+                - generic [ref=e192]:
+                  - generic [ref=e193]:
+                    - generic [ref=e194]:
+                      - paragraph
+                    - heading "How relevant and useful is this article for you?" [level=5] [ref=e195]
+                    - generic [ref=e196]:
+                      - button "Rate 1 star" [ref=e197] [cursor=pointer]:
+                        - generic [ref=e198]:
+                          - img
+                      - button "Rate 2 star" [ref=e199] [cursor=pointer]:
+                        - generic [ref=e200]:
+                          - img
+                      - button "Rate 3 star" [ref=e201] [cursor=pointer]:
+                        - generic [ref=e202]:
+                          - img
+                      - button "Rate 4 star" [ref=e203] [cursor=pointer]:
+                        - generic [ref=e204]:
+                          - img
+                      - button "Rate 5 star" [ref=e205] [cursor=pointer]:
+                        - generic [ref=e206]:
+                          - img
+                  - generic [ref=e207]:
+                    - heading "Most Popular Insights" [level=3] [ref=e208]
+                    - list [ref=e209]:
+                      - listitem [ref=e210]:
+                        - 'link "The state of AI in 2025: Agents, innovation, and transformation" [ref=e211] [cursor=pointer]':
+                          - /url: /capabilities/quantumblack/our-insights/the-state-of-ai
+                          - strong: "The state of AI in 2025: Agents, innovation, and transformation"
+                      - listitem [ref=e212]:
+                        - 'link "Agents, robots, and us: Skill partnerships in the age of AI" [ref=e213] [cursor=pointer]':
+                          - /url: /mgi/our-research/agents-robots-and-us-skill-partnerships-in-the-age-of-ai
+                          - strong: "Agents, robots, and us: Skill partnerships in the age of AI"
+                      - listitem [ref=e214]:
+                        - 'link "Superagency in the workplace: Empowering people to unlock AI’s full potential" [ref=e215] [cursor=pointer]':
+                          - /url: /capabilities/tech-and-ai/our-insights/superagency-in-the-workplace-empowering-people-to-unlock-ais-full-potential-at-work
+                          - strong: "Superagency in the workplace: Empowering people to unlock AI’s full potential"
+                      - listitem [ref=e216]:
+                        - 'link "The State of Fashion 2026: When the rules change" [ref=e217] [cursor=pointer]':
+                          - /url: /industries/retail/our-insights/state-of-fashion
+                          - strong: "The State of Fashion 2026: When the rules change"
+                      - listitem [ref=e218]:
+                        - 'link "The agentic organization: Contours of the next paradigm for the AI era" [ref=e219] [cursor=pointer]':
+                          - /url: /capabilities/people-and-organizational-performance/our-insights/the-agentic-organization-contours-of-the-next-paradigm-for-the-ai-era
+                          - strong: "The agentic organization: Contours of the next paradigm for the AI era"
+                - paragraph [ref=e220]:
+                  - text: Agentic AI efforts that focus on fundamentally
+                  - link "reimagining entire workflows" [ref=e221] [cursor=pointer]:
+                    - /url: /capabilities/quantumblack/our-insights/seizing-the-agentic-ai-advantage
+                  - text: —that is, the steps that involve people, processes, and technology—are more likely to deliver a positive outcome. Understanding how agents can help with each of these steps is the path to value. People will still be central to getting the work done, but now with different agents, tools, and automations to support them.
+                - paragraph [ref=e222]: An important starting point in redesigning workflows is mapping processes and identifying key user pain points. This step is critical in designing agentic systems that reduce unnecessary work and allow agents and people to collaborate and accomplish business goals more efficiently and effectively. That collaboration can happen through learning loops and feedback mechanisms, creating a self-reinforcing system. The more frequently agents are used, the smarter and more aligned they become.
+                - paragraph [ref=e223]: Consider an alternative dispute resolution service provider that was working to modernize its contract review workflows. Legal reasoning in the company’s domain was constantly evolving, with new case law, jurisdictional nuances, and policy interpretations, making it challenging to codify expertise.
+                - paragraph [ref=e224]: To account for natural variance, the team designed its agentic systems to learn within the workflow. Every user edit in the document editor, for example, was logged and categorized. This provided the engineers and data scientists with a rich stream of feedback, which they could then use to teach the agents, adjust prompt logic, and enrich the knowledge base. Over time, the agents could codify new expertise.
+                - paragraph [ref=e225]: Focusing on the workflow instead of the agent enabled teams to deploy the right technology at the right point, which is especially important when reengineering complex, multistep workflows (exhibit). For example, insurance companies often have big investigative workflows that span multiple steps (such as claims handling and underwriting), with each step requiring different types of activities and cognitive tasks. Companies can redesign these types of workflows by thoughtfully deploying a targeted mix of rule-based systems, analytical AI, gen AI, and agents, all underpinned by a common orchestration framework (such as open-source frameworks like AutoGen, CrewAI, and LangGraph). In these cases, the agents are the orchestrators and the integrators, accessing tools and integrating outputs of other systems into their context. They are the glue that unifies the workflow so it delivers real closure with less intervention needed.
+                - generic [ref=e226]:
+                  - generic [ref=e228]: Exhibit
+                  - img "Complex workflows should incorporate the best tool for each task." [ref=e231]
+                  - generic [ref=e232]:
+                    - text: "We strive to provide individuals with disabilities equal access to our website. If you would like information about this content we will be happy to work with you. Please email us at:"
+                    - link "McKinsey_Website_Accessibility@mckinsey.com" [ref=e233] [cursor=pointer]:
+                      - /url: mailto:McKinsey_Website_Accessibility@mckinsey.com
+                - heading "Agents aren’t always the answer" [level=2] [ref=e234]
+                - paragraph [ref=e235]: AI agents can do a lot, but they shouldn’t necessarily be used for everything. Too often, leaders don’t look closely enough at the work that needs to be done or ask whether an agent would be the best choice to perform that work.
+                - paragraph [ref=e236]: To help avoid wasted investments or unwanted complexity, business leaders can approach the role of agents much like they do when evaluating people for a high-performing team. The key question to ask is, “What is the work to be done and what are the relative talents of each potential team member—or agent—to work together to achieve those goals?” Business problems can often be addressed with simpler automation approaches, such as rules-based automation, predictive analytics, or large language model (LLM) prompting, which can be more reliable than agents out of the box.
+                - paragraph [ref=e237]: Before rushing into an agentic solution, business leaders should take stock of the task’s demands. In practice, that means getting clear on how standardized the process should be, how much variance the process needs to handle, and what portions of the work agents are best suited to do.
+                - generic [ref=e239]:
+                  - img "Book jacket cover of Rewired Second Edition" [ref=e242]
+                  - generic [ref=e243]:
+                    - generic [ref=e245]:
+                      - heading "Rewired, second edition" [level=3] [ref=e246]
+                      - paragraph [ref=e248]: This updated edition offers brand-new insights into cutting-edge AI solutions—and what it takes to implement them—as well as the new economics of digital and AI transformations.
+                    - link "Learn more" [ref=e250] [cursor=pointer]:
+                      - /url: /featured-insights/mckinsey-on-books/rewired
+                      - text: Learn more
+                      - generic [ref=e251]: 
+                - paragraph [ref=e252]: On one level, these issues are straightforward. For example, low-variance, high-standardization workflows, such as investor onboarding or regulatory disclosures, tend to be tightly governed and follow predictable logic. In these cases, agents based on nondeterministic LLMs could add more complexity and uncertainty than value.
+                - paragraph [ref=e253]:
+                  - text: By contrast, high-variance, low-standardization workflows could benefit significantly from agents. For example, agents were deployed at a financial-services company to extract complex financial information, reducing the amount of human validation required and streamlining workflows. These tasks demanded information aggregation, verification checks, and
+                  - link "compliance analysis" [ref=e254] [cursor=pointer]:
+                    - /url: /capabilities/risk-and-resilience/our-insights/deploying-agentic-ai-with-safety-and-security-a-playbook-for-technology-leaders
+                  - text: —tasks where agents can be effective.
+                - generic [ref=e256]:
+                  - generic [ref=e258]:
+                    - button " Share" [ref=e260] [cursor=pointer]:
+                      - generic [ref=e261]: 
+                      - generic [ref=e262]: Share
+                    - button "Expandable Sidebar" [ref=e263] [cursor=pointer]:
+                      - generic [ref=e264]: 
+                  - generic [ref=e265]:
+                    - generic [ref=e266]: Sidebar
+                    - heading "High-level rules of thumb when considering what AI tools to use" [level=2] [ref=e268]:
+                      - generic [ref=e269]: High-level rules of thumb when considering what AI tools to use
+                - paragraph [ref=e270]: The important thing to remember is not to get trapped in a binary “agent/no agent” mindset. Some agents can do specific tasks well, others can help people do their work better, and in many cases, different technologies altogether might be more appropriate. The key is to figure out which tool or agent is best suited to the task, how people can work with them most effectively, and how agents and workers should be combined to deliver the greatest output. How well people, agents, and tools work together is the secret sauce for value (see sidebar “High-level rules of thumb when considering what AI tools to use”).
+                - 'heading "Stop ‘AI slop’: Invest in evaluations and build trust with users" [level=2] [ref=e271]'
+                - paragraph [ref=e272]: One of the most common pitfalls teams encounter when deploying AI agents is agentic systems that seem impressive in demos but frustrate users who are actually responsible for the work. It’s common to hear users complain about “AI slop” or low-quality outputs. Users quickly lose trust in the agents, and adoption levels are poor. Any efficiency gains achieved through automation can easily be offset by a loss in trust or a decline in quality.
+                - paragraph [ref=e273]: A hard-won lesson of this recurring problem is that companies should invest heavily in agent development, just like they do for employee development. As one business leader told us, “Onboarding agents is more like hiring a new employee versus deploying software.” Agents should be given clear job descriptions, onboarded, and given continual feedback so they become more effective and improve regularly.
+                - paragraph [ref=e274]: Developing effective agents is challenging work that requires harnessing individual expertise to create evaluations (or “evals”) and codifying best practices with sufficient granularity for given tasks. This codification serves as both the training manual and performance test for the agent, ensuring that it performs as expected.
+                - paragraph [ref=e275]: These practices may exist in standard operating procedures or as tacit knowledge in people’s heads. When codifying practices, it’s important to focus on what separates top performers from the rest. For sales reps, this might include how they drive the conversation, handle objections, and match the customer’s style (see sidebar “Eval types”).
+                - generic [ref=e277]:
+                  - generic [ref=e279]:
+                    - button " Share" [ref=e281] [cursor=pointer]:
+                      - generic [ref=e282]: 
+                      - generic [ref=e283]: Share
+                    - button "Expandable Sidebar" [ref=e284] [cursor=pointer]:
+                      - generic [ref=e285]: 
+                  - generic [ref=e286]:
+                    - generic [ref=e287]: Sidebar
+                    - heading "Eval types" [level=2] [ref=e289]:
+                      - generic [ref=e290]: Eval types
+                - paragraph [ref=e291]: Crucially, experts should stay involved to test agents’ performance over time; there can be no “launch and leave” in this arena. This commitment to evaluation requires, for example, experts to literally write down or label desired (and perhaps undesired) outputs for given inputs, which can sometimes number in the thousands for more complex agents. In this way, teams can evaluate how much an agent got right or wrong and make the necessary corrections.
+                - paragraph [ref=e292]: A global bank took this approach to heart when transforming its know-your-customer and credit-risk-analysis processes. Whenever the agent’s recommendation on compliance with intake guidelines differed from human judgment, the team identified the logic gaps, refined the decision criteria, and reran tests.
+                - paragraph [ref=e293]: In one case, for example, the agents’ initial analysis was too general. The team provided that feedback, then developed and deployed additional agents to ensure that the depth of analysis provided useful insights at the right level of granularity. One way they did this was by asking the agents “why” in multiple succession. This approach ensured the agents performed well, making it much more likely for people to accept their outputs.
+                - heading "Make it easy to track and verify every step" [level=2] [ref=e294]
+                - paragraph [ref=e295]: When working with only a few AI agents, reviewing their work and spotting errors can be mostly straightforward. But as companies roll out hundreds, or even thousands, of agents, the task becomes challenging. Exacerbating the issue is that many companies track only outcomes. So when there’s a mistake—and there will always be mistakes as companies scale agents—it’s hard to figure out precisely what went wrong.
+                - paragraph [ref=e296]: Agent performance should be verified at each step of the workflow. Building monitoring and evaluation into the workflow can enable teams to catch mistakes early, refine the logic, and continually improve performance, even after the agents are deployed.
+                - paragraph [ref=e297]: "In one document review workflow, for instance, an alternative dispute resolution service provider’s product team observed a sudden drop in accuracy when the system encountered a new set of cases. But since they’d built the agentic workflow with observability tools to track every step of the process, the team quickly identified the issue: Certain user segments were submitting lower-quality data, leading to incorrect interpretations and poor downstream recommendations."
+                - paragraph [ref=e298]: With that insight, the team improved its data collection practices, provided document formatting guidelines to upstream stakeholders, and adjusted the system’s parsing logic. Agent performance quickly rebounded.
+                - heading "The best use case is the reuse case" [level=2] [ref=e299]
+                - paragraph [ref=e300]: In the rush to make progress with agentic AI, companies often create a unique agent for each identified task. This can lead to significant redundancy and waste because the same agent can often accomplish different tasks that share many of the same actions (such as ingesting, extracting, searching, and analyzing).
+                - paragraph [ref=e301]: Deciding how much to invest in building reusable agents (versus an agent that executes one specific task) is analogous to the classic IT architecture problem where companies need to build fast but not lock in choices that constrain future capabilities. How to strike that balance often requires a lot of judgment and analysis.
+                - paragraph [ref=e302]:
+                  - text: Identifying recurring tasks is a good starting point. Companies can develop agents and agent components that can easily be reused across different workflows, and make it simple for developers to access them. That includes
+                  - link "developing a centralized set" [ref=e303] [cursor=pointer]:
+                    - /url: /capabilities/tech-and-ai/our-insights/overcoming-two-issues-that-are-sinking-gen-ai-programs
+                  - text: of validated services (such as LLM observability or preapproved prompts) and assets (for example, application patterns, reusable code, and training materials) that are easy to locate and use. Integrating these capabilities into a single platform is critical. In our experience, this helps to virtually eliminate 30 to 50 percent of the nonessential work typically required.
+                - heading "Humans remain essential, but their roles and numbers will change" [level=2] [ref=e304]
+                - paragraph [ref=e305]: As AI agents continue to proliferate, the question of what role humans will play has generated much anxiety—about job security, on the one hand, and about high expectations for productivity increases, on the other. This has led to wildly diverging views on the role of humans in many present-day jobs.
+                - paragraph [ref=e306]: "To be clear: Agents will be able to accomplish a lot, but humans will remain an essential part of the workforce equation even as the type of work that both agents and humans do changes over time. People will need to oversee model accuracy, ensure compliance, use judgment, and handle edge cases, for example. And as we discussed earlier, agents will not always be the best answer, so people working with other tools such as machine learning models will be needed. The number of people working in a particular workflow, however, will likely change and often will be lower once the workflow is transformed using agents. Business leaders will crucially have to manage these transitions as they would for any change program and thoughtfully allocate the work necessary to train and evaluate agents."
+                - paragraph [ref=e307]: Another big lesson from our experience is that companies should be deliberate in redesigning work so that people and agents can collaborate well together. Without that focus, even the most advanced agentic programs risk silent failures, compounding errors, and user rejection.
+                - paragraph [ref=e308]: Take the example of the alternative dispute resolution service provider mentioned earlier that wanted to use agents for a legal-analysis workflow. In designing the workflow, the team took the time to identify where, when, and how to integrate human input. In one case, agents were able to organize core claims and dollar amounts with high levels of accuracy, but it was important for lawyers to double-check and approve them, given how central the claims were to the entire case.
+                - paragraph [ref=e309]: Similarly, agents were able to recommend workplan approaches to a case, but given the importance of the decision, it was critical for people to not just review but also adjust the recommendation. The agents were also programmed to highlight edge cases and anomalies, helping lawyers develop more comprehensive views. Someone still had to sign the document at the end of the process, underwriting the legal decision with the person’s license and credentials.
+                - paragraph [ref=e310]: An important part of this human–agent collaborative design is developing simple visual user interfaces that make it easy for people to interact with agents. For example, one property and casualty insurance company developed interactive visual elements (such as bounding boxes, highlights, and automated scrolling) to help reviewers quickly validate AI-generated summaries. When people clicked on an insight, for example, the application would scroll directly to the correct page and highlight the appropriate text. This focus on the user experience saved time, reduced second-guessing, and built confidence in the system, leading to user acceptance levels near 95 percent.
+                - separator [ref=e311]
+                - paragraph [ref=e312]: The world of AI agents is moving quickly, so we can expect to learn many more lessons. But unless companies approach their agentic programs with learning in mind (and in practice), they’re likely to repeat mistakes and slow their progress.
+              - generic [ref=e313]:
+                - generic [ref=e314]:
+                  - paragraph
+                - heading "How relevant and useful is this article for you?" [level=5] [ref=e315]
+                - generic [ref=e316]:
+                  - button "Rate 1 star" [ref=e317] [cursor=pointer]:
+                    - generic [ref=e318]:
+                      - img
+                  - button "Rate 2 star" [ref=e319] [cursor=pointer]:
+                    - generic [ref=e320]:
+                      - img
+                  - button "Rate 3 star" [ref=e321] [cursor=pointer]:
+                    - generic [ref=e322]:
+                      - img
+                  - button "Rate 4 star" [ref=e323] [cursor=pointer]:
+                    - generic [ref=e324]:
+                      - img
+                  - button "Rate 5 star" [ref=e325] [cursor=pointer]:
+                    - generic [ref=e326]:
+                      - img
+            - generic [ref=e327]:
+              - contentinfo [ref=e328]:
+                - generic [ref=e329]:
+                  - heading "About the author(s)" [level=5] [ref=e330]
+                  - generic [ref=e332]:
+                    - paragraph [ref=e333]:
+                      - strong [ref=e334]:
+                        - link "Lareina Yee" [ref=e335] [cursor=pointer]:
+                          - /url: /mgi/our-people
+                      - text: is a McKinsey Global Institute director and a senior partner in McKinsey’s Bay Area office, where
+                      - strong [ref=e336]:
+                        - link "Michael Chui" [ref=e337] [cursor=pointer]:
+                          - /url: /our-people/michael-chui
+                      - text: is a senior fellow and
+                      - strong [ref=e338]:
+                        - link "Roger Roberts" [ref=e339] [cursor=pointer]:
+                          - /url: /our-people/roger-roberts
+                      - text: is a partner;
+                      - strong [ref=e340]: Stephen Xu
+                      - text: is a senior director of product management in the Toronto office.
+                    - paragraph [ref=e341]:
+                      - text: The authors wish to thank Alex Singla, Alexander Sukharevsky, Alberto Mario Pirovano, Allen Chen, Ani Aghababyan, Antonio Castro, Carlo Giovine, Medha Bankhwal, Rickard Ström, and the entire product team at
+                      - link "QuantumBlack Labs" [ref=e342] [cursor=pointer]:
+                        - /url: /capabilities/quantumblack/labs
+                      - text: ", McKinsey’s center dedicated to driving innovation and experimentation in AI, for their contributions to this article."
+                    - separator [ref=e343]
+                    - paragraph [ref=e344]: This article was edited by Barr Seitz, an editorial director in the New York office.
+                    - paragraph [ref=e345]:
+                      - emphasis [ref=e346]:
+                        - text: To request a demo or follow-up with an expert in QuantumBlack Labs, our software development and R&D hub, please reach out to
+                        - link "helloqb@mckinsey.com" [ref=e347] [cursor=pointer]:
+                          - /url: http://
+                        - text: .
+              - button "Talk to us" [ref=e349] [cursor=pointer]
+              - generic [ref=e351]:
+                - heading "Explore a career with us" [level=5] [ref=e352]
+                - link "Search openings" [ref=e354] [cursor=pointer]:
+                  - /url: /careers/search-jobs
+                  - generic [ref=e355]: Search openings
+        - generic [ref=e357]:
+          - heading "Related Articles" [level=5] [ref=e358]
+          - generic [ref=e359]:
+            - generic [ref=e360]:
+              - link "Computer Neural Network Concept Image. Bright dots connected by glowing lines." [ref=e362] [cursor=pointer]:
+                - /url: /capabilities/quantumblack/our-insights/seizing-the-agentic-ai-advantage
+                - img "Computer Neural Network Concept Image. Bright dots connected by glowing lines." [ref=e364]
+              - generic [ref=e366]:
+                - text: Report
+                - heading "Seizing the agentic AI advantage" [level=6] [ref=e367]:
+                  - link "Seizing the agentic AI advantage" [ref=e368] [cursor=pointer]:
+                    - /url: /capabilities/quantumblack/our-insights/seizing-the-agentic-ai-advantage
+                    - generic [ref=e369]: Seizing the agentic AI advantage
+            - generic [ref=e370]:
+              - link "AI robot with circuit, chemical structure and program code on a black background." [ref=e372] [cursor=pointer]:
+                - /url: /industries/life-sciences/our-insights/reimagining-life-science-enterprises-with-agentic-ai
+                - img "AI robot with circuit, chemical structure and program code on a black background." [ref=e374]
+              - generic [ref=e376]:
+                - text: Article
+                - heading "Reimagining life science enterprises with agentic AI" [level=6] [ref=e377]:
+                  - link "Reimagining life science enterprises with agentic AI" [ref=e378] [cursor=pointer]:
+                    - /url: /industries/life-sciences/our-insights/reimagining-life-science-enterprises-with-agentic-ai
+                    - generic [ref=e379]: Reimagining life science enterprises with agentic AI
+            - generic [ref=e380]:
+              - link "An abstract image of a stack of 3D credit cards swirling up in a repeating twisting pattern." [ref=e382] [cursor=pointer]:
+                - /url: /capabilities/risk-and-resilience/our-insights/how-agentic-ai-can-change-the-way-banks-fight-financial-crime
+                - img "An abstract image of a stack of 3D credit cards swirling up in a repeating twisting pattern." [ref=e384]
+              - generic [ref=e386]:
+                - text: Article
+                - heading "How agentic AI can change the way banks fight financial crime" [level=6] [ref=e387]:
+                  - link "How agentic AI can change the way banks fight financial crime" [ref=e388] [cursor=pointer]:
+                    - /url: /capabilities/risk-and-resilience/our-insights/how-agentic-ai-can-change-the-way-banks-fight-financial-crime
+                    - generic [ref=e389]: How agentic AI can change the way banks fight financial crime
+    - generic [ref=e391]:
+      - generic [ref=e393]:
+        - heading "Sign up for emails on new Artificial Intelligence articles" [level=5] [ref=e394]
+        - paragraph [ref=e395]: Never miss an insight. We'll email you when new articles are published on this topic.
+        - generic [ref=e397]:
+          - textbox "Email address" [ref=e401]
+          - button "Subscribe" [ref=e403] [cursor=pointer]
+      - button "Close" [ref=e404] [cursor=pointer]:
+        - generic [ref=e405]: 
+    - contentinfo [ref=e409]
+    - log [ref=e410]: Sign up for emails on new Artificial Intelligence articles
+  - alert [ref=e411]
+  - generic:
+    - dialog [ref=e413]:
+      - dialog "Privacy" [ref=e414]:
+        - generic [ref=e415]:
+          - generic [ref=e417]:
+            - text: McKinsey & Company, Inc. uses cookies to better understand how visitors use our site, to collect and analyze information on site performance and usage, and for targeted advertising purposes.
+            - link "Cookie Notice" [ref=e418] [cursor=pointer]:
+              - /url: https://www.mckinsey.com/cookie-policy
+            - text: We do not sell personal information, but we may share your personal data with third parties for cross-context behavioral advertising.
+            - text: Please see our
+            - link "Privacy Notice" [ref=e419] [cursor=pointer]:
+              - /url: https://www.mckinsey.com/privacy-policy
+            - text: for more information.
+          - generic [ref=e421]:
+            - generic [ref=e422]:
+              - button "Accept All Cookies" [ref=e423] [cursor=pointer]
+              - button "Decline optional cookies" [ref=e424] [cursor=pointer]
+            - button "Manage my preferences, Opens the preference center dialog" [ref=e425] [cursor=pointer]: Manage my preferences
+    - text:   Back

--- a/.playwright-mcp/page-2026-06-19T00-42-51-569Z.yml
+++ b/.playwright-mcp/page-2026-06-19T00-42-51-569Z.yml
@@ -1,0 +1,728 @@
+- generic [active] [ref=e1]:
+  - generic [ref=e2]:
+    - link "Skip to main content" [ref=e4] [cursor=pointer]:
+      - /url: "#skipToMain"
+      - generic [ref=e5]: Skip to main content
+    - generic [ref=e7]:
+      - navigation [ref=e8]:
+        - button "Navigation Menu" [ref=e9] [cursor=pointer]
+      - menu [ref=e15]:
+        - menuitem "Sign In | Subscribe":
+          - list [ref=e16]:
+            - listitem [ref=e17]:
+              - link "Sign In" [ref=e18] [cursor=pointer]:
+                - /url: "#/auth-signin"
+                - generic [ref=e19]: Sign In
+              - text: "|"
+            - listitem [ref=e20]:
+              - link "Subscribe" [ref=e21] [cursor=pointer]:
+                - /url: /user-registration/newsletter
+                - generic [ref=e22]: Subscribe
+        - menuitem "Search icon, hit enter to activate" [ref=e23]:
+          - link "Search icon, hit enter to activate" [ref=e24] [cursor=pointer]:
+            - /url: "#"
+            - generic [ref=e25]: 
+    - generic [ref=e27]:
+      - button "Open Ask McKinsey chat" [ref=e28] [cursor=pointer]:
+        - img "Ask McKinsey chat bubbles" [ref=e29]
+      - generic [ref=e30]:
+        - button "Ask McKinsey AI Chatbot" [ref=e31] [cursor=pointer]:
+          - img "Ask McKinsey AI Chatbot" [ref=e32]
+        - button "Close logo" [ref=e33] [cursor=pointer]:
+          - img "Ask McKinsey Close icon" [ref=e34]
+    - main [ref=e35]:
+      - generic [ref=e36]:
+        - generic [ref=e38]:
+          - generic [ref=e40]: Seizing the agentic AI advantage
+          - generic [ref=e41]:
+            - generic [ref=e44]:
+              - button [ref=e46] [cursor=pointer]:
+                - generic [ref=e47]: 
+                - generic [ref=e48]: Share
+              - link [ref=e50] [cursor=pointer]:
+                - /url: "#/print"
+                - generic [ref=e51]: 
+                - generic [ref=e52]: Print
+              - button [ref=e54] [cursor=pointer]:
+                - generic [ref=e55]: 
+                - generic [ref=e56]: Download
+              - link [ref=e59] [cursor=pointer]:
+                - /url: "#/save"
+                - generic [ref=e60]: 
+                - generic [ref=e61]: Save
+            - button [ref=e63] [cursor=pointer]:
+              - img [ref=e65]
+              - generic [ref=e68]: Summarize
+        - progressbar [ref=e69]
+      - generic [ref=e81]:
+        - heading "Seizing the agentic AI advantage" [level=1] [ref=e83]:
+          - generic [ref=e84]: Seizing the agentic AI advantage
+        - generic [ref=e87]:
+          - time [ref=e88]: June 13, 2025
+          - text: "| Report"
+        - button "Skip article header section" [ref=e90] [cursor=pointer]:
+          - generic [ref=e91]: 
+      - generic [ref=e93]:
+        - generic [ref=e94]:
+          - generic [ref=e96]:
+            - generic [ref=e99]:
+              - button "Share" [ref=e101] [cursor=pointer]:
+                - generic [ref=e102]: 
+                - generic [ref=e103]: Share
+              - link "Print" [ref=e105] [cursor=pointer]:
+                - /url: "#/print"
+                - generic [ref=e106]: 
+                - generic [ref=e107]: Print
+              - button "Download" [ref=e109] [cursor=pointer]:
+                - generic [ref=e110]: 
+                - generic [ref=e111]: Download
+              - link " Save" [ref=e114] [cursor=pointer]:
+                - /url: "#/save"
+                - generic [ref=e115]: 
+                - generic [ref=e116]: Save
+            - button "Summarize" [ref=e118] [cursor=pointer]:
+              - img [ref=e120]
+              - generic [ref=e123]: Summarize
+          - generic [ref=e127]: A CEO playbook to solve the gen AI paradox and unlock scalable impact with AI agents.
+          - main [ref=e128]:
+            - generic [ref=e130]:
+              - generic [ref=e131]:
+                - generic [ref=e133]:
+                  - heading "DOWNLOADS" [level=3] [ref=e134]
+                  - link " Full Report (28 pages)" [ref=e137] [cursor=pointer]:
+                    - /url: "#/download/%2F~%2Fmedia%2Fmckinsey%2Fbusiness%20functions%2Fquantumblack%2Four%20insights%2Fseizing%20the%20agentic%20ai%20advantage%2Fseizing-the-agentic-ai-advantage-final1.pdf%3FshouldIndex%3Dfalse"
+                    - generic [ref=e138]: 
+                    - generic [ref=e139]: Full Report (28 pages)
+                - generic:
+                  - navigation "Table of Contents":
+                    - generic [ref=e140]:
+                      - link "At a glance" [ref=e142] [cursor=pointer]:
+                        - /url: "#"
+                        - generic [ref=e143]: At a glance
+                      - link "Chapter 1" [ref=e145] [cursor=pointer]:
+                        - /url: "#"
+                        - generic [ref=e146]: Chapter 1
+                      - link "Chapter 2" [ref=e148] [cursor=pointer]:
+                        - /url: "#"
+                        - generic [ref=e149]: Chapter 2
+                      - link "Chapter 3" [ref=e151] [cursor=pointer]:
+                        - /url: "#"
+                        - generic [ref=e152]: Chapter 3
+                      - link "Conclusion" [ref=e154] [cursor=pointer]:
+                        - /url: "#"
+                        - generic [ref=e155]: Conclusion
+                      - button "Collapse table of contents menu" [ref=e156] [cursor=pointer]:
+                        - generic [ref=e157]: 
+                - region "At a glance"
+                - heading "At a glance" [level=3] [ref=e158]
+                - list [ref=e159]:
+                  - listitem [ref=e160]:
+                    - text: Nearly eight in ten companies report using gen AI—yet just as many report no significant bottom-line impact.
+                    - generic "footnote" [ref=e162] [cursor=pointer]:
+                      - superscript [ref=e163]: "[1]"
+                    - text: Think of it as the “gen AI paradox.”
+                - generic [ref=e165]:
+                  - button "Expandable Sidebar" [ref=e168] [cursor=pointer]:
+                    - generic [ref=e169]: 
+                  - generic [ref=e170]:
+                    - generic [ref=e171]: Byline
+                    - heading "About the authors" [level=2] [ref=e173]:
+                      - generic [ref=e174]: About the authors
+                - list [ref=e175]:
+                  - listitem [ref=e176]: At the heart of this paradox is an imbalance between “horizontal” (enterprise-wide) copilots and chatbots—which have scaled quickly but deliver diffuse, hard-to-measure gains—and more transformative “vertical” (function-specific) use cases—about 90 percent of which remain stuck in pilot mode.
+                  - listitem [ref=e177]: AI agents offer a way to break out of the gen AI paradox. That’s because agents have the potential to automate complex business processes—combining autonomy, planning, memory, and integration—to shift gen AI from a reactive tool to a proactive, goal-driven virtual collaborator.
+                  - listitem [ref=e178]: This shift enables far more than efficiency. Agents supercharge operational agility and create new revenue opportunities.
+                  - listitem [ref=e179]: But unlocking the full potential of agentic AI requires more than plugging agents into existing workflows. It calls for reimagining those workflows from the ground up—with agents at the core.
+                - generic [ref=e181]:
+                  - generic [ref=e183]:
+                    - button " Share" [ref=e185] [cursor=pointer]:
+                      - generic [ref=e186]: 
+                      - generic [ref=e187]: Share
+                    - button "Expandable Sidebar" [ref=e188] [cursor=pointer]:
+                      - generic [ref=e189]: 
+                  - generic [ref=e190]:
+                    - generic [ref=e191]: Sidebar
+                    - heading "Foreword" [level=2] [ref=e193]:
+                      - generic [ref=e194]: Foreword
+                - list [ref=e195]:
+                  - listitem [ref=e196]: "A new AI architecture paradigm—the agentic AI mesh—is needed to govern the rapidly evolving organizational AI landscape and enable teams to blend custom-built and off-the-shelf agents while managing mounting technical debt and new classes of risk. But the bigger challenge won’t be technical. It will be human: earning trust, driving adoption, and establishing the right governance to manage agent autonomy and prevent uncontrolled sprawl."
+                  - listitem [ref=e197]: To scale impact in the agentic era, organizations must reset their AI transformation approaches from scattered initiatives to strategic programs; from use cases to business processes; from siloed AI teams to cross-functional transformation squads; and from experimentation to industrialized, scalable delivery.
+                  - listitem [ref=e198]: Organizations will also need to set up the foundation to effectively operate in the agentic era. They will need to upskill the workforce, adapt the technology infrastructure, accelerate data productization, and deploy agent-specific governance mechanisms. The moment has come to bring the gen AI experimentation chapter to a close—a pivot only the CEO can make.
+                - generic [ref=e200]:
+                  - img "The Macro and Micro Implications of Agentic AI for the Workforce" [ref=e203]
+                  - generic [ref=e204]:
+                    - generic [ref=e206]:
+                      - heading "The Macro and Micro Implications of Agentic AI for the Workforce" [level=3] [ref=e207]
+                      - paragraph [ref=e209]: Join McKinsey experts on June 22 for a discussion on skills-based transformations, leading a workforce through the cultural shock of working alongside AI, and how CEOs should think about wage dynamics and labor adaptation as the productivity frontier expands faster than most organizations can absorb.
+                    - link "Request an invitation" [ref=e211] [cursor=pointer]:
+                      - /url: https://mck.co/EnterpriseAI
+                      - text: Request an invitation
+                      - generic [ref=e212]: 
+                - region "Chapter 1"
+                - generic [ref=e213]:
+                  - img "Computer Neural Network Concept Image. Bright dots connected by glowing lines." [ref=e214]
+                  - generic [ref=e220]:
+                    - generic [ref=e221]: Chapter 1
+                    - 'heading "The gen AI paradox: Widespread deployment, minimal impact The gen AI paradox: Widespread deployment, minimal impact" [level=2] [ref=e222]':
+                      - generic [ref=e223]:
+                        - text: "The gen AI paradox: Widespread deployment, minimal impact"
+                        - 'link "The gen AI paradox: Widespread deployment, minimal impact" [ref=e224] [cursor=pointer]':
+                          - /url: "#"
+                          - generic [ref=e225]: 
+                - generic [ref=e228]:
+                  - generic [ref=e229]:
+                    - heading "Key Points" [level=2] [ref=e230]:
+                      - generic [ref=e231]: Key Points
+                    - generic [ref=e232]:
+                      - generic [ref=e233] [cursor=pointer]: Continue to next section
+                      - button "" [ref=e234] [cursor=pointer]:
+                        - generic [ref=e235]: 
+                  - generic [ref=e236]:
+                    - button " Share" [ref=e239] [cursor=pointer]:
+                      - generic [ref=e240]: 
+                      - generic [ref=e241]: Share
+                    - list [ref=e245]:
+                      - listitem [ref=e246]:
+                        - strong [ref=e247]:
+                          - emphasis [ref=e248]: Nearly eight in ten companies have deployed gen AI in some form, but roughly the same percentage report no material impact on earnings.
+                        - generic "footnote" [ref=e250] [cursor=pointer]:
+                          - superscript [ref=e251]: "[1]"
+                        - strong [ref=e252]:
+                          - emphasis [ref=e253]: We call this the “gen AI paradox.”
+                      - listitem [ref=e254]:
+                        - strong [ref=e255]:
+                          - emphasis [ref=e256]: The main issue is an imbalance between “horizontal” and “vertical” use cases. The former, such as employee copilots and chatbots, have been widely deployed but deliver diffuse benefits, while higher-impact vertical, or function-specific, use cases seldom make it out of the pilot phase because of technical, organizational, data, and cultural barriers.
+                      - listitem [ref=e257]:
+                        - strong [ref=e258]:
+                          - emphasis [ref=e259]: Unless companies address these barriers, the transformational promise of gen AI will remain largely untapped.
+                - heading "Gen AI is everywhere—except in company P&L" [level=2] [ref=e260]
+                - generic [ref=e262]:
+                  - generic [ref=e264]:
+                    - button " Share" [ref=e266] [cursor=pointer]:
+                      - generic [ref=e267]: 
+                      - generic [ref=e268]: Share
+                    - button "Expandable Sidebar" [ref=e269] [cursor=pointer]:
+                      - generic [ref=e270]: 
+                  - generic [ref=e271]:
+                    - generic [ref=e272]: Sidebar
+                    - heading "About QuantumBlack, AI by McKinsey" [level=2] [ref=e274]:
+                      - generic [ref=e275]: About QuantumBlack, AI by McKinsey
+                - paragraph [ref=e276]:
+                  - text: Even before the advent of gen AI, artificial intelligence had already carved out a key place in the enterprise, powering advanced prediction, classification, and optimization capabilities. And the technology’s estimated value potential was already immense—
+                  - link "between $11 trillion and $18 trillion globally" [ref=e277] [cursor=pointer]:
+                    - /url: /capabilities/tech-and-ai/our-insights/the-economic-potential-of-generative-ai-the-next-productivity-frontier
+                  - generic "footnote" [ref=e279] [cursor=pointer]:
+                    - superscript [ref=e280]: "[2]"
+                  - text: —mainly in the fields of marketing (powering capabilities such as personalized email targeting and customer segmentation), sales (lead scoring), and supply chain (inventory optimization and demand forecasting). Yet AI was largely the domain of experts. As a result, adoption across the rank and file tended to be slow. From 2018 to 2022, for example, AI adoption remained relatively stagnant, with about 50 percent of companies deploying the technology in just one business function, according to McKinsey research (Exhibit 1).
+                - generic [ref=e281]:
+                  - generic [ref=e283]: Exhibit 1
+                  - img "Gen AI has accelerated AI deployment overall." [ref=e286]
+                  - generic [ref=e287]:
+                    - text: "We strive to provide individuals with disabilities equal access to our website. If you would like information about this content we will be happy to work with you. Please email us at:"
+                    - link "McKinsey_Website_Accessibility@mckinsey.com" [ref=e288] [cursor=pointer]:
+                      - /url: mailto:McKinsey_Website_Accessibility@mckinsey.com
+                - paragraph [ref=e289]:
+                  - text: "Gen AI has extended the reach of traditional AI in three breakthrough areas: information synthesis, content generation, and communication in human language. McKinsey estimates that the technology has the potential to unlock"
+                  - link "$2.6 trillion to $4.4 trillion in additional value" [ref=e290] [cursor=pointer]:
+                    - /url: /capabilities/tech-and-ai/our-insights/the-economic-potential-of-generative-ai-the-next-productivity-frontier
+                  - text: on top of the value potential of traditional analytical AI.
+                  - generic "footnote" [ref=e292] [cursor=pointer]:
+                    - superscript [ref=e293]: "[3]"
+                - paragraph [ref=e294]:
+                  - text: "Two and a half years after the launch of ChatGPT, gen AI has reshaped how enterprises engage with AI. Its potentially transformative power lies not only in the new capabilities gen AI introduces but also in its ability to democratize access to advanced AI technologies across organizations. This democratization has led to widespread growth in awareness of, and experimentation with, AI: According to"
+                  - link "McKinsey’s most recent Global Survey on AI" [ref=e295] [cursor=pointer]:
+                    - /url: /capabilities/quantumblack/our-insights/the-state-of-ai-how-organizations-are-rewiring-to-capture-value
+                  - text: ","
+                  - generic "footnote" [ref=e297] [cursor=pointer]:
+                    - superscript [ref=e298]: "[4]"
+                  - text: more than 78 percent of companies are now using gen AI in at least one business function (up from 55 percent a year earlier).
+                - paragraph [ref=e299]:
+                  - text: However, this enthusiasm has yet to translate into tangible economic results.
+                  - link "More than 80 percent of companies still report no material contribution to earnings" [ref=e300] [cursor=pointer]:
+                    - /url: /capabilities/quantumblack/our-insights/the-state-of-ai-how-organizations-are-rewiring-to-capture-value
+                  - text: from their gen AI initiatives.
+                  - generic "footnote" [ref=e302] [cursor=pointer]:
+                    - superscript [ref=e303]: "[5]"
+                  - text: What’s more, only
+                  - link "1 percent of enterprises we surveyed view their gen AI strategies as mature" [ref=e304] [cursor=pointer]:
+                    - /url: /capabilities/tech-and-ai/our-insights/superagency-in-the-workplace-empowering-people-to-unlock-ais-full-potential-at-work
+                  - text: .
+                  - generic "footnote" [ref=e306] [cursor=pointer]:
+                    - superscript [ref=e307]: "[6]"
+                  - text: "Call it the “gen AI paradox”: For all the energy, investment, and potential surrounding the technology, at-scale impact has yet to materialize for most organizations."
+                - heading "At the heart of the gen AI paradox lies an imbalance between horizontal and vertical use cases" [level=2] [ref=e308]
+                - paragraph [ref=e309]:
+                  - text: Many organizations have deployed horizontal use cases, such as enterprise-wide copilots and chatbots; nearly 70 percent of Fortune 500 companies, for example, use Microsoft 365 Copilot.
+                  - generic "footnote" [ref=e311] [cursor=pointer]:
+                    - superscript [ref=e312]: "[7]"
+                  - text: These tools are widely seen as levers to enhance individual productivity by helping employees save time on routine tasks and access and synthesize information more efficiently. But these improvements, while real, tend to be spread thinly across employees. As a result, they are not easily visible in terms of top- or bottom-line results.
+                - paragraph [ref=e313]:
+                  - text: By contrast, vertical use cases—those embedded into specific business functions and processes—have seen limited scaling in most companies despite their higher potential for direct economic impact (Exhibit 2).
+                  - link "Fewer than 10 percent of use cases deployed ever make it past the pilot stage" [ref=e314] [cursor=pointer]:
+                    - /url: /about-us/new-at-mckinsey-blog/mckinsey-alliances-bring-the-power-of-generative-ai-to-clients
+                  - text: ", according to McKinsey research."
+                  - generic "footnote" [ref=e316] [cursor=pointer]:
+                    - superscript [ref=e317]: "[8]"
+                  - text: Even when they have been fully deployed, these use cases typically have supported only isolated steps of a business process and operated in a reactive mode when prompted by a human, rather than functioning proactively or autonomously. As a result, their impact on business performance also has been limited.
+                - generic [ref=e318]:
+                  - generic [ref=e320]: Exhibit 2
+                  - 'img "Across business functions, gen AI use cases tend to fall into two categories: horizontal and vertical." [ref=e323]'
+                  - generic [ref=e324]:
+                    - text: "We strive to provide individuals with disabilities equal access to our website. If you would like information about this content we will be happy to work with you. Please email us at:"
+                    - link "McKinsey_Website_Accessibility@mckinsey.com" [ref=e325] [cursor=pointer]:
+                      - /url: mailto:McKinsey_Website_Accessibility@mckinsey.com
+                - paragraph [ref=e326]: What accounts for this imbalance? For one thing, horizontally deployed copilots such as Microsoft Copilot or Google AI Workspace are accessible, off-the-shelf solutions that are relatively easy to implement. (In many cases, enabling Microsoft Copilot is as simple as activating an extension to an existing Office 365 contract, requiring no redesign of workflows or major change management efforts.) Rapid deployment of enterprise chatbots also has been driven by risk mitigation concerns. As employees began experimenting with external large language models (LLMs) such as ChatGPT, many organizations implemented internal, secure alternatives to limit data leakage and ensure compliance with corporate security policies.
+                - paragraph [ref=e327]: "The limited deployment and narrow scope of vertical use cases can in turn be attributed to six primary factors:"
+                - list [ref=e328]:
+                  - listitem [ref=e329]:
+                    - strong [ref=e330]: Fragmented initiatives.
+                    - text: At many companies, vertical use cases have been identified through a bottom-up, highly granular approach within individual functions. In fact,
+                    - link "fewer than 30 percent of companies report that their CEOs sponsor their AI agenda directly" [ref=e331] [cursor=pointer]:
+                      - /url: /capabilities/quantumblack/our-insights/the-state-of-ai-how-organizations-are-rewiring-to-capture-value
+                    - text: .
+                    - generic "footnote" [ref=e333] [cursor=pointer]:
+                      - superscript [ref=e334]: "[9]"
+                    - text: This has led to a proliferation of disconnected micro-initiatives and a dispersion of AI investments, with limited coordination at the enterprise level.
+                  - listitem [ref=e335]:
+                    - strong [ref=e336]: Lack of mature, packaged solutions.
+                    - text: Unlike off-the-shelf horizontal applications, such as copilots, vertical use cases often require custom development. As a result, teams are frequently forced to build from scratch, using emerging, fast-evolving technologies they have limited experience with. While many companies have invested in data scientists to develop AI models, they often lack MLOps engineers, who are critical to industrialize, deploy, and maintain those models in production environments.
+                  - listitem [ref=e337]:
+                    - strong [ref=e338]: Technological limitations of LLMs.
+                    - text: Despite their impressive capabilities, the first generation of LLMs faced limitations that significantly constrained their deployment at enterprise scale. First, LLMs can produce inaccurate outputs, which makes them difficult to trust in environments where precision and repeatability are essential. What’s more, despite their power, LLMs are fundamentally passive; they do not act unless prompted and cannot independently drive workflows or make decisions without human initiation. LLMs also have struggled to handle complex workflows involving multiple steps, decision points, or branching logic. Finally, many current LLMs have limited persistent memory, making it difficult to track context over time or operate coherently across extended interactions.
+                  - listitem [ref=e339]:
+                    - strong [ref=e340]: Siloed AI teams.
+                    - text: AI centers of excellence have played a crucial role in accelerating awareness and experimentation across many organizations. However, in many cases, these teams have operated in silos—developing AI models independently from core IT, data, or business functions. This autonomy, while useful for rapid prototyping, has often made solutions difficult to scale because of poor integration with enterprise systems, fragmented data pipelines, or a lack of operational alignment.
+                  - listitem [ref=e341]:
+                    - strong [ref=e342]: Data accessibility and quality gaps.
+                    - text: These gaps tend to exist for both structured and unstructured data, with unstructured material remaining largely ungoverned in most organizations.
+                  - listitem [ref=e343]:
+                    - strong [ref=e344]: Cultural apprehension and organizational inertia.
+                    - text: In many organizations, AI deployments have encountered implicit resistance from business teams and middle management due to fear of disruption, uncertainty around job impact, and lack of familiarity with the technology.
+                - paragraph [ref=e345]:
+                  - text: Despite its limited bottom-line impact so far, the first wave of gen AI has been far from wasted. It has enriched employee capabilities, enabled broad experimentation, accelerated AI familiarity across functions, and helped organizations build essential capabilities in prompt engineering, model evaluation, and governance. All of this has laid the groundwork for a more integrated and transformative second phase—
+                  - link "the emerging age of AI agents" [ref=e346] [cursor=pointer]:
+                    - /url: /capabilities/tech-and-ai/our-insights/why-agents-are-the-next-frontier-of-generative-ai
+                  - text: .
+                  - generic "footnote" [ref=e348] [cursor=pointer]:
+                    - superscript [ref=e349]: "[10]"
+                - region "Chapter 2"
+                - generic [ref=e350]:
+                  - img "Computer Neural Network Concept Image. Bright dots connected by glowing lines." [ref=e351]
+                  - generic [ref=e357]:
+                    - generic [ref=e358]: Chapter 2
+                    - 'heading "From paradox to payoff: How agents can scale AI From paradox to payoff: How agents can scale AI" [level=2] [ref=e359]':
+                      - generic [ref=e360]:
+                        - text: "From paradox to payoff: How agents can scale AI"
+                        - 'link "From paradox to payoff: How agents can scale AI" [ref=e361] [cursor=pointer]':
+                          - /url: "#"
+                          - generic [ref=e362]: 
+                - generic [ref=e365]:
+                  - generic [ref=e366]:
+                    - heading "Key Points" [level=2] [ref=e367]:
+                      - generic [ref=e368]: Key Points
+                    - generic [ref=e369]:
+                      - generic [ref=e370] [cursor=pointer]: Continue to next section
+                      - button "" [ref=e371] [cursor=pointer]:
+                        - generic [ref=e372]: 
+                  - generic [ref=e373]:
+                    - button " Share" [ref=e376] [cursor=pointer]:
+                      - generic [ref=e377]: 
+                      - generic [ref=e378]: Share
+                    - list [ref=e382]:
+                      - listitem [ref=e383]:
+                        - strong [ref=e384]:
+                          - emphasis [ref=e385]: By automating complex business workflows, agents unlock the full potential of vertical use cases. Forward-looking companies are already harnessing the power of agents to transform core processes.
+                      - listitem [ref=e386]:
+                        - strong [ref=e387]:
+                          - emphasis [ref=e388]: To realize the potential of agents, companies must reinvent the way work gets done—changing task flows, redefining human roles, and building agent-centric processes from the ground up.
+                      - listitem [ref=e389]:
+                        - strong [ref=e390]:
+                          - emphasis [ref=e391]: "Accomplishing this will require a new paradigm for AI architecture—the agentic AI mesh—capable of integrating both custom-built and off-the-shelf agents. But the bigger challenge will not be technical. It will be human: earning trust to drive adoption and establishing the proper governance protocols."
+                - 'heading "The breakthrough: Automating complex business workflows unlocks the full potential of vertical use cases" [level=2] [ref=e392]'
+                - paragraph [ref=e393]: LLMs have revolutionized how organizations interact with data—enabling information synthesis, content generation, and natural language interaction. But despite their power, LLMs have been fundamentally reactive and isolated from enterprise systems, largely unable to retain memory of past interactions or context across sessions or queries. Their role has been largely limited to enhancing individual productivity through isolated tasks. AI agents mark a major evolution in enterprise AI—extending gen AI from reactive content generation to autonomous, goal-driven execution. Agents can understand goals, break them into subtasks, interact with both humans and systems, execute actions, and adapt in real time—all with minimal human intervention. They do so by combining LLMs with additional technology components providing memory, planning, orchestration, and integration capabilities.
+                - paragraph [ref=e394]: With these new capabilities, AI agents expand the potential of horizontal solutions, upgrading general-purpose copilots from passive tools into proactive teammates that don’t just respond to prompts but also monitor dashboards, trigger workflows, follow up on open actions, and deliver relevant insights in real time. But the real breakthrough comes in the vertical realm, where agentic AI enables the automation of complex business workflows involving multiple steps, actors, and systems—processes that were previously beyond the capabilities of first-generation gen AI tools.
+                - heading "Agents deliver more than efficiency—they supercharge operational agility and unlock new revenue opportunities" [level=2] [ref=e395]
+                - paragraph [ref=e396]: "On the operations side, agents take on routine, data-heavy tasks so humans can focus on higher-value work. But they go further, transforming processes in five ways:"
+                - list [ref=e397]:
+                  - listitem [ref=e398]:
+                    - strong [ref=e399]: Agents accelerate execution by eliminating delays between tasks and by enabling parallel processing.
+                    - text: Unlike in traditional workflows that rely on sequential handoffs, agents can coordinate and execute multiple steps simultaneously, reducing cycle time and boosting responsiveness.
+                  - listitem [ref=e400]:
+                    - strong [ref=e401]: Agents bring adaptability.
+                    - text: By continuously ingesting data, agents can adjust process flows on the fly, reshuffling task sequences, reassigning priorities, or flagging anomalies before they cascade into failures. This makes workflows not only faster but smarter.
+                  - listitem [ref=e402]:
+                    - strong [ref=e403]: Agents enable personalization.
+                    - text: By tailoring interactions and decisions to individual customer profiles or behaviors, agents can adapt the process dynamically to maximize satisfaction and outcomes.
+                  - listitem [ref=e404]:
+                    - strong [ref=e405]: Agents bring elasticity to operations.
+                    - text: Because agents are digital, their execution capacity can expand or contract in real time depending on workload, business seasonality, or unexpected surges—something difficult to achieve with fixed human resource models.
+                  - listitem [ref=e406]:
+                    - strong [ref=e407]: Agents also make operations more resilient.
+                    - text: By monitoring disruptions, rerouting operations, and escalating only when needed, they keep processes running—whether it’s supply chains navigating port delays or service workflows adapting to system outages.
+                - paragraph [ref=e408]: "In a complex supply chain environment, for example, an AI agent could act as an autonomous orchestration layer across sourcing, warehousing, and distribution operations. Connected to internal systems (such as the supply chain planning system or the warehouse management system) and external data sources (such as weather forecasts, supplier feeds, and demand signals), the agent could continuously forecast demand. It could then identify risks, such as delays or disruptions, and dynamically replan transport and inventory flows. Selecting the optimal transport mode based on cost, lead time, and environmental impact, the agent could reallocate stock across warehouses, negotiate directly with external systems, and escalate decisions requiring strategic input. The result: improved service levels, reduced logistics costs, and lower emissions."
+                - paragraph [ref=e409]: "Agents can also help spur top-line growth by amplifying existing revenue streams and unlocking entirely new ones:"
+                - list [ref=e410]:
+                  - listitem [ref=e411]:
+                    - strong [ref=e412]: Amplifying existing revenues.
+                    - text: In e-commerce, agents embedded into online stores or apps could proactively analyze user behavior, cart content, and context (for example, seasonality or purchase history) to surface real-time upselling and cross-selling offers. In finance, agents might help customers discover suitable financial products such as loans, insurance plans, or investment portfolios, providing tailored guidance based on financial profiles, life events, and user behavior.
+                  - listitem [ref=e413]:
+                    - strong [ref=e414]: Creating new revenue streams.
+                    - text: For industrial companies, agents embedded in connected products or equipment could monitor usage, detect performance thresholds, and autonomously unlock features or trigger maintenance actions—enabling pay-per-use, subscription, or performance-based models of creating revenue. Similarly, service organizations could encapsulate internal expertise—legal reasoning, tax interpretation, and procurement best practices—into AI agents offered as software-as-a-service tools or APIs to clients, partners, or smaller businesses lacking in-house expertise.
+                - paragraph [ref=e415]: In short, agentic AI doesn’t just automate. It redefines how organizations operate, adapt, and create value.
+                - 'heading "No longer science fiction: Forward-looking companies are harnessing the power of agents" [level=2] [ref=e416]'
+                - paragraph [ref=e417]: The following case studies demonstrate how QuantumBlack helps organizations build agent workforces—with outcomes that extend far beyond efficiency gains.
+                - 'heading "Case study 1: How a bank used hybrid ‘digital factories’ for legacy app modernization" [level=3] [ref=e418]'
+                - paragraph [ref=e419]:
+                  - strong [ref=e420]: "The problem:"
+                  - text: A large bank needed to modernize its legacy core system, which consisted of 400 pieces of software—a massive undertaking budgeted at more than $600 million. Large teams of coders tackled the project using manual, repetitive tasks, which resulted in difficulty coordinating across silos. They also relied on often slow, error-prone documentation and coding. While first-generation gen AI tools helped accelerate individual tasks, progress remained slow and laborious.
+                - paragraph [ref=e421]:
+                  - strong [ref=e422]: "The agentic approach:"
+                  - text: Human workers were elevated to supervisory roles, overseeing squads of AI agents, each contributing to a shared objective in a defined sequence (Exhibit 3). These squads retroactively document the legacy application, write new code, review the code of other agents, and integrate code into features that are later tested by other agents prior to delivery of the end product. Freed from repetitive, manual tasks, human supervisors guide each stage of the process, enhancing the quality of deliverables and reducing the number of sprints required to implement new features.
+                - paragraph [ref=e423]:
+                  - strong [ref=e424]: "Impact:"
+                  - text: More than 50 percent reduction in time and effort in the early adopter teams
+                - generic [ref=e425]:
+                  - generic [ref=e427]: Exhibit 3
+                  - img "A large bank upgraded its legacy tech stack with a hybrid AI-human digital factory." [ref=e430]
+                  - generic [ref=e431]:
+                    - text: "We strive to provide individuals with disabilities equal access to our website. If you would like information about this content we will be happy to work with you. Please email us at:"
+                    - link "McKinsey_Website_Accessibility@mckinsey.com" [ref=e432] [cursor=pointer]:
+                      - /url: mailto:McKinsey_Website_Accessibility@mckinsey.com
+                - 'heading "Case study 2: How a research firm boosted data quality to derive deeper market insights" [level=3] [ref=e433]'
+                - paragraph [ref=e434]:
+                  - strong [ref=e435]: "The problem:"
+                  - text: A market research and intelligence firm was devoting substantial resources to ensure data quality, relying on a team of more than 500 people whose responsibilities included gathering data, structuring and codifying it, and generating tailored insights for clients. The process, conducted manually, was prone to error, with a staggering 80 percent of mistakes identified by the clients themselves.
+                - paragraph [ref=e436]:
+                  - strong [ref=e437]: "The agentic approach:"
+                  - text: A multiagent solution autonomously identifies data anomalies and explains shifts in sales or market share. It analyzes internal signals, such as changes in product taxonomy, and external events identified via web searches, including product recalls or severe weather. The most influential drivers are synthesized, ranked, and prepared for decision-makers. With advanced search and contextual reasoning, the agents often surface insights that would be difficult for human analysts to uncover manually. While not yet in production, the system is fully functional and has demonstrated strong potential to free up analysts for more strategic work.
+                - paragraph [ref=e438]:
+                  - strong [ref=e439]: "Impact:"
+                  - text: More than 60 percent potential productivity gain and expected savings of more than $3 million annually.
+                - 'heading "Case study 3: How a bank reimagined the way it creates credit-risk memos" [level=3] [ref=e440]'
+                - paragraph [ref=e441]:
+                  - strong [ref=e442]: "The problem:"
+                  - text: Relationship managers (RMs) at a retail bank were spending weeks writing and iterating credit-risk memos to help make credit decisions and fulfill regulatory requirements (Exhibit 4). This process required RMs to manually review and extract information from at least ten different data sources and develop complex nuanced reasoning across interdependent sections—for instance, loan, revenue, and cash joint evolution.
+                - paragraph [ref=e443]:
+                  - strong [ref=e444]: "The agentic approach:"
+                  - text: In close collaboration with the bank’s credit-risk experts and RMs, a proof of concept was developed to transform the credit memo workflow using AI agents. The agents assist RMs by extracting data, drafting memo sections, generating confidence scores to prioritize review, and suggesting relevant follow-up questions. In this model, the analyst’s role shifts from manual drafting to strategic oversight and exception handling.
+                - paragraph [ref=e445]:
+                  - strong [ref=e446]: "Impact:"
+                  - text: A potential 20 to 60 percent increase in productivity, including a 30 percent improvement in credit turnaround
+                - generic [ref=e447]:
+                  - generic [ref=e449]: Exhibit 4
+                  - img "A retail bank used AI agents to reinvent the process of creating credit-risk memos." [ref=e452]
+                  - generic [ref=e453]:
+                    - text: "We strive to provide individuals with disabilities equal access to our website. If you would like information about this content we will be happy to work with you. Please email us at:"
+                    - link "McKinsey_Website_Accessibility@mckinsey.com" [ref=e454] [cursor=pointer]:
+                      - /url: mailto:McKinsey_Website_Accessibility@mckinsey.com
+                - heading "Maximizing value from AI agents requires process reinvention" [level=2] [ref=e455]
+                - paragraph [ref=e456]: Realizing AI’s full potential in the vertical realm requires more than simply inserting agents into legacy workflows. It instead calls for a shift in design mindset—from automating tasks within an existing process to reinventing the entire process with human and agentic coworkers. That’s because when agents are embedded into a legacy process without redesign, they typically serve as faster assistants—generating content, retrieving data, or executing predefined steps. But the process itself remains sequential, rule bound, and shaped by human constraints.
+                - paragraph [ref=e457]: "Reinventing a process around agents means more than layering automation on top of existing workflows—it involves rearchitecting the entire task flow from the ground up. That includes reordering steps, reallocating responsibilities between humans and agents, and designing the process to fully exploit the strengths of agentic AI: parallel execution that collapses cycle time, real-time adaptability that reacts to changing conditions, deep personalization at scale, and elastic capacity that flexes instantly with demand."
+                - paragraph [ref=e458]: Consider a hypothetical customer call center. Before introducing AI agents, the facility was using gen AI tools to assist human support staff by retrieving articles from knowledge bases, summarizing ticket histories, and helping draft responses. While this assistance improved speed and reduced cognitive load, the process itself remained entirely manual and reactive, with human agents still managing every step of diagnosis, coordination, and resolution. The productivity improvement potential was modest, typically boosting resolution time and productivity between 5 and 10 percent.
+                - paragraph [ref=e459]: Now imagine that the call center introduces AI agents but largely preserves the existing workflow—agents are added to assist at specific steps without reconfiguring how work is routed, tracked, or resolved end-to-end. Agents can classify tickets, suggest likely root causes, propose resolution paths, and even autonomously resolve frequent, low-complexity issues (such as password resets). While the impact here can be increased—an estimated 20 to 40 percent savings in time and a 30 to 50 percent reduction in backlog—coordination friction and limited adaptability prevent true breakthrough gains.
+                - paragraph [ref=e460]: But the real shift occurs at the third level, when the call center’s process is reimagined around agent autonomy. In this model, AI agents don’t just respond—they proactively detect common customer issues (such as delayed shipments, failed payments, or service outages) by monitoring patterns across channels, anticipate likely needs, initiate resolution steps automatically (such as issuing refunds, reordering items, or updating account details), and communicate directly with customers via chat or email. Human agents are repositioned as escalation managers and service quality overseers, who are brought in only when agents detect uncertainty or exceptions to typical patterns. Impact at this level is transformative. This could allow a radical improvement of customer service desk productivity. Up to 80 percent of common incidents could be resolved autonomously, with a reduction in time to resolution of 60 to 90 percent (Exhibit 5).
+                - generic [ref=e461]:
+                  - generic [ref=e463]: Exhibit 5
+                  - img "Agents hold the key to breaking through--if processes are reinvented, not just optimized." [ref=e466]
+                  - generic [ref=e467]:
+                    - text: "We strive to provide individuals with disabilities equal access to our website. If you would like information about this content we will be happy to work with you. Please email us at:"
+                    - link "McKinsey_Website_Accessibility@mckinsey.com" [ref=e468] [cursor=pointer]:
+                      - /url: mailto:McKinsey_Website_Accessibility@mckinsey.com
+                - paragraph [ref=e469]: Of course, not every business process requires full reinvention. Simple task automation is sufficient for highly standard, repetitive workflows with limited variability—such as payroll processing, travel expense approvals, or password resets—where gains come primarily from reducing manual effort. In contrast, processes that are complex, cross-functional, prone to exceptions, or tightly linked to business performance often warrant full redesign. Key indicators that call for reinvention include high coordination overhead, rigid sequences that delay responsiveness, frequent human intervention for decisions that could be data driven, and opportunities for dynamic adaptation or personalization. In these cases, redesigning the process around the agent’s ability to orchestrate, adapt, and learn delivers far greater value than simply speeding up existing workflows.
+                - heading "A new AI architecture paradigm—the agentic AI mesh—is required to orchestrate value in the agentic era" [level=2] [ref=e470]
+                - paragraph [ref=e471]: "To scale agents, companies will need to overcome a threefold challenge: handling the newfound risks that AI agents bring, blending custom and off-the-shelf agentic systems, and staying agile amid fast-evolving tech (while avoiding lock-ins)."
+                - list [ref=e472]:
+                  - listitem [ref=e473]:
+                    - strong [ref=e474]: Managing a new wave of risks.
+                    - text: "Agents introduce a new class of systemic risks that traditional gen AI architectures, designed primarily for isolated LLM-centric use cases, were never built to handle: uncontrolled autonomy, fragmented system access, lack of observability and traceability, expanding surface of attack, and agent sprawl and duplication. What starts as intelligent automation can quickly become operational chaos—unless it is built on a foundation that prioritizes control, scalability, and trust."
+                  - listitem [ref=e475]:
+                    - strong [ref=e476]: Blending custom and off-the-shelf agents.
+                    - text: To fully capture the transformative potential of AI agents, organizations must go beyond simply activating agents embedded in software suites. These off-the-shelf agents may streamline routine workflows, but they rarely unlock strategic advantage. Realizing the full potential of agentic AI will require the development of custom-built agents for high-impact processes, such as end-to-end customer resolution, adaptive supply chain orchestration, or complex decision-making. These agents must be deeply aligned with the company’s logic, data flows, and value creation levers—making them difficult to replicate and uniquely powerful.
+                  - listitem [ref=e477]:
+                    - strong [ref=e478]: Staying agile amid fast-evolving tech.
+                    - text: Agentic AI is a new technology area, and solutions are evolving very rapidly. Agents will have to support workflows across multiple systems and should not be hardwired within a specific platform. An evolutive and vendor-agnostic architecture is therefore needed.
+                - paragraph [ref=e479]: "These challenges cannot be addressed by merely bolting new components, such as memory stores or orchestration engines, on top of existing gen AI stacks. While such capabilities are necessary, they are not sufficient. What’s needed is a fundamental architectural shift: from static, LLM-centric infrastructure to a dynamic, modular, and governed environment built specifically for agent-based intelligence—the agentic AI mesh."
+                - paragraph [ref=e480]: "The agentic AI mesh is a composable, distributed, and vendor-agnostic architectural paradigm that enables multiple agents to reason, collaborate, and act autonomously across a wide array of systems, tools, and language models—securely, at scale, and built to evolve with the technology. At the heart of this paradigm are five mutually reinforcing design principles:"
+                - list [ref=e481]:
+                  - listitem [ref=e482]:
+                    - strong [ref=e483]: Composability.
+                    - text: Any agent, tool, or LLM can be plugged into the mesh without system rework.
+                  - listitem [ref=e484]:
+                    - strong [ref=e485]: Distributed intelligence.
+                    - text: Tasks can be decomposed and resolved by networks of cooperating agents.
+                  - listitem [ref=e486]:
+                    - strong [ref=e487]: Layered decoupling.
+                    - text: Logic, memory, orchestration, and interface functions are decoupled to maximize modularity.
+                  - listitem [ref=e488]:
+                    - strong [ref=e489]: Vendor neutrality.
+                    - text: All components can be independently updated or replaced as technology advances, avoiding vendor lock-in and future-proofing the architecture. In particular, open standards such as the Model Context Protocol (MCP) and Agent2Agent (A2A) are preferred to proprietary protocols.
+                  - listitem [ref=e490]:
+                    - strong [ref=e491]: Governed autonomy.
+                    - text: Agent behavior is proactively controlled via embedded policies, permissions, and escalation mechanisms that ensure safe, transparent operation.
+                - generic [ref=e493]:
+                  - generic [ref=e495]:
+                    - button " Share" [ref=e497] [cursor=pointer]:
+                      - generic [ref=e498]: 
+                      - generic [ref=e499]: Share
+                    - button "Expandable Sidebar" [ref=e500] [cursor=pointer]:
+                      - generic [ref=e501]: 
+                  - generic [ref=e502]:
+                    - generic [ref=e503]: Sidebar
+                    - heading "Seven interconnected capabilities of the AI agentic mesh" [level=2] [ref=e505]:
+                      - generic [ref=e506]: Seven interconnected capabilities of the AI agentic mesh
+                - paragraph [ref=e507]: The agentic AI mesh acts as the connective and orchestration layer that enables large-scale, intelligent agent ecosystems to operate safely and efficiently, and continuously evolve. It allows companies to coordinate custom-built and off-the-shelf agents within a unified framework, support multiagent collaboration by allowing agents to share context and delegate tasks, and mitigate key risks such as agent sprawl, autonomy drift, and lack of observability—all while preserving the agility required for a rapid technology evolution (see sidebar “Seven interconnected capabilities of the AI agentic mesh”).
+                - generic [ref=e509]:
+                  - generic [ref=e511]:
+                    - button " Share" [ref=e513] [cursor=pointer]:
+                      - generic [ref=e514]: 
+                      - generic [ref=e515]: Share
+                    - button "Expandable Sidebar" [ref=e516] [cursor=pointer]:
+                      - generic [ref=e517]: 
+                  - generic [ref=e518]:
+                    - generic [ref=e519]: Sidebar
+                    - 'heading "Foundation models for agents: Five requirements" [level=2] [ref=e521]':
+                      - generic [ref=e522]: "Foundation models for agents: Five requirements"
+                - paragraph [ref=e523]: "Beyond this architectural evolution, organizations will also have to revisit their LLM strategies. At the core of every custom agent lies a foundation model—the reasoning engine that powers perception, decision-making, and interaction. In the agentic era, the requirements placed on LLMs evolve significantly. Agents are not passive copilots—they are autonomous, persistent, embedded systems. This creates five critical categories of LLM requirements, each aligned with specific deployment contexts, for which different kinds of models will be relevant (see sidebar “Foundational models for agents: Five requirements”)."
+                - paragraph [ref=e524]: Finally, to truly scale agent deployment across the enterprise, the enterprise systems themselves must also evolve.
+                - paragraph [ref=e525]: In the short term, APIs—protocols that allow different software applications to communicate and exchange data—will remain the primary interface for agents to interact with enterprise systems. But in the long term, APIs alone will not suffice. Organizations must begin reimagining their IT architectures around an agent-first model—one in which user interfaces, logic, and data access layers are natively designed for machine interaction rather than human navigation. In such a model, systems are no longer organized around screens and forms but around machine-readable interfaces, autonomous workflows, and agent-led decision flows.
+                - paragraph [ref=e526]: "This shift is already underway. Microsoft is embedding agents into the core of Dynamics 365 and Microsoft 365 via Copilot Studio; Salesforce is expanding Agentforce into a multiagent orchestration layer; SAP is rearchitecting its Business Technology Platform (BTP) to support agent integration through Joule. These changes signal a broader transition: The future of enterprise software is not just AI-augmented—it is agent-native."
+                - heading "The main challenge won’t be technical—it will be human" [level=2] [ref=e527]
+                - paragraph [ref=e528]: "As agents evolve from passive copilots to proactive actors—and scale across the enterprise—the complexity they introduce will be not only technical but mostly organizational. The real challenge lies in coordination, judgment, and trust. This organizational complexity will play out most visibly across three dimensions: how humans and agents cohabit day-to-day workflows; how organizations establish governance over systems that can act autonomously; and how they prevent unchecked sprawl as agent creation becomes increasingly democratized."
+                - list [ref=e529]:
+                  - listitem [ref=e530]:
+                    - strong [ref=e531]: Human–agent cohabitation.
+                    - text: "Agents won’t just assist humans—they’ll act alongside them. This raises nuanced questions about interaction and coexistence: When should an agent take initiative? When should it defer? How do we maintain human agency and oversight without slowing down the very benefits agents bring? Building clarity around these roles will take time, experimentation, and cultural adjustment. Trust won’t come from technical performance alone—it will hinge on how transparently agents communicate, how predictably they behave, and how intuitively they integrate into daily workflows."
+                  - listitem [ref=e532]:
+                    - strong [ref=e533]: Autonomy control.
+                    - text: "What makes agents powerful—their ability to act independently—also introduces ambiguity. Unlike traditional tools, agents don’t wait to be instructed. They respond, adapt, and sometimes surprise. Navigating this new reality means confronting edge cases: What if an agent executes too aggressively? Or fails to escalate a subtle issue? The challenge is not to eliminate autonomy but to make it intelligible and aligned with organizational expectations. That alignment won’t be static. It will need to evolve as agents learn, systems shift, and trust deepens. Control mechanisms must also address the risk of hallucinations, or plausible but inaccurate outputs agents may produce."
+                  - listitem [ref=e534]:
+                    - strong [ref=e535]: Sprawl containment.
+                    - text: "As in the early days of robotic process automation, there’s a real risk of agent sprawl—the uncontrolled proliferation of redundant, fragmented, and ungoverned agents across teams and functions. As low-code and no-code platforms make agent creation accessible to anyone, organizations risk a new kind of shadow IT: agents that multiply across teams, duplicate efforts, or operate without oversight. How do we avoid fragmentation? Who decides what gets built—and what gets retired? Without structured governance, design standards, and life cycle management, agent ecosystems can quickly become fragile, redundant, and unscalable."
+                - paragraph [ref=e536]: Agents unlock the full potential of vertical use cases, offering companies a path to generate value well beyond efficiency gains. But realizing that potential requires a reimagined approach to AI transformation—one tailored to the unique nature of agents and capable of addressing the lingering limitations they alone cannot resolve. This approach is the subject of our next chapter.
+                - region "Chapter 3"
+                - generic [ref=e537]:
+                  - img "Computer Neural Network Concept Image. Bright dots connected by glowing lines." [ref=e538]
+                  - generic [ref=e544]:
+                    - generic [ref=e545]: Chapter 3
+                    - 'heading "AI transformation at a tipping point: The CEO mandate in the agentic era AI transformation at a tipping point: The CEO mandate in the agentic era" [level=2] [ref=e546]':
+                      - generic [ref=e547]:
+                        - text: "AI transformation at a tipping point: The CEO mandate in the agentic era"
+                        - 'link "AI transformation at a tipping point: The CEO mandate in the agentic era" [ref=e548] [cursor=pointer]':
+                          - /url: "#"
+                          - generic [ref=e549]: 
+                - generic [ref=e552]:
+                  - generic [ref=e553]:
+                    - heading "Key Points" [level=2] [ref=e554]:
+                      - generic [ref=e555]: Key Points
+                    - generic [ref=e556]:
+                      - generic [ref=e557] [cursor=pointer]: Continue to next section
+                      - button "" [ref=e558] [cursor=pointer]:
+                        - generic [ref=e559]: 
+                  - generic [ref=e560]:
+                    - button " Share" [ref=e563] [cursor=pointer]:
+                      - generic [ref=e564]: 
+                      - generic [ref=e565]: Share
+                    - list [ref=e569]:
+                      - listitem [ref=e570]:
+                        - strong [ref=e571]:
+                          - emphasis [ref=e572]: Generating impact in the agentic era requires organizations to shift from scattered initiatives to strategic programs; from use cases to business processes; from siloed AI teams to cross-functional transformation squads; and from experimentation to industrialized, scalable delivery.
+                      - listitem [ref=e573]:
+                        - strong [ref=e574]:
+                          - emphasis [ref=e575]: To scale agents, organizations will also need to set a new foundation by upskilling the workforce, adapting the technology infrastructure, and developing new governance structures for agents.
+                      - listitem [ref=e576]:
+                        - strong [ref=e577]:
+                          - emphasis [ref=e578]: The time has come to bring the gen AI experimentation phase to an end—a pivot only the CEO can make.
+                - heading "Scaling impact in the agentic era requires a reset of the AI transformation approach" [level=2] [ref=e579]
+                - paragraph [ref=e580]:
+                  - text: Unlike gen AI tools that could be easily plugged into existing workflows, AI agents demand a more foundational shift, one that requires rethinking business processes and enabling deep integration with enterprise systems. McKinsey has a
+                  - link "proven Rewired playbook for AI-driven transformations" [ref=e581] [cursor=pointer]:
+                    - /url: /capabilities/tech-and-ai/our-insights/rewired-to-outcompete
+                  - text: .
+                  - generic "footnote" [ref=e583] [cursor=pointer]:
+                    - superscript [ref=e584]: "[11]"
+                  - text: "To capitalize on the agentic opportunity, organizations must build on that, fundamentally reshaping their AI transformation approach across four dimensions:"
+                - list [ref=e585]:
+                  - listitem [ref=e586]:
+                    - strong [ref=e587]: "Strategy: From scattered tactical initiatives to strategic programs."
+                    - text: With agentic AI set to reshape the foundations of competition, organizations must move beyond bottom-up use case identification and directly align AI initiatives with their most critical strategic priorities. This means not only translating existing goals—such as enhancing operational efficiency, improving customer intimacy, or strengthening compliance—into AI-addressable transformation domains, but also adopting a forward-looking lens. Executives must challenge their organizations to look beyond the boundaries of today’s operating model and explore how AI can be used to reimagine entire segments of the business, create new revenue streams, and build competitive moats that will define leadership in the next decade.
+                  - listitem [ref=e588]:
+                    - strong [ref=e589]: "Unit of transformation: From use case to business processes."
+                    - text: In the early wave of gen AI adoption, most vertical initiatives focused on plugging a solution into a specific step of an existing process—which tended to deliver narrow gains without changing the overall structure of how work is done. With AI agents, the paradigm shifts entirely. Opportunity now lies not in optimizing isolated tasks but in transforming entire business processes by embedding agents throughout the value chain. As a result, AI initiatives should no longer be scoped around a single use case, but instead around the end-to-end reinvention of a full process or persona journey. In vertical domains, this means moving from the question, “Where can I use AI in this function?” to “What would this function look like if agents ran 60 percent of it?” It involves rethinking workflows, decision logic, human–system interactions, and performance metrics across the board.
+                  - listitem [ref=e590]:
+                    - strong [ref=e591]: "Delivery model: From siloed AI teams to cross-functional transformation squads."
+                    - text: AI centers of excellence have played a key role in accelerating AI awareness and experimentation across organizations. However, this model reaches its limits in the agentic era—in which agents are deeply embedded into enterprise systems, operate across complex business processes, and rely on high-quality data as their primary fuel. In this context, AI initiatives can no longer be delivered by isolated, specialized AI teams. To succeed at scale, organizations must shift to a cross-functional delivery model, anchored in durable transformation squads composed of business domain experts, process designers, AI and MLOps engineers, IT architects, software engineers, and data engineers.
+                  - listitem [ref=e592]:
+                    - strong [ref=e593]: "Implementation process: From experimentation to industrialized, scalable delivery."
+                    - text: While the previous phase rightly focused on exploring the potential of gen AI, organizations must now shift to an industrialized delivery model, in which solutions are designed from the outset to scale, both technically and financially. This requires organizations to anticipate the full set of technical prerequisites for enterprise deployment—notably in terms of system integration, day-to-day monitoring, and release management, but also to rigorously estimate future running costs and design a solution to minimize them. Unlike traditional IT systems—for which
+                    - link "annual run costs typically represent 10 to 20 percent of initial build costs" [ref=e594] [cursor=pointer]:
+                      - /url: /industries/technology-media-and-telecommunications/our-insights/transforming-infrastructure-operations-for-a-hybrid-cloud-world
+                    - generic "footnote" [ref=e596] [cursor=pointer]:
+                      - superscript [ref=e597]: "[12]"
+                    - text: —gen AI solutions, especially at scale, can incur recurring costs that exceed the initial build investment. Designing for scalability must therefore include not just technical robustness but also economic sustainability, especially for high-volume applications.
+                - heading "Four critical enablers are required to effectively operate in the agentic era" [level=2] [ref=e598]
+                - paragraph [ref=e599]: Redesigning the approach to AI transformation is an important step, but it is not enough. To unlock their full potential at scale, organizations must also activate a robust set of enablers that support the structural, cultural, and technical shifts required to integrate agents into day-to-day operations. These enablers span four dimensions—people, governance, technology architecture, and data—each of which is a foundation for scalable, secure, and high-impact deployment of agents across the enterprise.
+                - list [ref=e600]:
+                  - listitem [ref=e601]:
+                    - strong [ref=e602]: "People: Equip the workforce and introduce new roles."
+                    - text: The workforce must be equipped for new ways of working driven by human–agent collaboration. This involves fostering a “human + agent” mindset through cultural change, targeted training, and supporting early adopters as internal champions. New roles must also be introduced, such as prompt engineers to refine interactions, agent orchestrators to manage agent workflows, and human-in-the-loop designers to handle exceptions and build trust.
+                  - listitem [ref=e603]:
+                    - strong [ref=e604]: "Governance: Ensure autonomy control and prevent agent sprawl."
+                    - text: With the rise of autonomous agents comes the need for strong governance to avoid risk and uncontrolled sprawl. Enterprises should define governance frameworks that establish agent autonomy levels, decision boundaries, behavior monitoring, and audit mechanisms. Policies for development, deployment, and usage must also be formalized, along with classification systems that group agents by function (such as task automators, domain orchestrators, and virtual collaborators), each with an appropriate oversight model.
+                  - listitem [ref=e605]:
+                    - strong [ref=e606]: "Technology architecture: Build a foundation for interoperability and scale."
+                    - text: Agents, whether custom-built or off-the-shelf, must operate across a fragmented ecosystem of systems, data, and workflows. In the short term, organizations must evolve their AI architecture from LLM-centric setups to an agentic AI mesh. Beyond this first step, organizations should start preparing for their next-generation architecture, in which all enterprise systems will be reshuffled around agents in terms of user interface, business logic, and day-to-day operations.
+                  - listitem [ref=e607]:
+                    - strong [ref=e608]: "Data: Accelerate data productization and address quality gaps in unstructured data."
+                    - text: Finally, agents depend on the quality and accessibility of enterprise data. Organizations must transition from use-case-specific data pipelines to reusable data products and extend data governance to unstructured data.
+                - 'heading "CEOs have a leadership challenge: Bringing the gen AI experimentation phase to a close" [level=2] [ref=e609]'
+                - paragraph [ref=e610]: The rise of AI agents is more than just a technological shift. Agents represent a strategic inflection point that will redefine how companies operate, compete, and create value. To navigate this transition successfully, organizations must move beyond experimentation and pilot programs and enter a new phase of scaled, enterprise-wide transformation.
+                - paragraph [ref=e611]: "This pivot cannot be delegated—it must be initiated and led by the CEO. It will rely on three key actions:"
+                - list [ref=e612]:
+                  - listitem [ref=e613]:
+                    - strong [ref=e614]: "Action 1: Conclude the experimentation phase and realign AI priorities."
+                    - text: Conduct a structured review to capture lessons learned, retire unscalable pilots, and formally close the exploratory phase. Refocus efforts on strategic AI programs targeting high-impact domains and processes.
+                  - listitem [ref=e615]:
+                    - strong [ref=e616]: "Action 2: Redesign the AI governance and operating model."
+                    - text: Set up a strategic AI council involving business leaders, the chief human resources officer, the chief data officer, and the chief information officer. This council should oversee AI direction-setting; coordinate AI, IT, and data investments; and implement rigorous value-tracking mechanisms based on KPIs tied to business outcomes.
+                  - listitem [ref=e617]:
+                    - strong [ref=e618]: "Action 3: Launch a first lighthouse transformation project and simultaneously initialize the agentic AI tech foundation."
+                    - text: Kick off a select number of high-impact agentic AI–driven workflow transformations in core business areas. In parallel, lay the groundwork for an agentic AI technology foundation by investing in key enablers—technology infrastructure, data quality, governance frameworks, and workforce readiness.
+                - region "Conclusion"
+                - heading "Conclusion Conclusion" [level=2] [ref=e626]:
+                  - generic [ref=e627]:
+                    - text: Conclusion
+                    - link "Conclusion" [ref=e628] [cursor=pointer]:
+                      - /url: "#"
+                      - generic [ref=e629]: 
+                - paragraph [ref=e630]: Like any truly disruptive technology, AI agents have the power to reshuffle the deck. Done right, they offer laggards a leapfrog opportunity to rewire their competitiveness. Done wrong—or not at all—they risk accelerating the decline of today’s market leaders. This is a moment of strategic divergence.
+                - paragraph [ref=e631]: "While the technology will continue to evolve, it is already mature enough to drive real, transformative change across industries. But to realize the full promise of agentic AI, CEOs must rethink their approach to AI transformation—not as a series of scattered pilots but as focused, end-to-end reinvention efforts. That means identifying a few business domains with the highest potential and pulling every lever: from reimagining workflows to redistributing tasks between humans and machines to rewiring the organization based on new operating models."
+                - paragraph [ref=e632]:
+                  - text: Some leaders are already moving—not just by deploying fleets of agents but by rewiring their organizations to harness their full disruptive potential. (Moderna, for example, merged its HR and IT leadership
+                  - generic "footnote" [ref=e634] [cursor=pointer]:
+                    - superscript [ref=e635]: "[13]"
+                  - text: —signaling that AI is not just a technical tool but a workforce-shaping force.) This is a structural move toward a new kind of enterprise. Agentic AI is not an incremental step—it is the foundation of the next-generation operating model. CEOs who act now won’t just gain a performance edge. They will redefine how their organizations think, decide, and execute.
+                - paragraph [ref=e636]: The time for exploration is ending. The time for transformation is now.
+              - generic [ref=e637]:
+                - generic [ref=e638]:
+                  - paragraph
+                - heading "How relevant and useful is this article for you?" [level=5] [ref=e639]
+                - generic [ref=e640]:
+                  - button "Rate 1 star" [ref=e641] [cursor=pointer]:
+                    - generic [ref=e642]:
+                      - img
+                  - button "Rate 2 star" [ref=e643] [cursor=pointer]:
+                    - generic [ref=e644]:
+                      - img
+                  - button "Rate 3 star" [ref=e645] [cursor=pointer]:
+                    - generic [ref=e646]:
+                      - img
+                  - button "Rate 4 star" [ref=e647] [cursor=pointer]:
+                    - generic [ref=e648]:
+                      - img
+                  - button "Rate 5 star" [ref=e649] [cursor=pointer]:
+                    - generic [ref=e650]:
+                      - img
+            - generic [ref=e651]:
+              - contentinfo [ref=e652]:
+                - generic [ref=e653]:
+                  - heading "About the author(s)" [level=5] [ref=e654]
+                  - generic [ref=e656]:
+                    - paragraph [ref=e657]:
+                      - strong [ref=e658]:
+                        - link "Alexander Sukharevsky" [ref=e659] [cursor=pointer]:
+                          - /url: /our-people/alexander-sukharevsky
+                      - text: is a senior partner in McKinsey’s London office, where
+                      - strong [ref=e660]:
+                        - link "Dave Kerr" [ref=e661] [cursor=pointer]:
+                          - /url: /our-people/dave-kerr
+                      - text: is a partner;
+                      - strong [ref=e662]:
+                        - link "Klemens Hjartar" [ref=e663] [cursor=pointer]:
+                          - /url: /our-people/klemens-hjartar
+                      - text: is a senior partner in the Copenhagen office;
+                      - strong [ref=e664]:
+                        - link "Lari Hämäläinen" [ref=e665] [cursor=pointer]:
+                          - /url: /our-people/lari-hamalainen
+                      - text: is a senior partner in the Seattle office;
+                      - strong [ref=e666]:
+                        - link "Stéphane Bout" [ref=e667] [cursor=pointer]:
+                          - /url: /our-people/stephane-bout
+                      - text: is a senior partner in the Lyon office;
+                      - strong [ref=e668]:
+                        - link "Vito Di Leo" [ref=e669] [cursor=pointer]:
+                          - /url: /our-people/vito-di-leo
+                      - text: is a partner in the Zurich office; and
+                      - strong [ref=e670]: Guillaume Dagorret
+                      - text: is a senior fellow with the McKinsey Global Institute and is based in the Paris office.
+                    - paragraph [ref=e671]: The authors wish to thank Alena Fedorenko, Annie David, Clarisse Magnin, Lareina Yee, Larry Kanter, Michael Chui, Roger Roberts, Sarah Mulligan, Thomas Vlot, and Timo Mauerhoefer for their contributions to this report.
+                    - separator [ref=e672]
+                    - paragraph [ref=e673]: This article was edited by Larry Kanter, a senior editor in the New York office.
+              - button "Talk to us" [ref=e675] [cursor=pointer]
+              - generic [ref=e677]:
+                - heading "Explore a career with us" [level=5] [ref=e678]
+                - link "Search openings" [ref=e680] [cursor=pointer]:
+                  - /url: /careers/search-jobs
+                  - generic [ref=e681]: Search openings
+        - generic [ref=e683]:
+          - heading "Related Articles" [level=5] [ref=e684]
+          - generic [ref=e685]:
+            - generic [ref=e686]:
+              - link "Delicate blue and purple tendrils constantly expanding. These tendrils bear a resemblance to neurons, with luminous buds at their tips." [ref=e688] [cursor=pointer]:
+                - /url: /capabilities/quantumblack/our-insights/the-state-of-ai-how-organizations-are-rewiring-to-capture-value
+                - img "Delicate blue and purple tendrils constantly expanding. These tendrils bear a resemblance to neurons, with luminous buds at their tips." [ref=e690]
+              - generic [ref=e692]:
+                - text: Survey
+                - 'heading "The state of AI: How organizations are rewiring to capture value" [level=6] [ref=e693]':
+                  - 'link "The state of AI: How organizations are rewiring to capture value" [ref=e694] [cursor=pointer]':
+                    - /url: /capabilities/quantumblack/our-insights/the-state-of-ai-how-organizations-are-rewiring-to-capture-value
+                    - generic [ref=e695]: "The state of AI: How organizations are rewiring to capture value"
+            - generic [ref=e696]:
+              - link "Abstract image of colorful digital lines coming down and spreading forward like a highway." [ref=e698] [cursor=pointer]:
+                - /url: /capabilities/tech-and-ai/our-insights/superagency-in-the-workplace-empowering-people-to-unlock-ais-full-potential-at-work
+                - img "Abstract image of colorful digital lines coming down and spreading forward like a highway." [ref=e700]
+              - generic [ref=e702]:
+                - text: Report
+                - 'heading "Superagency in the workplace: Empowering people to unlock AI’s full potential" [level=6] [ref=e703]':
+                  - 'link "Superagency in the workplace: Empowering people to unlock AI’s full potential" [ref=e704] [cursor=pointer]':
+                    - /url: /capabilities/tech-and-ai/our-insights/superagency-in-the-workplace-empowering-people-to-unlock-ais-full-potential-at-work
+                    - generic [ref=e705]: "Superagency in the workplace: Empowering people to unlock AI’s full potential"
+            - generic [ref=e706]:
+              - link "Image of a hand tracing a light circle in the air" [ref=e708] [cursor=pointer]:
+                - /url: /capabilities/tech-and-ai/our-insights/why-agents-are-the-next-frontier-of-generative-ai
+                - img "Image of a hand tracing a light circle in the air" [ref=e710]
+              - generic [ref=e712]:
+                - generic [ref=e713]: Article - McKinsey Quarterly
+                - heading "Why agents are the next frontier of generative AI" [level=6] [ref=e714]:
+                  - link "Why agents are the next frontier of generative AI" [ref=e715] [cursor=pointer]:
+                    - /url: /capabilities/tech-and-ai/our-insights/why-agents-are-the-next-frontier-of-generative-ai
+                    - generic [ref=e716]: Why agents are the next frontier of generative AI
+    - generic [ref=e718]:
+      - generic [ref=e720]:
+        - heading "Sign up for emails on new Artificial Intelligence articles" [level=5] [ref=e721]
+        - paragraph [ref=e722]: Never miss an insight. We'll email you when new articles are published on this topic.
+        - generic [ref=e724]:
+          - textbox "Email address" [ref=e728]
+          - button "Subscribe" [ref=e730] [cursor=pointer]
+      - button "Close" [ref=e731] [cursor=pointer]:
+        - generic [ref=e732]: 
+    - contentinfo [ref=e736]
+    - log [ref=e737]
+  - generic:
+    - dialog "Privacy" [ref=e739]:
+      - generic [ref=e740]:
+        - generic [ref=e742]:
+          - text: McKinsey & Company, Inc. uses cookies to better understand how visitors use our site, to collect and analyze information on site performance and usage, and for targeted advertising purposes.
+          - link "Cookie Notice" [ref=e743] [cursor=pointer]:
+            - /url: https://www.mckinsey.com/cookie-policy
+          - text: We do not sell personal information, but we may share your personal data with third parties for cross-context behavioral advertising.
+          - text: Please see our
+          - link "Privacy Notice" [ref=e744] [cursor=pointer]:
+            - /url: https://www.mckinsey.com/privacy-policy
+          - text: for more information.
+        - generic [ref=e746]:
+          - button "Manage my preferences, Opens the preference center dialog" [ref=e747] [cursor=pointer]: Manage my preferences
+          - generic [ref=e748]:
+            - button "Decline optional cookies" [ref=e749] [cursor=pointer]
+            - button "Accept All Cookies" [ref=e750] [cursor=pointer]
+    - text:   Back
+  - alert [ref=e751]

--- a/plugins/handsonai/skills/indexing-registry/references/manifest-resolution.md
+++ b/plugins/handsonai/skills/indexing-registry/references/manifest-resolution.md
@@ -42,7 +42,7 @@ where `<slug>` is the workflow's kebab-case ID (the same value the YAML backend 
 | `autonomy` | frontmatter `autonomy` — `deterministic` \| `guided` \| `autonomous` |
 | `definition_type` | frontmatter `definition_type` — `step-decomposed` \| `outcome-driven` (kebab-case) |
 | `trigger` | frontmatter `trigger` |
-| `business_process` | frontmatter `process:` — a root-relative link to the Process node: `/processes/<process-slug>.md` |
+| `business_process` | a `N. [Title](/workflows/<slug>.md)` line in the Process node's curated ordered `# Workflows` list (`registry/processes/<process-slug>.md`) — the list is BOTH the Workflow→Process edge and the value-chain order. Never write a `process:` frontmatter field on the Workflow node (banned; lint errors). Place the line at the workflow's position in the process sequence (append at the end if unknown); a workflow must appear in exactly one process's list. |
 | `next_review` | frontmatter `next_review` |
 | `artifacts:` map | labeled links in the `# Artifacts` body section (see below) |
 | `platform_artifacts` | links in the `# Skills` and `# Agents` body sections |
@@ -111,4 +111,4 @@ Never write these to a Workflow node — they have no equivalent and must not be
 
 ### Process nodes
 
-In bundle mode the business-process record is likewise a concept node: `registry/processes/<process-slug>.md`. Workflow nodes join to it via their `process:` frontmatter link. When a skill produces a process guide, the Process node's `guide:` frontmatter field points at the guide file (same link conventions as above).
+In bundle mode the business-process record is likewise a concept node: `registry/processes/<process-slug>.md`. Workflows join to it via the process's curated ordered `# Workflows` list (see the mapping table above) — child nodes carry no pointer. When a skill produces a process guide, the Process node's `guide:` frontmatter field points at the guide file (same link conventions as above).

--- a/src/content/docs/platforms/claude/cowork/index.md
+++ b/src/content/docs/platforms/claude/cowork/index.md
@@ -1,0 +1,85 @@
+---
+title: Claude Cowork
+description: How to give Cowork the persistent context it needs by writing a CLAUDE.md file.
+---
+
+Cowork is what Anthropic calls Claude when you point it at a folder and hand it a goal, instead of driving it turn-by-turn in chat. Cowork reads the files in that folder, works through the steps, and often runs while you're doing something else.
+
+The catch: every session starts cold. Whatever Claude needs to know about you, your folder, and how you work has to live in a file Cowork can read. That file is `CLAUDE.md`.
+
+## Why CLAUDE.md matters in Cowork
+
+In chat, you can correct Claude in real time. In Cowork, you often aren't watching. Anything you'd otherwise re-type — your role, your working style, how the folder is organized, the rules Claude should never break — belongs in the folder's `CLAUDE.md`. If it's not in the file, it's not in the room.
+
+## The one thing to know about CLAUDE.md
+
+Cowork looks for a `CLAUDE.md` file inside the folder you've pointed it at. That file is plain markdown. You create it, you edit it, you keep it current. There's no special syntax, no separate config screen, no slash command to manage it — it's just a markdown file in the folder, loaded at the start of every Cowork session there.
+
+## Best practices
+
+1. **Keep it short.** Aim for under 200 lines. The whole file loads into Claude's working context at the start of every session, and a bloated file gets followed less reliably than a focused one.
+2. **Be concrete.** "Save new meeting notes to `Clients/<slug>/notes/YYYY-MM-DD.md`" beats "stay organized." Claude can only follow rules it can actually verify.
+3. **Structure with headings.** Claude scans markdown the way a person does. Short sections with clear headers beat walls of paragraph text.
+4. **Write what you'd otherwise re-type.** If you've corrected Claude on the same thing twice, that correction belongs in `CLAUDE.md`.
+5. **Don't contradict yourself.** If two instructions conflict, Claude will pick one of them more or less arbitrarily. Read the file end to end occasionally to weed those out.
+6. **Move long procedures out.** A multi-step workflow isn't a `CLAUDE.md` entry — it's a skill. See [Skills](/agentic-building-blocks/skills/).
+
+## Example CLAUDE.md
+
+Here's a complete, realistic `CLAUDE.md` for a consultant's main Cowork folder. Copy it, edit it for your own work, and drop it into the folder you point Cowork at.
+
+````markdown
+# Working with Me
+
+## About me
+
+I'm an independent strategy consultant. My clients are mid-stage B2B SaaS companies, mostly Series B–D. I get hired to do go-to-market diagnostics, pricing work, and the occasional board-prep sprint. The output I produce is almost always one of three things: a short memo (1–3 pages), a deck (10–20 slides), or a working session agenda.
+
+I am not a developer. Don't suggest code or terminal commands unless I ask.
+
+## How I work
+
+- Write in plain, direct language. Short sentences. No marketing voice, no hype words ("leverage", "unlock", "transform"), no em dashes.
+- Default to short. If a memo can be one page, make it one page.
+- Lead with the answer. Recommendation first, reasoning second, supporting detail third.
+- When you draft something for a client, give me the draft to review before doing anything with it. Never send a draft directly to a client.
+- If I ask a question and the honest answer is "I don't know" or "I'd need to check X," say so. Don't fabricate.
+
+## Folder layout
+
+- `Clients/<client-slug>/` — one folder per active engagement. Inside each: `notes/`, `drafts/`, `final/`, `meetings/`.
+- `Drafts/` — work in progress that isn't tied to a specific client yet (talks, articles, frameworks).
+- `Admin/` — invoices, contracts, expense receipts.
+- `Archive/` — anything from a closed engagement. Don't put new work here.
+
+## Standing rules
+
+- Date format: `YYYY-MM-DD`. Use it in filenames and inside documents.
+- New meeting notes go to `Clients/<client-slug>/meetings/YYYY-MM-DD-<topic>.md`.
+- New client deliverables go to `Clients/<client-slug>/drafts/` first. When I approve, move to `final/`.
+- Never delete a file without asking me first. If you think something should go, propose it and wait.
+- Never move files between client folders without confirming. Cross-contamination of client material is the one thing I cannot have happen.
+
+## Default tools and formats
+
+- Save documents as Markdown (`.md`) unless I ask for Word or PDF.
+- For decks, draft the outline and slide-by-slide content in Markdown first. I'll handle layout in Keynote.
+- Spreadsheets: CSV by default, Excel if I ask.
+- When researching online, give me the sources alongside the summary, not at the end.
+````
+
+That's ~60 lines, which is well within the limit and leaves plenty of room to add your own rules as they come up.
+
+## Keeping CLAUDE.md current
+
+Open the file and edit it whenever you notice yourself correcting Claude on the same thing more than once. There's no special UI for managing it — it's a file in your folder, like any other. Reopen it when your role changes, your folder layout changes, or you adopt a new working preference you want Claude to honor from then on.
+
+## A quick mental model
+
+`CLAUDE.md` is the briefing document you hand Cowork at the start of every shift. Keep it focused on the slow-changing facts: who you are, how you work, where things live, what's off-limits. Update it when those facts change. Everything else is conversation.
+
+## Related
+
+- [Getting Started with Claude](/platforms/claude/getting-started/) — set up your Claude account and apps before using Cowork.
+- [Claude Projects Setup Guide](/platforms/claude/projects/claude-projects-setup/) — the chat-side Projects feature, for contrast with how Cowork uses folders.
+- [Skills](/agentic-building-blocks/skills/) — when a procedure outgrows `CLAUDE.md` and should become a reusable skill.


### PR DESCRIPTION
Bundle-mode update matching the registry's uniform ordering rule: the Workflow→Process edge lives in the Process node's curated ordered `# Workflows` list (edge + value-chain order); `process:` frontmatter is banned on Workflow nodes. YAML backend unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)