### PR TITLE
Widen What's New scope; migrate categories to tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,9 @@ cd mcp-server && npm install && wrangler dev
 - Link to official documentation rather than duplicating it
 - When adding new docs to `src/content/docs/`, also update the sidebar in `astro.config.mjs`
 - Questions pages must include `question` and `short_answer` frontmatter for AEO schema
-- Changelog posts require `date`, `authors`, `categories`, and `description` frontmatter — `description` appears on the homepage Latest Updates section
+- Blog posts require `date`, `authors`, `tags`, and `description` frontmatter — `description` appears in the homepage What's New section. `tags` is starlight-blog's real schema field; `categories` was a MkDocs leftover that nothing read
+- Tags are metadata only right now: starlight-blog's `/blog/tags/[tag]` and `/blog/authors/[author]` routes render nothing here, because the blog is hand-rolled via `BlogList.astro` over the `docs` collection rather than driven by the plugin's routes. Verified 2026-07-25 — the build produces no tag or author pages
+- The blog covers both playbook updates and notable releases from Anthropic, OpenAI, and other platforms — keep `/blog/` and RSS scope copy consistent with that
 
 ## Feature Development Workflow
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -13,7 +13,6 @@ export const collections = {
         question: z.string().optional(),
         short_answer: z.string().optional(),
         author: z.string().optional(),
-        categories: z.array(z.string()).optional(),
         course_provider: z.string().optional(),
         course_url: z.string().optional(),
         course_mode: z.string().optional(),

--- a/src/content/docs/blog/2026-02-10-introducing-the-cookbook.md
+++ b/src/content/docs/blog/2026-02-10-introducing-the-cookbook.md
@@ -2,7 +2,7 @@
 date: 2026-02-10
 authors:
   - jamesgray
-categories:
+tags:
   - Announcements
 description: "Why I built the Hands-on AI Playbook -- a free, open-source resource with a framework, building blocks, and ready-made tools for applied AI."
 title: "I Built an Open-Source AI Playbook for Builders. Here's What's Inside."

--- a/src/content/docs/blog/2026-02-14-introducing-the-changelog.md
+++ b/src/content/docs/blog/2026-02-14-introducing-the-changelog.md
@@ -2,7 +2,7 @@
 date: 2026-02-14
 authors:
   - jamesgray
-categories:
+tags:
   - Announcements
 description: "New Changelog with RSS feed, plus a dedicated MCP server so AI assistants can search the playbook directly."
 title: "Introducing the Changelog and MCP Server"

--- a/src/content/docs/blog/2026-02-15-slash-commands-for-plugin-skills.md
+++ b/src/content/docs/blog/2026-02-15-slash-commands-for-plugin-skills.md
@@ -2,7 +2,7 @@
 date: 2026-02-15
 authors:
   - jamesgray
-categories:
+tags:
   - Plugins
 description: "All 10 plugin skills now have slash commands — invoke any skill directly instead of relying on auto-triggering."
 title: "Slash Commands for All Plugin Skills"

--- a/src/content/docs/blog/2026-02-16-agentic-coding-plugin.md
+++ b/src/content/docs/blog/2026-02-16-agentic-coding-plugin.md
@@ -2,7 +2,7 @@
 date: 2026-02-16
 authors:
   - jamesgray
-categories:
+tags:
   - Plugins
 description: "New plugin for AI-assisted coding workflows — define requirements with structured PRDs before you build."
 title: "New Plugin: Agentic Coding"

--- a/src/content/docs/blog/2026-02-16-content-calendar-planning-example.md
+++ b/src/content/docs/blog/2026-02-16-content-calendar-planning-example.md
@@ -2,8 +2,8 @@
 date: 2026-02-16
 authors:
   - jamesgray
-categories:
-  - Business-First AI Framework
+tags:
+  - Framework
 description: "See what the Business-First AI Framework actually produces — a complete worked example with all three deliverables for a real content planning workflow."
 title: "New Example: Content Calendar Planning"
 ---The Business-First AI Framework now has a **full worked example** showing what the framework produces when you run a real workflow through all three steps. The example is Content Calendar Planning — a weekly process for planning content across LinkedIn, Substack, X, and YouTube.

--- a/src/content/docs/blog/2026-02-16-vision-brief-skill.md
+++ b/src/content/docs/blog/2026-02-16-vision-brief-skill.md
@@ -2,7 +2,7 @@
 date: 2026-02-16
 authors:
   - jamesgray
-categories:
+tags:
   - Plugins
 description: "Agentic Coding plugin update: PRD skill gets paired AC/user stories and scope sections; Vision Brief skill adds strategic depth with 10 questions and inline examples."
 title: "Agentic Coding Plugin: Stronger PRDs and Vision Briefs"

--- a/src/content/docs/blog/2026-02-18-product-engineering-adrs-platform-agents.md
+++ b/src/content/docs/blog/2026-02-18-product-engineering-adrs-platform-agents.md
@@ -2,7 +2,7 @@
 date: 2026-02-18
 authors:
   - jamesgray
-categories:
+tags:
   - New Content
   - Plugins
 description: "New Product & Engineering section, Architecture Decision Records page, platform-specific agent examples, and fixed agentic-coding slash commands."

--- a/src/content/docs/blog/2026-02-19-build-workflows-redesign-skills-orchestration.md
+++ b/src/content/docs/blog/2026-02-19-build-workflows-redesign-skills-orchestration.md
@@ -2,7 +2,7 @@
 date: 2026-02-19
 authors:
   - jamesgray
-categories:
+tags:
   - New Content
   - Plugins
 description: "Step 3 — Build Workflows redesigned around skill-driven orchestration with a new Construct page, Launch Guide, and cross-platform skills standard."

--- a/src/content/docs/blog/2026-02-19-build-workflows-v31-agents-matrix-architecture.md
+++ b/src/content/docs/blog/2026-02-19-build-workflows-v31-agents-matrix-architecture.md
@@ -2,7 +2,7 @@
 date: 2026-02-19
 authors:
   - jamesgray
-categories:
+tags:
   - Plugins
   - Platform Updates
 description: "Building Workflows v3.1 adds plan mode gate, spec approval, and reference specs. Agents matrix expanded with SDK and browser agents. Architecture decisions streamlined."

--- a/src/content/docs/blog/2026-02-25-orchestration-patterns-building-blocks-framework.md
+++ b/src/content/docs/blog/2026-02-25-orchestration-patterns-building-blocks-framework.md
@@ -2,7 +2,7 @@
 date: 2026-02-25
 authors:
   - jamesgray
-categories:
+tags:
   - New Content
 description: "Agent orchestration patterns, expanded building blocks, agent programming frameworks, and framework refinements."
 title: "Orchestration patterns, new building blocks, and framework refinements"

--- a/src/content/docs/blog/2026-02-26-plugin-marketplace-repo.md
+++ b/src/content/docs/blog/2026-02-26-plugin-marketplace-repo.md
@@ -2,7 +2,7 @@
 date: 2026-02-26
 authors:
   - jamesgray
-categories:
+tags:
   - Plugins
 description: "The plugin marketplace moved to a dedicated lightweight repo for faster installs in Cowork and other tools."
 title: "Plugin Marketplace Moved to Dedicated Repo"

--- a/src/content/docs/blog/2026-02-28-platform-getting-started-memory-building-block.md
+++ b/src/content/docs/blog/2026-02-28-platform-getting-started-memory-building-block.md
@@ -2,7 +2,7 @@
 date: 2026-02-28
 authors:
   - jamesgray
-categories:
+tags:
   - Platform Updates
   - New Content
 description: "Every platform now has a Getting Started checklist, Memory joins as the 10th building block, and Product & Engineering gets an Evaluation page."

--- a/src/content/docs/blog/2026-03-01-workflow-design-matrix-comparison-terminology.md
+++ b/src/content/docs/blog/2026-03-01-workflow-design-matrix-comparison-terminology.md
@@ -2,7 +2,7 @@
 date: 2026-03-01
 authors:
   - jamesgray
-categories:
+tags:
   - New Content
   - Plugins
 description: "New AI Workflow Design Matrix defines six workflow archetypes, Building Block Comparison Matrix helps choose the right block, and framework terminology is streamlined site-wide."

--- a/src/content/docs/blog/2026-03-02-build-phase-autonomy-orchestration.md
+++ b/src/content/docs/blog/2026-03-02-build-phase-autonomy-orchestration.md
@@ -2,7 +2,7 @@
 date: 2026-03-02
 authors:
   - jamesgray
-categories:
+tags:
   - Plugins
 description: "The Build phase now uses a two-step decision model — autonomy assessment plus orchestration mechanism — replacing the old execution pattern spectrum."
 title: "Build Phase: Autonomy Levels and Orchestration Mechanisms"

--- a/src/content/docs/blog/2026-03-04-portable-analyze-prompt-cross-platform-install.md
+++ b/src/content/docs/blog/2026-03-04-portable-analyze-prompt-cross-platform-install.md
@@ -2,9 +2,9 @@
 date: 2026-03-04
 authors:
   - jamesgray
-categories:
+tags:
   - New Content
-  - Business-First AI Framework
+  - Framework
 description: "Portable Analyze prompt for non-skill users and cross-platform skill install consistency across framework pages"
 title: "Portable Analyze Prompt and Cross-Platform Install Clarity"
 ---Two updates to make the Business-First AI Framework more accessible, regardless of which AI platform you use.

--- a/src/content/docs/blog/2026-03-05-deconstruct-prompt-markdown-registry-skills.md
+++ b/src/content/docs/blog/2026-03-05-deconstruct-prompt-markdown-registry-skills.md
@@ -2,7 +2,7 @@
 date: 2026-03-05
 authors:
   - jamesgray
-categories:
+tags:
   - New Content
   - Plugins
 description: "Portable Deconstruct prompt for any AI chat tool and AI Registry skills updated to save markdown files instead of Notion page bodies"

--- a/src/content/docs/blog/2026-03-07-vision-brief-prd-upgrade-coding-page-org-lens.md
+++ b/src/content/docs/blog/2026-03-07-vision-brief-prd-upgrade-coding-page-org-lens.md
@@ -2,7 +2,7 @@
 date: 2026-03-07
 authors:
   - jamesgray
-categories:
+tags:
   - Plugins
 description: "Upgraded Vision Brief and Feature PRD skills with deeper PM rigor, restructured Agentic Coding page, and added organizational workflow lens"
 title: "Stronger product specs, restructured coding page, and organizational workflows"

--- a/src/content/docs/blog/2026-03-12-data-readiness-11-building-blocks-build-phase-split.md
+++ b/src/content/docs/blog/2026-03-12-data-readiness-11-building-blocks-build-phase-split.md
@@ -2,7 +2,7 @@
 date: 2026-03-12
 authors:
   - jamesgray
-categories:
+tags:
   - Plugins
 description: "Data readiness probing, 11 building blocks, Design Prompt, and the Build phase split into three focused skills."
 title: "Data Readiness, 11 Building Blocks, and a Redesigned Build Phase"

--- a/src/content/docs/blog/2026-03-17-cli-building-block-smarter-construct.md
+++ b/src/content/docs/blog/2026-03-17-cli-building-block-smarter-construct.md
@@ -2,7 +2,7 @@
 date: 2026-03-17
 authors:
   - jamesgray
-categories:
+tags:
   - New Content
   - Plugins
 description: "CLI joins as the 11th agentic building block, and the Construct step now discovers creation tools automatically."

--- a/src/content/docs/blog/2026-03-20-framework-7-step-restructure.md
+++ b/src/content/docs/blog/2026-03-20-framework-7-step-restructure.md
@@ -2,7 +2,7 @@
 date: 2026-03-20
 authors:
   - jamesgray
-categories:
+tags:
   - Plugins
   - New Content
 description: "The Business-First AI Framework expands from 3 steps to 7 — with new Test and Improve steps, renamed skills, evaluation criteria, and a skills-only approach replacing portable prompts."

--- a/src/content/docs/blog/2026-03-20-outcome-driven-path-optimize-for-ai.md
+++ b/src/content/docs/blog/2026-03-20-outcome-driven-path-optimize-for-ai.md
@@ -2,7 +2,7 @@
 date: 2026-03-20
 authors:
   - jamesgray
-categories:
+tags:
   - Plugins
 description: "Deconstruct skill adds outcome-driven path for agent systems and optimize-for-AI step for step-decomposed workflows"
 title: "Outcome-Driven Path and Process Optimization in Deconstruct"

--- a/src/content/docs/blog/2026-05-04-plugin-consolidation.md
+++ b/src/content/docs/blog/2026-05-04-plugin-consolidation.md
@@ -2,7 +2,7 @@
 date: 2026-05-04
 authors:
   - jamesgray
-categories:
+tags:
   - Plugins
 description: "Four plugins are now one. The handsonai plugin bundles the Business-First AI Framework, AI Registry, and Agentic Coding skills into a single install. Example agents move to a new gallery."
 title: "One Plugin to Install: Hands-on AI Marketplace Consolidation"

--- a/src/content/docs/blog/2026-05-16-ai-workflow-framework-rename.md
+++ b/src/content/docs/blog/2026-05-16-ai-workflow-framework-rename.md
@@ -2,7 +2,7 @@
 date: 2026-05-16
 authors:
   - jamesgray
-categories:
+tags:
   - Framework
 description: "The Business-First AI Framework is now the AI Workflow Framework. Same seven steps, same skills, same /handsonai:* commands — just a clearer name that says what it actually is."
 title: "Renamed: AI Workflow Framework"

--- a/src/content/docs/blog/index.mdx
+++ b/src/content/docs/blog/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: What's New
-description: Recent updates to the Hands-on AI Playbook — new content, plugins, and platform guides.
+description: Playbook updates plus notable releases from Anthropic, OpenAI, and the other AI platforms worth following.
 ---
 
 import BlogList from '../../../components/BlogList.astro';
 
-Recent updates to the Hands-on AI Playbook. [Subscribe via RSS](/rss.xml).
+Updates to the Hands-on AI Playbook, plus notable releases from Anthropic, OpenAI, and the other platforms I follow. [Subscribe via RSS](/rss.xml).
 
 For long-form articles and deep dives, visit the [Graymatter newsletter](https://graymatter.jamesgray.ai).
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -45,6 +45,8 @@ It's free, it's open, and it gets updated constantly. I hope you find something 
 
 ## What's New
 
+Playbook updates, plus notable releases from Anthropic, OpenAI, and the other AI platforms I follow.
+
 <BlogList limit={3} />
 
 [See all updates →](blog/)

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -11,7 +11,7 @@ export async function GET(context: APIContext) {
 
   return rss({
     title: 'Hands-on AI Playbook Changelog',
-    description: 'Latest updates from the Hands-on AI Playbook — new content, plugins, and platform guides.',
+    description: 'Updates to the Hands-on AI Playbook, plus notable releases from Anthropic, OpenAI, and other AI platforms.',
     site: context.site!,
     items: posts.map((post) => ({
       title: post.data.title,


### PR DESCRIPTION
## Summary

The blog will now carry notable releases from Anthropic, OpenAI, and other platforms alongside playbook changelog entries. This updates the copy that promised otherwise, and fixes some dead frontmatter.

## 1. Scope copy

Three places said this feed was about the playbook specifically, and would have read as wrong the moment an industry-news post landed:

| Location | Before |
|---|---|
| `blog/index.mdx` body | "Recent updates to the Hands-on AI Playbook." |
| `blog/index.mdx` description | "Recent updates to the Hands-on AI Playbook — new content, plugins, and platform guides." |
| `src/pages/rss.xml.ts` | "Latest updates from the Hands-on AI Playbook — …" |

All three now state the wider scope.

## 2. Homepage subhead

One line under the `What's New` heading so a first-time visitor knows what the feed covers without clicking through.

## 3. `categories` → `tags`

`categories` is **MkDocs Material's** field — another migration leftover. Nothing in this codebase read it; it survived only because `content.config.ts` explicitly declared a passthrough, now removed. starlight-blog's real field is `tags`.

Migrated across all 23 posts. The two `Business-First AI Framework` values were folded into the existing `Framework` tag rather than carrying the retired product name forward.

Resulting tags: Plugins (16), New Content (9), Framework (3), Platform Updates (2), Announcements (2).

## Honest caveat on tag pages

I expected this to produce browsable tag pages. **It does not.** starlight-blog injects `/blog/tags/[tag]` and `/blog/authors/[author]` routes, but neither renders here — this repo hand-rolls the blog with `BlogList.astro` over the `docs` collection rather than using the plugin's routes. Verified: the build produces no tag or author pages, and the page count is unchanged at 195.

The migration is still correct — `tags` is the right field and `categories` was dead — but tags are metadata only for now. Making them browsable is separate work. CLAUDE.md records this so it isn't assumed later.

## Verification

`npm run build` — 195 pages, no errors. Homepage: 3 posts + subhead. `/blog/`: 23 posts. RSS description updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)