### PR TITLE
Review the automations that generate content

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,6 +11,14 @@ on:
     # frontmatter, and the link-check workflow verifies every internal link and
     # heading anchor in the built output.
     #
+    # The automations that GENERATE content are code too, and are covered here:
+    # .claude/** (skills and agents that write files), mcp-server/** (the MCP
+    # worker and its index builder), and plugins/** (distributed skills and
+    # agents). Two production bugs on 2026-07-25 lived in exactly these paths
+    # and shipped unreviewed: build-index.ts emitted 404 URLs for every .mdx
+    # page, and publishing-playbook-updates wrote posts to the retired MkDocs
+    # directory, where they would never have published.
+    #
     # NOTE: this only works because claude-review is NOT a required check —
     # a required check that never triggers would block merges forever. `main`
     # is unprotected as of 2026-07-25; re-check this if that changes.
@@ -25,6 +33,9 @@ on:
       - "package.json"
       - "scripts/**"
       - ".github/**"
+      - ".claude/**"
+      - "mcp-server/**"
+      - "plugins/**"
 
 jobs:
   claude-review:


### PR DESCRIPTION
## Summary

Adds `.claude/**`, `mcp-server/**`, and `plugins/**` to the code review path filter.

These directories hold the skills, agents, and scripts that write files and build the MCP index — code by any reasonable definition. They matched no path filter, so they were never reviewed.

## Why now

Two production bugs on 2026-07-25 lived in exactly these paths and shipped unreviewed:

| Bug | Path | Impact |
|---|---|---|
| `build-index.ts` emitted `https://handsonai.info/index.mdx` and 23 other 404 URLs after the index glob was widened to `.mdx` | `mcp-server/**` | MCP consumers got dead links for the homepage and every `.mdx` page |
| `publishing-playbook-updates` wrote posts to the retired MkDocs directory `docs/blog/posts/` | `.claude/**` | A published post would land outside the content collection and silently never appear |

The first was caught by the review on #208 — which ran because that PR *also* touched `src/**`. Had it touched only `mcp-server/`, nothing would have looked at it. The second was caught only by manual self-review.

## Why this is safe

The workflow is deliberately **not a required check** — the existing comment in the file explains that a required check which never triggers would block merges forever. Widening the filter therefore cannot block a merge; the cost is a few extra minutes on PRs touching these paths.

## Not included

Nothing verifies the MCP index's URLs. An audit (resolve every indexed URL, fail on non-200) would have caught the first bug directly and takes about a minute for 196 URLs. Worth adding as a separate step if you want that guarded permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)