### PR TITLE
Fix MCP index URLs for .mdx pages

### DIFF
--- a/mcp-server/scripts/build-index.ts
+++ b/mcp-server/scripts/build-index.ts
@@ -49,27 +49,27 @@ function getSection(filePath: string): string {
 }
 
 function getUrl(filePath: string): string {
-  // Remove index.md → directory URL, remove .md → page URL
+  // Remove index.md/.mdx → directory URL, remove .md/.mdx → page URL
   let urlPath = filePath;
-  if (urlPath.endsWith("/index.md")) {
-    urlPath = urlPath.replace(/\/index\.md$/, "/");
-  } else if (urlPath === "index.md") {
+  if (/\/index\.mdx?$/.test(urlPath)) {
+    urlPath = urlPath.replace(/\/index\.mdx?$/, "/");
+  } else if (/^index\.mdx?$/.test(urlPath)) {
     urlPath = "";
   } else {
-    urlPath = urlPath.replace(/\.md$/, "/");
+    urlPath = urlPath.replace(/\.mdx?$/, "/");
   }
   return `${SITE_URL}/${urlPath}`;
 }
 
 function getPagePath(filePath: string): string {
-  // Remove .md and index suffixes for a clean path identifier
+  // Remove .md/.mdx and index suffixes for a clean path identifier
   let p = filePath;
-  if (p.endsWith("/index.md")) {
-    p = p.replace(/\/index\.md$/, "");
-  } else if (p === "index.md") {
+  if (/\/index\.mdx?$/.test(p)) {
+    p = p.replace(/\/index\.mdx?$/, "");
+  } else if (/^index\.mdx?$/.test(p)) {
     p = "home";
   } else {
-    p = p.replace(/\.md$/, "");
+    p = p.replace(/\.mdx?$/, "");
   }
   return p;
 }


### PR DESCRIPTION
## Summary

Fixes a regression from #208. Widening the MCP index glob to `**/*.{md,mdx}` brought 24 `.mdx` pages into the index, but `getUrl()` and `getPagePath()` in `build-index.ts` matched only `/\.md$/`. Every `.mdx` page kept its extension, so the live MCP server has been returning URLs like:

```
https://handsonai.info/index.mdx   → 404
```

The homepage's path identifier also regressed from `home` to `index.mdx`.

## Fix

Both functions now match `/\.mdx?$/`, handling `index.md`, `index.mdx`, `.md`, and `.mdx` uniformly.

## Verification

Rebuilt the index locally:

- 196 pages indexed
- **0** paths containing `.md`
- **0** URLs containing `.md`
- Homepage restored: path `home` → `https://handsonai.info/`
- Sampled 8 `.mdx`-sourced URLs against production — all return `200`

## Note

Deploying this rebuilds the index and redeploys the worker automatically (`deploy.yml` runs `build-index.ts` then `wrangler deploy`, and the worker imports `content-index.json` at build time), so no manual step is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)