### PR TITLE
Builder setup: separate GitHub account, repository, and credential paths

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -457,6 +457,7 @@ export default defineConfig({
             { label: 'AI Code Editor', link: '/builder-setup/editor-setup/' },
             { label: 'Git', link: '/builder-setup/git-install/' },
             { label: 'GitHub', link: '/builder-setup/github-setup/' },
+            { label: 'Repository Creation & Cloning', link: '/builder-setup/repo-creation-and-cloning/' },
             { label: 'Voice to Text', link: '/builder-setup/voice-to-text-setup/' },
             { label: 'AI Registry', link: '/builder-setup/ai-registry-setup/' },
             { label: 'Terminal Basics (reference)', link: '/builder-setup/terminal-basics/' },

--- a/src/content/docs/builder-setup/git-install.md
+++ b/src/content/docs/builder-setup/git-install.md
@@ -19,6 +19,15 @@ For AI development, Git is essential for two reasons. First, AI coding tools use
 
 This guide installs Git on your machine and sets up your identity so your work is properly attributed.
 
+## Opening a Terminal
+
+Every command in this guide is typed into a terminal — a window where you type instructions instead of clicking them.
+
+- **macOS:** press `Cmd + Space`, type `Terminal`, press Enter.
+- **Windows:** use **Git Bash**, which the Git installer adds to your Start menu. (Windows also has PowerShell and Command Prompt — Git Bash is the one these guides assume.)
+
+You type a command, press Enter, and read what comes back. Never used a terminal before? The [Terminal Basics primer](/courses/tools-setup-checklist/) is about 15 minutes and covers everything the guides below assume.
+
 ## Check If Git Is Already Installed
 
 Open your terminal and run:
@@ -83,7 +92,7 @@ git config --global user.name "Your Name"
 git config --global user.email "your.email@example.com"
 ```
 
-Use the email address you plan to use for your GitHub account (set up in the next step).
+Use the email address you plan to use for your GitHub account (set up in the next step). If these don't match, your commits still work but GitHub won't attribute them to your profile — they show up as an unlinked name, and fixing it later means rewriting history.
 
 Confirm your identity actually saved:
 

--- a/src/content/docs/builder-setup/git-install.md
+++ b/src/content/docs/builder-setup/git-install.md
@@ -85,6 +85,29 @@ git config --global user.email "your.email@example.com"
 
 Use the email address you plan to use for your GitHub account (set up in the next step).
 
+Confirm your identity actually saved:
+
+```bash
+git config --list
+```
+
+Look for `user.name` and `user.email` in the output, with the values you just set.
+
+## Corporate Networks (Proxy / Firewall)
+
+On a work machine, Git may fail to reach GitHub if traffic has to go through a corporate proxy or a restrictive firewall.
+
+**Behind a proxy:**
+
+```bash
+git config --global http.proxy http://proxy.company.com:port
+git config --global https.proxy http://proxy.company.com:port
+```
+
+Ask your IT team for the proxy address and port if you don't have it. To remove the setting later: `git config --global --unset http.proxy`.
+
+**Behind a firewall that blocks SSH:** if `git clone git@github.com:...` hangs or times out, corporate firewalls often allow HTTPS (port 443) but block the SSH port. Use the HTTPS clone URL instead (`https://github.com/...`) — this is also what the [GitHub Setup Guide](../github-setup/) and [Repository Creation and Cloning Guide](../repo-creation-and-cloning/) use by default.
+
 ## Troubleshooting
 
 **Command not found (Mac)?**
@@ -95,6 +118,14 @@ Use the email address you plan to use for your GitHub account (set up in the nex
 - Close and reopen your terminal
 - Make sure you selected the PATH option during installation
 - Reinstall and select "Git from the command line and also from 3rd-party software"
+
+**PATH still broken after reinstalling on Windows?**
+1. Open **Start → Environment Variables** (search "edit the system environment variables")
+2. Click **Environment Variables…**
+3. Under **System variables**, select **Path**, click **Edit**
+4. Confirm an entry exists for Git's `cmd` folder (typically `C:\Program Files\Git\cmd`) — click **New** and add it if missing
+5. Click **OK** on every dialog, then close and reopen your terminal
+6. Run `git --version` again to confirm
 
 **Permission errors?**
 - On Mac, you may need to enter your password during Xcode tools installation

--- a/src/content/docs/builder-setup/git-install.md
+++ b/src/content/docs/builder-setup/git-install.md
@@ -26,7 +26,7 @@ Every command in this guide is typed into a terminal — a window where you type
 - **macOS:** press `Cmd + Space`, type `Terminal`, press Enter.
 - **Windows:** press Start, type `PowerShell`, press Enter.
 
-You type a command, press Enter, and read what comes back. Never used a terminal before? The [Terminal Basics primer](/courses/tools-setup-checklist/) is about 15 minutes and covers everything the guides below assume.
+You type a command, press Enter, and read what comes back. Never used a terminal before? The [Terminal Basics primer](/builder-setup/terminal-basics/) is about 15 minutes and covers everything the guides below assume.
 
 Every command in this guide and the [GitHub Setup Guide](../github-setup/) works in PowerShell — they all run the `git` or `gh` program, which the installer adds to your system.
 

--- a/src/content/docs/builder-setup/git-install.md
+++ b/src/content/docs/builder-setup/git-install.md
@@ -24,9 +24,15 @@ This guide installs Git on your machine and sets up your identity so your work i
 Every command in this guide is typed into a terminal — a window where you type instructions instead of clicking them.
 
 - **macOS:** press `Cmd + Space`, type `Terminal`, press Enter.
-- **Windows:** use **Git Bash**, which the Git installer adds to your Start menu. (Windows also has PowerShell and Command Prompt — Git Bash is the one these guides assume.)
+- **Windows:** press Start, type `PowerShell`, press Enter.
 
 You type a command, press Enter, and read what comes back. Never used a terminal before? The [Terminal Basics primer](/courses/tools-setup-checklist/) is about 15 minutes and covers everything the guides below assume.
+
+Every command in this guide and the [GitHub Setup Guide](../github-setup/) works in PowerShell — they all run the `git` or `gh` program, which the installer adds to your system.
+
+**Windows: when you might want Git Bash instead.** The Git installer also adds **Git Bash**, a terminal that behaves like the macOS one. If you follow a tutorial written for Mac or Linux — anything using `ls`, `touch`, or forward-slash paths — run it in Git Bash and the commands work unchanged. For everything in these guides, PowerShell is fine.
+
+> **PowerShell says `git` is not recognized?** Git installed without being added to your PATH. See [Troubleshooting](#troubleshooting) to fix it — or use Git Bash, which works either way.
 
 ## Check If Git Is Already Installed
 

--- a/src/content/docs/builder-setup/git-install.md
+++ b/src/content/docs/builder-setup/git-install.md
@@ -119,7 +119,12 @@ git config --global http.proxy http://proxy.company.com:port
 git config --global https.proxy http://proxy.company.com:port
 ```
 
-Ask your IT team for the proxy address and port if you don't have it. To remove the setting later: `git config --global --unset http.proxy`.
+Ask your IT team for the proxy address and port if you don't have it. To remove both settings later — do unset **both**, or the leftover `https.proxy` keeps breaking HTTPS remotes once you're off the corporate network:
+
+```bash
+git config --global --unset http.proxy
+git config --global --unset https.proxy
+```
 
 **Behind a firewall that blocks SSH:** if `git clone git@github.com:...` hangs or times out, corporate firewalls often allow HTTPS (port 443) but block the SSH port. Use the HTTPS clone URL instead (`https://github.com/...`) — this is also what the [GitHub Setup Guide](../github-setup/) and [Repository Creation and Cloning Guide](../repo-creation-and-cloning/) use by default.
 

--- a/src/content/docs/builder-setup/github-setup.md
+++ b/src/content/docs/builder-setup/github-setup.md
@@ -124,10 +124,10 @@ Prefer **fine-grained** personal access tokens over classic tokens throughout. E
 3. Give it a descriptive name (e.g., `claude-code-my-repo`)
 4. Choose the **Resource owner** — your personal account, or an organisation if the repository belongs to one. Organisation-owned tokens usually need an admin to approve them before they work, which can take days; start early if that applies to you.
 5. Set an **expiration** that outlasts whatever you're building with it — if you're on a course, set it past the last session; otherwise 30 or 90 days is a good default. GitHub caps custom expiry at 366 days. Avoid "No expiration" where offered. A token that expires mid-project silently breaks every integration using it.
-6. Set **Repository access**. Which option is right depends on what the resource owner already owns:
-   - **A personal account with little or nothing in it:** **All repositories** is fine, and is the simpler choice — it covers current *and future* repositories, so you can generate the token before you've created a repo and it will still work afterwards. The blast radius is whatever that account owns, which is close to nothing.
-   - **An account or organisation holding work you care about:** **Only select repositories**, and choose just the repo(s) needed. This requires the repository to exist first. Never point a token at an organisation's full repository list to save a step.
-7. Under **Permissions**, grant only what's needed (e.g., **Contents: Read and write** for an agent that commits and pushes — GitHub adds **Metadata: Read** automatically)
+6. Set **Repository access** — **Only select repositories**, and choose just the repo(s) needed. Create the repository first if it doesn't exist yet (see the [Repository Creation and Cloning Guide](../repo-creation-and-cloning/)); you can't select one that isn't there.
+
+   **All repositories** also exists, and covers current *and future* repositories — occasionally useful on a personal account holding nothing you care about, when you want a token that keeps working as you add repos. Two reasons to prefer selecting: many tools that consume a token require a specific repository anyway (Notion's Claude agent connector, for one, states this on its connect screen), and on any account holding real work the wider scope is a genuine risk. Never point a token at an organisation's full repository list to save a step.
+7. Under **Permissions**, grant only what's needed. The tool you're connecting will list the permissions it requires — treat that list as authoritative. Two you'll meet often: **Contents** (read and write files) and **Pull requests** (open a pull request instead of writing straight to the main branch), each set to **Read and write**. GitHub adds **Metadata: Read** automatically.
 8. Click **Generate token**
 9. **Copy the token now** — GitHub shows it exactly once and cannot show it to you again
 

--- a/src/content/docs/builder-setup/github-setup.md
+++ b/src/content/docs/builder-setup/github-setup.md
@@ -58,7 +58,7 @@ With [Homebrew](https://brew.sh):
 brew install gh
 ```
 
-**No Homebrew?** If you installed Git via Xcode Command Line Tools (the recommended path above), you probably don't have Homebrew. Download the macOS `.pkg` installer from [cli.github.com](https://cli.github.com) and run it — no terminal needed.
+**No Homebrew?** If you installed Git via [Xcode Command Line Tools](../git-install/#option-1-xcode-command-line-tools-recommended) — the path the Git guide recommends — you probably don't have Homebrew. Download the macOS `.pkg` installer from [cli.github.com](https://cli.github.com) and run it — no terminal needed.
 
 ### Windows
 
@@ -123,7 +123,7 @@ Prefer **fine-grained** personal access tokens over classic tokens throughout. E
 2. Click **Generate new token**
 3. Give it a descriptive name (e.g., `claude-code-my-repo`)
 4. Choose the **Resource owner** — your personal account, or an organisation if the repository belongs to one. Organisation-owned tokens usually need an admin to approve them before they work, which can take days; start early if that applies to you.
-5. Set an **expiration** that outlasts whatever you're building with it — if you're on a course, set it past the last session; otherwise 30 or 90 days is a good default. GitHub caps custom expiry at 366 days. Avoid "No expiration" where offered. A token that expires mid-project silently breaks every integration using it.
+5. Set an **expiration** that outlasts whatever you're building with it — if you're on a course, set it past the last session; otherwise 30 or 90 days is a good default. Fine-grained tokens always expire, and GitHub caps a custom expiry at 366 days, so pick deliberately: one that lapses mid-project silently breaks every integration using it.
 6. Set **Repository access** — **Only select repositories**, and choose just the repo(s) needed. Create the repository first if it doesn't exist yet (see the [Repository Creation and Cloning Guide](../repo-creation-and-cloning/)); you can't select one that isn't there.
 
    **All repositories** also exists, and covers current *and future* repositories — occasionally useful on a personal account holding nothing you care about, when you want a token that keeps working as you add repos. Two reasons to prefer selecting: many tools that consume a token require a specific repository anyway (Notion's Claude agent connector, for one, states this on its connect screen), and on any account holding real work the wider scope is a genuine risk. Never point a token at an organisation's full repository list to save a step.

--- a/src/content/docs/builder-setup/github-setup.md
+++ b/src/content/docs/builder-setup/github-setup.md
@@ -19,17 +19,17 @@ This guide walks you through creating a GitHub account, securing it, and setting
 
 ## Prerequisites
 
-**For everyone (sections 1 and 3):**
+**For everyone (section 1 — creating your account):**
 
 - An email address for your GitHub account
 - Your phone with an authenticator app, for two-factor authentication
 
-Creating an account and generating a token happen entirely in your browser — nothing to install. If a hosted AI agent or automation is the only thing that needs GitHub access, sections 1 and 3 are all you need.
+Section 1 and the token steps in section 3 happen entirely in your browser — nothing to install. If a hosted AI agent or automation is the only thing that needs GitHub access, those are all you need.
 
 **Additionally, if you'll run Git commands yourself (section 2):**
 
 - Git installed (see [Git Installation Guide](../git-install/))
-- Cursor or VS Code installed (see [Editor Setup Guide](../editor-setup/))
+- An editor such as Cursor or VS Code — useful, but not required for anything in this guide (see [Editor Setup Guide](../editor-setup/))
 
 ## 1. Create a GitHub Account
 
@@ -52,9 +52,13 @@ The GitHub CLI (`gh`) is required for cloning repos from Claude Desktop's Code t
 
 ### macOS
 
+With [Homebrew](https://brew.sh):
+
 ```bash
 brew install gh
 ```
+
+**No Homebrew?** If you installed Git via Xcode Command Line Tools (the recommended path above), you probably don't have Homebrew. Download the macOS `.pkg` installer from [cli.github.com](https://cli.github.com) and run it — no terminal needed.
 
 ### Windows
 
@@ -106,10 +110,10 @@ gh auth status
 
 | | Fine-grained personal access token | `gh auth login` |
 |---|---|---|
-| What it is | A credential you generate and store | An interactive browser flow; token stored in your local keychain |
+| What it is | A credential you generate and store | An interactive browser flow; the token is stored locally in `gh`'s config or your system credential helper |
 | Use when | Something *other than you* must authenticate — a hosted agent, CI, an automation | *You* are working on your own machine |
-| Scope | Per-repository, per-permission, with an expiry date | Your full account access |
-| Main risk | It's a secret: if it leaks it works until revoked or expired | Cannot be used on other machines or shared with tools |
+| Scope | Per-repository, per-permission, with an expiry date | A broad set of account scopes (repo, read:org, gist, workflow) |
+| Main risk | It's a secret: if it leaks it works until revoked or expired | Broad scope, and anyone with access to your machine can read it with `gh auth token` |
 
 Prefer **fine-grained** personal access tokens over classic tokens throughout — classic tokens grant broad, all-repository access with no expiry, which is far more than most integrations need.
 
@@ -118,11 +122,12 @@ Prefer **fine-grained** personal access tokens over classic tokens throughout �
 1. Go to **Settings → Developer settings → Personal access tokens → Fine-grained tokens**
 2. Click **Generate new token**
 3. Give it a descriptive name (e.g., `claude-code-my-repo`)
-4. Set an **expiration** that outlasts whatever you're building with it — if you're on a course, set it past the last session; otherwise 30 or 90 days is a good default. Avoid "No expiration". A token that expires mid-project silently breaks every integration using it.
-5. Under **Repository access**, select **Only select repositories** and choose the specific repo(s) it needs — avoid "All repositories"
-6. Under **Permissions**, grant only what's needed (e.g., **Contents: Read and write** for an agent that commits and pushes)
-7. Click **Generate token**
-8. **Copy the token now** — GitHub shows it exactly once and cannot show it to you again
+4. Choose the **Resource owner** — your personal account, or an organisation if the repository belongs to one. Organisation-owned tokens usually need an admin to approve them before they work, which can take days; start early if that applies to you.
+5. Set an **expiration** that outlasts whatever you're building with it — if you're on a course, set it past the last session; otherwise 30 or 90 days is a good default. GitHub caps custom expiry at 366 days. Avoid "No expiration" where offered. A token that expires mid-project silently breaks every integration using it.
+6. Under **Repository access**, select **Only select repositories** and choose the specific repo(s) it needs — avoid "All repositories". The repository must already exist; create an empty one first if you don't have it yet.
+7. Under **Permissions**, grant only what's needed (e.g., **Contents: Read and write** for an agent that commits and pushes — GitHub adds **Metadata: Read** automatically)
+8. Click **Generate token**
+9. **Copy the token now** — GitHub shows it exactly once and cannot show it to you again
 
 ### Storing Your Token Safely
 

--- a/src/content/docs/builder-setup/github-setup.md
+++ b/src/content/docs/builder-setup/github-setup.md
@@ -115,7 +115,7 @@ gh auth status
 | Scope | Per-repository, per-permission, with an expiry date | A broad set of account scopes (repo, read:org, gist, workflow) |
 | Main risk | It's a secret: if it leaks it works until revoked or expired | Broad scope, and anyone with access to your machine can read it with `gh auth token` |
 
-Prefer **fine-grained** personal access tokens over classic tokens throughout — classic tokens grant broad, all-repository access with no expiry, which is far more than most integrations need.
+Prefer **fine-grained** personal access tokens over classic tokens throughout. Even at their widest setting, fine-grained tokens still expire and still grant only the specific permissions you tick. Classic tokens do neither — they carry coarse scopes across every repository you can reach, and can be created with no expiry at all.
 
 ### Creating a Fine-Grained Personal Access Token
 
@@ -124,7 +124,9 @@ Prefer **fine-grained** personal access tokens over classic tokens throughout �
 3. Give it a descriptive name (e.g., `claude-code-my-repo`)
 4. Choose the **Resource owner** — your personal account, or an organisation if the repository belongs to one. Organisation-owned tokens usually need an admin to approve them before they work, which can take days; start early if that applies to you.
 5. Set an **expiration** that outlasts whatever you're building with it — if you're on a course, set it past the last session; otherwise 30 or 90 days is a good default. GitHub caps custom expiry at 366 days. Avoid "No expiration" where offered. A token that expires mid-project silently breaks every integration using it.
-6. Under **Repository access**, select **Only select repositories** and choose the specific repo(s) it needs — avoid "All repositories". The repository must already exist; create an empty one first if you don't have it yet.
+6. Set **Repository access**. Which option is right depends on what the resource owner already owns:
+   - **A personal account with little or nothing in it:** **All repositories** is fine, and is the simpler choice — it covers current *and future* repositories, so you can generate the token before you've created a repo and it will still work afterwards. The blast radius is whatever that account owns, which is close to nothing.
+   - **An account or organisation holding work you care about:** **Only select repositories**, and choose just the repo(s) needed. This requires the repository to exist first. Never point a token at an organisation's full repository list to save a step.
 7. Under **Permissions**, grant only what's needed (e.g., **Contents: Read and write** for an agent that commits and pushes — GitHub adds **Metadata: Read** automatically)
 8. Click **Generate token**
 9. **Copy the token now** — GitHub shows it exactly once and cannot show it to you again

--- a/src/content/docs/builder-setup/github-setup.md
+++ b/src/content/docs/builder-setup/github-setup.md
@@ -1,23 +1,21 @@
 ---
 title: GitHub Setup Guide
-description: Create a GitHub account, create your first repository, clone it, and learn core Git concepts for AI development
+description: Create a GitHub account with 2FA, install the GitHub CLI, and choose between a CLI login and a personal access token
 schema_type: HowTo
 howto_steps:
   - name: Create a GitHub account
-    text: Go to github.com, click Sign up, follow the prompts, and verify your email address.
-  - name: Create a repository
-    text: Click the + menu, select New repository, name it, add a README, and click Create repository.
+    text: Go to github.com, click Sign up, follow the prompts, verify your email address, and enable two-factor authentication.
   - name: Install GitHub CLI
     text: Install gh via Homebrew (macOS), winget (Windows), or apt (Linux), then run gh auth login to connect your GitHub account.
-  - name: Clone a repository
-    text: Open the Command Palette (Cmd/Ctrl + Shift + P), type Git Clone, paste the repository URL, and choose a local folder.
+  - name: Choose your authentication method
+    text: Use gh auth login when you're running commands yourself. Generate a fine-grained personal access token when a hosted agent or automation needs to authenticate without you present.
 ---## What Is GitHub?
 
 GitHub is a website where people store and share code projects. If Git tracks your changes locally (like a save history on your computer), GitHub is where that history lives in the cloud — backed up, shareable, and accessible from anywhere.
 
 As you build with AI, you'll create prompts, skills, agents, and project files that become the foundation of your workflows. GitHub is where those files live in the cloud — backed up, versioned, and accessible from any machine. Think of it as your portfolio and safety net in one place. Your files are stored in *repositories* (project folders that Git tracks), and you work with them by *cloning* — making a local copy on your computer.
 
-This guide walks you through creating a GitHub account, creating your first repository, and cloning it to your computer.
+This guide walks you through creating a GitHub account, securing it, and setting up the two ways you'll authenticate with GitHub. Once you're set up, head to the [Repository Creation and Cloning Guide](../repo-creation-and-cloning/) to create your first repository.
 
 ## Prerequisites
 
@@ -31,23 +29,18 @@ This guide walks you through creating a GitHub account, creating your first repo
 2. Click **Sign up**
 3. Follow the prompts to create your account
 4. Verify your email address
+5. Enable two-factor authentication (2FA):
+   - Go to **Settings → Password and authentication**
+   - Under **Two-factor authentication**, click **Enable two-factor authentication**
+   - Choose an authenticator app (recommended — e.g., 1Password, Authy, Google Authenticator) or a security key
+   - Scan the QR code with your authenticator app and enter the generated code to confirm
+   - Save the recovery codes GitHub shows you somewhere safe (a password manager, not a text file) — you'll need one if you lose access to your authenticator
 
-**Already have an account and a repository?** Skip to step 3.
+**Already have an account with 2FA enabled?** Skip to step 2.
 
-## 2. Create a Repository
+## 2. Install GitHub CLI
 
-1. From GitHub, click the **+** button (top-right corner) → **New repository**
-2. Enter a repository name (e.g., `my-ai-projects`)
-3. Add an optional description
-4. Select **Private** (recommended for personal work)
-5. Check **Add a README file**
-6. Click **Create repository**
-
-You'll land on your new repository's page with a README file. The URL in your browser (e.g., `https://github.com/your-username/my-ai-projects`) is what you'll use to clone it in the next step.
-
-## 3. Install GitHub CLI
-
-The GitHub CLI (`gh`) is required for cloning repos from Claude Desktop's Code tab and for letting Cursor or Claude Code authenticate with GitHub programmatically. Install it before cloning.
+The GitHub CLI (`gh`) is required for cloning repos from Claude Desktop's Code tab and for letting Cursor or Claude Code authenticate with GitHub programmatically. Install it before creating or cloning a repository.
 
 ### macOS
 
@@ -88,43 +81,35 @@ gh auth status
 
 **Official docs:** [GitHub CLI manual](https://cli.github.com/manual/)
 
-## 4. Clone a Repository
+## 3. Choose How You'll Authenticate: Token vs. CLI Login
 
-Download (clone) a repository from GitHub using whichever tool you're working in.
+**A token is a stored secret. A CLI login is a session.**
 
-### In Cursor or VS Code
+`gh auth login` opens your browser, you approve, and the token lands in *your machine's* keychain. That works when **you** are the one running commands. It cannot work when something else needs to reach GitHub without you present — an AI agent, an automation, a hosted tool — because that thing can't read your keychain. For those, you generate a token and give it to them.
 
-1. Open the Command Palette (Cmd/Ctrl + Shift + P)
-2. Type **Git: Clone**
-3. Paste the repository URL (e.g., `https://github.com/username/project-name.git`)
-4. Choose a local folder location
-5. Open the cloned repository when prompted
+| | Fine-grained personal access token | `gh auth login` |
+|---|---|---|
+| What it is | A credential you generate and store | An interactive browser flow; token stored in your local keychain |
+| Use when | Something *other than you* must authenticate — a hosted agent, CI, an automation | *You* are working on your own machine |
+| Scope | Per-repository, per-permission, with an expiry date | Your full account access |
+| Main risk | It's a secret: if it leaks it works until revoked or expired | Bound to the machine you logged in on |
 
-### In Claude Desktop (Code tab)
+Prefer **fine-grained** personal access tokens over classic tokens throughout — classic tokens grant broad, all-repository access with no expiry, which is far more than most integrations need.
 
-If you're working in the Claude Desktop app without a separate code editor, you can clone a repo by asking Claude to do it for you. Because you installed and authenticated the GitHub CLI in the previous step, Claude can use `gh` on your behalf.
+### Creating a Fine-Grained Personal Access Token
 
-1. Open **Claude Desktop** and click the **Code** tab
-2. Start a new session and pick (or create) a local folder you want the repo cloned into
-3. In the chat box, paste a prompt like:
+1. Go to **Settings → Developer settings → Personal access tokens → Fine-grained tokens**
+2. Click **Generate new token**
+3. Give it a descriptive name (e.g., `claude-code-my-repo`)
+4. Set an **expiration** — 30 or 90 days is a good default; avoid "No expiration"
+5. Under **Repository access**, select **Only select repositories** and choose the specific repo(s) it needs — avoid "All repositories"
+6. Under **Permissions**, grant only what's needed (e.g., **Contents: Read and write** for an agent that commits and pushes)
+7. Click **Generate token**
+8. **Copy the token now** — GitHub shows it exactly once and cannot show it to you again
 
-   > Clone `https://github.com/username/project-name.git` into this folder.
+### Storing Your Token Safely
 
-4. Approve the command when Claude asks for permission to run `gh repo clone` (or `git clone`)
-5. When it finishes, open Finder (macOS) or File Explorer (Windows) and navigate to the folder you chose — you should see the cloned repo there
-
-### Verify the Clone Worked
-
-After cloning, confirm the repository is on your machine:
-
-1. Check the **sidebar** in your editor — you should see the project's files and folders
-2. Open the integrated terminal (**Ctrl + `**) and run:
-
-```bash
-git status
-```
-
-You should see a message like `On branch main` — this confirms the repository was cloned correctly and Git is tracking it.
+Save the token in a password manager (1Password, Bitwarden, etc.), not in a plain text file, a `.env` you might commit, or a note. If a hosted agent or tool needs the token, paste it directly into that tool's credential/secret field rather than writing it to disk in your repository.
 
 ## Git Concepts
 
@@ -159,28 +144,30 @@ Claude Code handles the Git commands for you.
 
 ## Troubleshooting
 
-**Can't clone the repository?**
-- Verify you have access to the repository
-- Check that the URL is correct
-- Make sure you're signed into GitHub in your editor
+**`gh auth login` fails or hangs?**
+- Make sure you have a browser available to complete the flow
+- Try `gh auth login --web` to force the browser-based flow
+- Check `gh auth status` afterward to confirm
 
-**Authentication issues?**
-- Your editor may prompt you to sign into GitHub
-- Follow the browser authentication flow when prompted
+**Token doesn't work?**
+- Confirm the token hasn't expired
+- Confirm the repository you're targeting is one of the repositories the token was scoped to
+- Confirm the token has the permission the operation needs (e.g., **Contents: Read and write** to push commits)
 
 <details>
 <summary>Ask AI for help</summary>
 
 If you're stuck, paste this into ChatGPT, Claude, or Gemini:
 
-> I'm trying to clone a GitHub repository in [Cursor / VS Code] on [Mac / Windows] and getting this error: [paste the error message]. I have Git installed and a GitHub account. What should I try?
+> I'm setting up GitHub authentication (2FA / gh auth login / a fine-grained personal access token) and getting this error: [paste the error message]. What should I try?
 
 </details>
 ## Next Steps
 
-- Try cloning a public repository to practice the workflow
+- [Create a repository and clone it](../repo-creation-and-cloning/) — the next step now that your account and authentication are set up
 
 ## Resources
 
 - [GitHub Docs](https://docs.github.com)
 - [GitHub CLI manual](https://cli.github.com/manual/)
+- [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)

--- a/src/content/docs/builder-setup/github-setup.md
+++ b/src/content/docs/builder-setup/github-setup.md
@@ -19,9 +19,17 @@ This guide walks you through creating a GitHub account, securing it, and setting
 
 ## Prerequisites
 
-- Email address for GitHub account
-- Cursor or VS Code installed (see [Editor Setup Guide](../editor-setup/))
+**For everyone (sections 1 and 3):**
+
+- An email address for your GitHub account
+- Your phone with an authenticator app, for two-factor authentication
+
+Creating an account and generating a token happen entirely in your browser — nothing to install. If a hosted AI agent or automation is the only thing that needs GitHub access, sections 1 and 3 are all you need.
+
+**Additionally, if you'll run Git commands yourself (section 2):**
+
 - Git installed (see [Git Installation Guide](../git-install/))
+- Cursor or VS Code installed (see [Editor Setup Guide](../editor-setup/))
 
 ## 1. Create a GitHub Account
 
@@ -68,7 +76,16 @@ For other Linux distributions, see the [official install instructions](https://g
 gh auth login
 ```
 
-Follow the browser prompts to connect your GitHub account.
+Before it opens your browser, `gh` asks four questions in the terminal. Use the arrow keys to choose and press Enter:
+
+| Question | Choose |
+|---|---|
+| What account do you want to log into? | **GitHub.com** |
+| What is your preferred protocol for Git operations? | **HTTPS** |
+| Authenticate Git with your GitHub credentials? | **Yes** |
+| How would you like to authenticate? | **Login with a web browser** |
+
+It then shows a one-time code and opens your browser. Paste the code, approve the access, and return to the terminal — it confirms when it's done.
 
 ### Verify
 
@@ -101,7 +118,7 @@ Prefer **fine-grained** personal access tokens over classic tokens throughout �
 1. Go to **Settings → Developer settings → Personal access tokens → Fine-grained tokens**
 2. Click **Generate new token**
 3. Give it a descriptive name (e.g., `claude-code-my-repo`)
-4. Set an **expiration** — 30 or 90 days is a good default; avoid "No expiration"
+4. Set an **expiration** that outlasts whatever you're building with it — if you're on a course, set it past the last session; otherwise 30 or 90 days is a good default. Avoid "No expiration". A token that expires mid-project silently breaks every integration using it.
 5. Under **Repository access**, select **Only select repositories** and choose the specific repo(s) it needs — avoid "All repositories"
 6. Under **Permissions**, grant only what's needed (e.g., **Contents: Read and write** for an agent that commits and pushes)
 7. Click **Generate token**

--- a/src/content/docs/builder-setup/github-setup.md
+++ b/src/content/docs/builder-setup/github-setup.md
@@ -85,14 +85,14 @@ gh auth status
 
 **A token is a stored secret. A CLI login is a session.**
 
-`gh auth login` opens your browser, you approve, and the token lands in *your machine's* keychain. That works when **you** are the one running commands. It cannot work when something else needs to reach GitHub without you present — an AI agent, an automation, a hosted tool — because that thing can't read your keychain. For those, you generate a token and give it to them.
+`gh auth login` opens your browser, you approve, and the credential is stored locally on your machine (in `gh`'s configuration or your system credential helper). That works when **you** are the one running commands. It cannot work when something else needs to reach GitHub without you present — an AI agent, an automation, a hosted tool — because that thing can't access your machine's credential storage. For those, you generate a token and give it to them.
 
 | | Fine-grained personal access token | `gh auth login` |
 |---|---|---|
 | What it is | A credential you generate and store | An interactive browser flow; token stored in your local keychain |
 | Use when | Something *other than you* must authenticate — a hosted agent, CI, an automation | *You* are working on your own machine |
 | Scope | Per-repository, per-permission, with an expiry date | Your full account access |
-| Main risk | It's a secret: if it leaks it works until revoked or expired | Bound to the machine you logged in on |
+| Main risk | It's a secret: if it leaks it works until revoked or expired | Cannot be used on other machines or shared with tools |
 
 Prefer **fine-grained** personal access tokens over classic tokens throughout — classic tokens grant broad, all-repository access with no expiry, which is far more than most integrations need.
 

--- a/src/content/docs/builder-setup/github-setup.md
+++ b/src/content/docs/builder-setup/github-setup.md
@@ -11,11 +11,11 @@ howto_steps:
     text: Use gh auth login when you're running commands yourself. Generate a fine-grained personal access token when a hosted agent or automation needs to authenticate without you present.
 ---## What Is GitHub?
 
-GitHub is a website where people store and share code projects. If Git tracks your changes locally (like a save history on your computer), GitHub is where that history lives in the cloud — backed up, shareable, and accessible from anywhere.
+GitHub is a website where people store, version, and share files — application code, but equally the prompts, skills, agents, and markdown you build with AI. If Git tracks your changes locally (like a save history on your computer), GitHub is where that history lives in the cloud — backed up, shareable, and accessible from anywhere.
 
 As you build with AI, you'll create prompts, skills, agents, and project files that become the foundation of your workflows. GitHub is where those files live in the cloud — backed up, versioned, and accessible from any machine. Think of it as your portfolio and safety net in one place. Your files are stored in *repositories* (project folders that Git tracks), and you work with them by *cloning* — making a local copy on your computer.
 
-This guide walks you through creating a GitHub account, securing it, and setting up the two ways you'll authenticate with GitHub. Once you're set up, head to the [Repository Creation and Cloning Guide](../repo-creation-and-cloning/) to create your first repository.
+This guide walks you through creating a GitHub account, securing it, and setting up the two ways you'll authenticate with GitHub. Create your repository before you generate a token — a token has to be scoped to a repository that already exists. The [Repository Creation and Cloning Guide](../repo-creation-and-cloning/) covers that, and section 1 of it needs nothing installed.
 
 ## Prerequisites
 
@@ -48,7 +48,7 @@ Section 1 and the token steps in section 3 happen entirely in your browser — n
 
 ## 2. Install GitHub CLI
 
-The GitHub CLI (`gh`) is required for cloning repos from Claude Desktop's Code tab and for letting Cursor or Claude Code authenticate with GitHub programmatically. Install it before creating or cloning a repository.
+The GitHub CLI (`gh`) is the simplest way to authenticate Git on your own machine, and it is what AI code editors and coding agents use to reach GitHub on your behalf. Install it before cloning a repository. Skip this section entirely if you won't be working with files locally.
 
 ### macOS
 

--- a/src/content/docs/builder-setup/repo-creation-and-cloning.md
+++ b/src/content/docs/builder-setup/repo-creation-and-cloning.md
@@ -1,0 +1,103 @@
+---
+title: Repository Creation and Cloning Guide
+description: Create your first GitHub repository and clone it to your computer using your editor or Claude Desktop
+schema_type: HowTo
+howto_steps:
+  - name: Create a repository
+    text: Click the + menu, select New repository, name it, add a README, and click Create repository.
+  - name: Clone a repository
+    text: Open the Command Palette (Cmd/Ctrl + Shift + P), type Git Clone, paste the repository URL, and choose a local folder.
+  - name: Verify the clone
+    text: Open the integrated terminal and run 'git status' to confirm the repository was cloned correctly.
+---## What This Guide Covers
+
+Once your GitHub account is set up and authenticated (see the [GitHub Setup Guide](../github-setup/)), the next step is creating a repository — a project folder that Git tracks — and cloning it to your computer so you have a local copy to work in.
+
+## Prerequisites
+
+- GitHub account with 2FA enabled and GitHub CLI authenticated (see [GitHub Setup Guide](../github-setup/))
+- Git installed (see [Git Installation Guide](../git-install/))
+- Cursor or VS Code installed (see [Editor Setup Guide](../editor-setup/))
+
+## 1. Create a Repository
+
+1. From GitHub, click the **+** button (top-right corner) → **New repository**
+2. Enter a repository name (e.g., `my-ai-projects`)
+3. Add an optional description
+4. Select **Private** (recommended for personal work)
+5. Check **Add a README file**
+6. Click **Create repository**
+
+You'll land on your new repository's page with a README file. The URL in your browser (e.g., `https://github.com/your-username/my-ai-projects`) is what you'll use to clone it in the next step.
+
+## 2. Clone a Repository
+
+Download (clone) a repository from GitHub using whichever tool you're working in.
+
+### In Cursor or VS Code
+
+1. Open the Command Palette (Cmd/Ctrl + Shift + P)
+2. Type **Git: Clone**
+3. Paste the repository URL (e.g., `https://github.com/username/project-name.git`)
+4. Choose a local folder location
+5. Open the cloned repository when prompted
+
+### In Claude Desktop (Code tab)
+
+If you're working in the Claude Desktop app without a separate code editor, you can clone a repo by asking Claude to do it for you. Because you installed and authenticated the GitHub CLI in the [GitHub Setup Guide](../github-setup/), Claude can use `gh` on your behalf.
+
+1. Open **Claude Desktop** and click the **Code** tab
+2. Start a new session and pick (or create) a local folder you want the repo cloned into
+3. In the chat box, paste a prompt like:
+
+   > Clone `https://github.com/username/project-name.git` into this folder.
+
+4. Approve the command when Claude asks for permission to run `gh repo clone` (or `git clone`)
+5. When it finishes, open Finder (macOS) or File Explorer (Windows) and navigate to the folder you chose — you should see the cloned repo there
+
+## 3. Verify the Clone Worked
+
+After cloning, confirm the repository is on your machine:
+
+1. Check the **sidebar** in your editor — you should see the project's files and folders
+2. Open the integrated terminal (**Ctrl + `**) and run:
+
+```bash
+git status
+```
+
+You should see a message like `On branch main` — this confirms the repository was cloned correctly and Git is tracking it.
+
+## Troubleshooting
+
+**Can't create the repository?**
+- Make sure you're signed in to GitHub
+- Repository names must be unique within your account — try a different name if you get a conflict
+
+**Can't clone the repository?**
+- Verify you have access to the repository
+- Check that the URL is correct
+- Make sure you're signed into GitHub in your editor
+
+**Authentication issues?**
+- Your editor may prompt you to sign into GitHub
+- Follow the browser authentication flow when prompted
+- If you're cloning as an automation or hosted agent rather than yourself, it needs a [fine-grained personal access token](../github-setup/#3-choose-how-youll-authenticate-token-vs-cli-login), not `gh auth login`
+
+<details>
+<summary>Ask AI for help</summary>
+
+If you're stuck, paste this into ChatGPT, Claude, or Gemini:
+
+> I'm trying to create/clone a GitHub repository in [Cursor / VS Code] on [Mac / Windows] and getting this error: [paste the error message]. I have Git installed, a GitHub account, and the GitHub CLI authenticated. What should I try?
+
+</details>
+## Next Steps
+
+- Try cloning a public repository to practice the workflow
+- Set up your AI platform (see [Platforms](../../platforms/))
+
+## Resources
+
+- [GitHub Docs](https://docs.github.com)
+- [GitHub CLI manual](https://cli.github.com/manual/)

--- a/src/content/docs/builder-setup/repo-creation-and-cloning.md
+++ b/src/content/docs/builder-setup/repo-creation-and-cloning.md
@@ -11,12 +11,20 @@ howto_steps:
     text: Open the integrated terminal and run 'git status' to confirm the repository was cloned correctly.
 ---## What This Guide Covers
 
-Once your GitHub account is set up and authenticated (see the [GitHub Setup Guide](../github-setup/)), the next step is creating a repository — a project folder that Git tracks — and cloning it to your computer so you have a local copy to work in.
+Once you have a GitHub account (see the [GitHub Setup Guide](../github-setup/)), the next step is creating a repository — a project folder that Git tracks. If you'll also work with the files on your own machine, you then clone it, so you have a local copy to work in.
 
 ## Prerequisites
 
-- GitHub account with 2FA enabled and GitHub CLI authenticated (see [GitHub Setup Guide](../github-setup/))
+**To create a repository (section 1):**
+
+- A GitHub account
+
+That's all. Creating a repository happens entirely in your browser — nothing to install. If a hosted agent or automation is the only thing that will touch this repository, you can stop after section 1.
+
+**Additionally, to clone it to your machine (sections 2 and 3):**
+
 - Git installed (see [Git Installation Guide](../git-install/))
+- GitHub CLI authenticated (see [GitHub Setup Guide](../github-setup/))
 - Cursor or VS Code installed (see [Editor Setup Guide](../editor-setup/))
 
 ## 1. Create a Repository

--- a/src/content/docs/courses/builders/week-1.md
+++ b/src/content/docs/courses/builders/week-1.md
@@ -11,7 +11,8 @@ Create a GitHub repository to store and version your AI prompts, skills, and ref
 
 1. [Git Installation](../../../builder-setup/git-install/) — Install Git on your machine
 2. [Editor Setup](../../../builder-setup/editor-setup/) — Install Cursor or VS Code
-3. [GitHub Setup](../../../builder-setup/github-setup/) — Create account and clone repositories
+3. [GitHub Setup](../../../builder-setup/github-setup/) — Create account, enable 2FA, and authenticate
+4. [Repository Creation and Cloning](../../../builder-setup/repo-creation-and-cloning/) — Create your first repository and clone it
 
 ## Lesson: Configure Your AI Code Editor
 

--- a/src/content/docs/courses/tools-setup-checklist.md
+++ b/src/content/docs/courses/tools-setup-checklist.md
@@ -158,7 +158,7 @@ Some steps below (Code Editor, Git, GitHub) involve running commands in the term
 
 **What:** Create an account, enable two-factor authentication (2FA), install the GitHub CLI, and create a repository for your coursework. Backs your building blocks up to the cloud and makes them accessible from any machine.
 
-**Action:** [Follow the GitHub setup guide →](/builder-setup/github-setup/)
+**Action:** [Follow the GitHub setup guide →](/builder-setup/github-setup/) for your account, 2FA, and CLI authentication, then [create and clone your first repository →](/builder-setup/repo-creation-and-cloning/)
 
 **Done when:**
 


### PR DESCRIPTION
Reworks the `builder-setup/` guides so a student can set up GitHub without being asked to install things they don't need, and so the guidance stops contradicting itself between the site and the course material that links into it.

Driven by a course-content change in the private business repo (a shared "Set Up Your GitHub Access" project now links these pages deep, by anchor). **Merge this first** — the course PR's links depend on anchors that only exist here.

## What changed

**Repo creation split out of account setup.** `github-setup` ended at verified authentication; creating and cloning a repository moved to a new `repo-creation-and-cloning` guide, which is where the course project now sends students.

**Token vs. CLI login explained.** New section: a token is a stored secret, a CLI login is a session. Covers why a hosted agent or automation can't use `gh auth login`, when to use each, fine-grained-over-classic, and the full creation steps including **Resource owner** — a mandatory field the guide previously skipped, and the one most likely to silently stall a student whose org requires admin approval.

**Prerequisites scoped per section, on both guides.** Both pages previously demanded Git, the GitHub CLI, and an editor up front. Creating an account, generating a token, and creating a repository are all browser-only. Someone connecting a hosted agent now installs nothing.

**Terminal basics.** New "Opening a Terminal" section on `git-install` — the guides opened straight into commands with no statement of where they're typed. Windows leads with **PowerShell** (every command here works there, and the installer's PATH option is already the recommended one); Git Bash is kept and explained as the option that gives command parity with macOS tutorials.

**`gh auth login` prompts.** It asks four questions before the browser opens; the guide said "follow the browser prompts". Now a table of question → answer.

**Accuracy fixes.** `gh` doesn't always store credentials in a system keychain; its OAuth grant is scoped rather than "full account access"; the comparison table's "Main risk" row described a limitation. macOS `gh` install now offers the `.pkg` for anyone without Homebrew — which is everyone who installed Git via Xcode CLT, as this guide recommends.

**Framing.** "GitHub is a website where people store and share code projects" now includes the prompts, skills, agents, and markdown these students actually version.

## Known and deliberate

`github-setup` still carries a Claude Code section on a page two non-Claude audiences read. Reviewed and deliberately deferred; tracked as an improvement in the business repo.

## Verification

`npm run build` clean, 196 pages. Every anchor the course material links — `#1-create-a-github-account`, `#2-install-github-cli`, `#3-choose-how-youll-authenticate-token-vs-cli-login`, `#authenticate`, `#creating-a-fine-grained-personal-access-token`, `#storing-your-token-safely`, `#troubleshooting`, `#1-create-a-repository`, `#macos`, `#windows`, `#configure-your-identity`, `#corporate-networks-proxy--firewall` — verified present in the built HTML. Both pre-existing routes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)