### PR TITLE
Fix blog post templates for tags and the real content path

### DIFF
--- a/.claude/agents/release-notes-generator.md
+++ b/.claude/agents/release-notes-generator.md
@@ -83,8 +83,8 @@ Create a draft changelog entry at `outputs/changelog-draft-YYYY-MM-DD.md` using 
 date: YYYY-MM-DD
 authors:
   - jamesgray
-categories:
-  - <primary category>
+tags:
+  - <primary tag>
 description: "<one-line summary>"
 ---
 

--- a/.claude/agents/release-notes-generator.md
+++ b/.claude/agents/release-notes-generator.md
@@ -97,7 +97,7 @@ description: "<one-line summary>"
 <Notable changes with links to playbook pages>
 ```
 
-This draft is for James to review before publishing to `docs/blog/posts/`. It is NOT automatically published.
+This draft is for James to review before publishing to `src/content/docs/blog/`. It is NOT automatically published.
 
 ## Step 8: Log the Result
 
@@ -130,4 +130,4 @@ Changelog draft: outputs/changelog-draft-YYYY-MM-DD.md
 
 - Always run from the repository root directory
 - The `gh` CLI must be authenticated (it is in this environment)
-- The changelog draft in `outputs/` requires manual review before publishing — run `/publishing-playbook-updates` or manually move it to `docs/blog/posts/`
+- The changelog draft in `outputs/` requires manual review before publishing — run `/publishing-playbook-updates` or manually move it to `src/content/docs/blog/`

--- a/.claude/skills/publishing-playbook-updates/SKILL.md
+++ b/.claude/skills/publishing-playbook-updates/SKILL.md
@@ -59,8 +59,8 @@ Draft a curated changelog entry from recent git history, get approval, publish i
    date: YYYY-MM-DD
    authors:
      - jamesgray
-   categories:
-     - <category>
+   tags:
+     - <tag>
    description: "<one-line summary of the update>"
    ---
 
@@ -74,13 +74,13 @@ Draft a curated changelog entry from recent git history, get approval, publish i
    ```
 
    Rules:
-   - Filename format: `docs/blog/posts/YYYY-MM-DD-<slug>.md`
+   - Filename format: `src/content/docs/blog/YYYY-MM-DD-<slug>.md`
    - Use today's date
    - Keep it short and scannable — this is a changelog, not a blog post
-   - Link to the actual playbook pages using relative paths (e.g., `../../agentic-building-blocks/agents/index.md`)
+   - Link to playbook pages with site-root paths (e.g., `/agentic-building-blocks/agents/`), matching every existing post
    - If a related Substack article was published, cross-reference it
-   - Categories: `New Content`, `Plugins`, `Platform Updates`, `Builder Setup`, `Courses`, `Announcements`
-   - Multiple categories can be listed if the update spans areas
+   - Tags: `New Content`, `Plugins`, `Platform Updates`, `Framework`, `Announcements`
+   - Multiple tags can be listed if the update spans areas
 
 5. **Present for review**
 

--- a/.claude/skills/publishing-playbook-updates/SKILL.md
+++ b/.claude/skills/publishing-playbook-updates/SKILL.md
@@ -16,7 +16,7 @@ Draft a curated changelog entry from recent git history, get approval, publish i
 
 1. **Find the last changelog entry date**
 
-   Look at the most recent file in `docs/blog/posts/` to determine the date range. Use the date from the filename (format: `YYYY-MM-DD-slug.md`).
+   Look at the most recent file in `src/content/docs/blog/` to determine the date range. Use the date from the filename (format: `YYYY-MM-DD-slug.md`).
 
 2. **Scan recent changes**
 
@@ -95,7 +95,7 @@ Draft a curated changelog entry from recent git history, get approval, publish i
 
 6. **Create the file**
 
-   Write the approved entry to `docs/blog/posts/YYYY-MM-DD-<slug>.md`.
+   Write the approved entry to `src/content/docs/blog/YYYY-MM-DD-<slug>.md`.
 
 7. **Commit and push**
 


### PR DESCRIPTION
## Summary

Addresses the code review on #211, which I merged without reading.

## The review's finding

#211 migrated `categories` → `tags` across all 23 posts, removed `categories` from the content schema, and codified `tags` in CLAUDE.md — but missed the two templates that generate **new** posts:

- `.claude/skills/publishing-playbook-updates/SKILL.md`
- `.claude/agents/release-notes-generator.md`

Because `categories` is no longer in the schema, Zod **silently strips** the unknown key rather than erroring. The next generated post would have had no `tags` at all — violating the requirement #211 just established, with no build failure to catch it.

## A second problem the review didn't flag

`publishing-playbook-updates` instructed the author to write posts to:

```
docs/blog/posts/YYYY-MM-DD-<slug>.md
```

That's the **MkDocs** path. Real posts live at `src/content/docs/blog/`. A post written to the stated path would land outside the content collection and never publish.

Also corrected: link guidance said to use relative `.md` paths (`../../agentic-building-blocks/agents/index.md`); all 23 existing posts use site-root paths (`/agentic-building-blocks/agents/`). And the suggested tag list now matches the tags actually in use.

## Left alone

`<!-- more -->` is a MkDocs excerpt marker (starlight-blog uses an `excerpt` frontmatter field), but all 23 posts carry it and it renders as an invisible HTML comment. Not worth churning 23 files over.

## Verification

`npm run build` — 195 pages, no errors. No `categories:` remains in either template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)