### PR TITLE
Rewrite the bio from the canonical source

### DIFF
--- a/src/content/docs/about.md
+++ b/src/content/docs/about.md
@@ -7,7 +7,13 @@ I'm **James Gray**. I built this playbook because I believe the best way to acce
 
 ## A Bit of Background
 
-I'm an AI strategist, builder, and instructor. I teach AI strategy at UC Berkeley, where I've spent the past four years working with executives, and I run cohort courses on Maven for both leaders and hands-on builders. Before that came 30 years in technology — including a decade at Microsoft — and more recently, working with leaders from companies like Deloitte, Accenture, Adobe, and Anthropic as they put AI to work. The through-line has always been the same: take something complicated and make it usable by people who don't have time to become specialists.
+I teach data and AI strategy at UC Berkeley Haas Executive Education — including the largest AI program in the school's portfolio, plus custom programs for companies like Capital One — reaching between 1,200 and 2,500 senior leaders a year. I also run hands-on cohort courses on Maven for leaders and builders.
+
+Before teaching, I spent nearly a decade at Microsoft building the data and analytics platforms the business ran on. I've since held Chief Product Officer and Chief Information Officer roles across global enterprises and high-growth startups. My work sits at the intersection of product management, data, and AI.
+
+Today, as founder of JamesGray.AI, I advise leaders through consulting, fractional AI leadership, executive coaching, and hands-on learning. I hold an MS in Information and Data Science and an MBA from UC Berkeley, a BS in Electrical Engineering from Union College, and a leadership and performance coaching certification from Brown University.
+
+One conviction runs through all of it: AI accelerates and amplifies human capability, and realizing that takes both hands-on technical mastery and self-leadership.
 
 ## Why This Exists
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -35,7 +35,7 @@ import BlogList from '../../components/BlogList.astro';
 
 ## Hi, I'm James
 
-I teach AI strategy at UC Berkeley and have trained thousands of executives over the past four years — after 30 years in tech, including a decade at Microsoft.
+I teach AI strategy at UC Berkeley Haas Executive Education, including the largest AI program in its portfolio. Before that I spent nearly a decade at Microsoft, and I've served as a Chief Product Officer and Chief Information Officer across global enterprises and startups.
 
 I built this playbook because the best way to accelerate innovation is to make complex things simple — and then share them freely. Everything here comes from real work: building AI systems, teaching live cohorts, and learning alongside a global community of builders.
 


### PR DESCRIPTION
## Summary

Replaces bio copy drafted from the jamesgray.ai landing page with copy sourced from the canonical bio in the business repo (`shared/assets/brand/copy/bio.md`), which the brand reference designates as winning any conflict.

## Corrections to live claims

**1. Removed an inferred client relationship.** The About page said *"working with leaders from companies like Deloitte, Accenture, Adobe, and Anthropic."* I had inferred that framing from the logo wall on jamesgray.ai; the canonical bio does not state an advisory relationship with those companies. The sourced fact is custom Berkeley Haas programs for companies like **Capital One**.

**2. Added the CIO and CPO roles**, which were missing entirely. The brand reference explicitly flags *"former tech CIO and CPO (not CEO)"* as a fact to keep aligned.

## Other changes

- Teaching claim sharpened from "thousands of executives over the past four years" to **UC Berkeley Haas Executive Education** specifically — the largest AI program in its portfolio, 1,200–2,500 senior leaders a year
- Added degrees (MS Information and Data Science, MBA — both UC Berkeley; BS EE — Union College) and the Brown University coaching certification
- Added the closing conviction from the canonical bio, which lines up with the Graymatter subtitle already on the homepage
- Homepage credibility line updated to match, kept to two sentences

## Deliberately omitted

The 4.8/5 cohort rating. The brand reference notes an unsupported 4.9/5 figure circulated until 2026-07-19, and a rating isn't needed in this context.

## Verification

`npm run build` — 195 pages, no errors. Confirmed the removed claims appear nowhere in the built output and each sourced fact renders on the intended page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)