### PR TITLE
Add Markdown Basics reference page for non-technical students

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -459,6 +459,7 @@ export default defineConfig({
           collapsed: true,
           items: [
             { label: 'Overview', link: '/builder-setup/' },
+            { label: 'Markdown Basics (reference)', link: '/builder-setup/markdown-basics/' },
             { label: 'AI Code Editor', link: '/builder-setup/editor-setup/' },
             { label: 'Git', link: '/builder-setup/git-install/' },
             { label: 'GitHub', link: '/builder-setup/github-setup/' },

--- a/src/content/docs/agentic-building-blocks/context/index.md
+++ b/src/content/docs/agentic-building-blocks/context/index.md
@@ -9,6 +9,8 @@ description: The Context building block — background information, reference do
 
 Every AI model has broad general knowledge, but it doesn't know your company's style guide, your product specs, your customer data, or your industry's specific terminology. Context bridges that gap.
 
+Most context is written as Markdown — plain text with a few formatting marks that give the model structure to navigate. If you're new to it, see [Markdown Basics](../../builder-setup/markdown-basics/).
+
 ## Key Characteristics
 
 - **Provides knowledge the model doesn't have** — your data, your docs, your domain

--- a/src/content/docs/builder-setup/ai-registry-setup.md
+++ b/src/content/docs/builder-setup/ai-registry-setup.md
@@ -13,6 +13,8 @@ howto_steps:
     text: Ask Claude to "update my registry" to regenerate the index after adding assets outside the framework.
 ---The **AI Registry** is your inventory of everything you build with AI: workflows, skills, agents, business processes, and the apps they connect to. It lives entirely in your workspace as Markdown files — no database, no external account, nothing extra to maintain.
 
+New to Markdown? It's plain text with a few formatting marks — see [Markdown Basics](../markdown-basics/) for a ten-minute primer.
+
 The registry has one simple principle: **the file is the record.**
 
 - Every **skill** and **agent** already describes itself in its own file (the `name` and `description` at the top).

--- a/src/content/docs/builder-setup/index.md
+++ b/src/content/docs/builder-setup/index.md
@@ -66,6 +66,10 @@ Pick any combination — each row names the specific capability it unlocks.
 | 7 | [Voice to Text](voice-to-text-setup/) | ~10 min | Nothing | Talk instead of type when writing prompts |
 | 8 | [AI Registry](ai-registry-setup/) | ~10 min | AI platform | Track every workflow, skill, agent, and connected app in your workspace — pure Markdown, no external tools |
 
+:::note[New to Markdown?]
+Everything you build here — skills, prompts, context files, your registry — is stored as Markdown. If that word is unfamiliar, read [Markdown Basics](markdown-basics/) first. It takes about ten minutes and requires nothing installed.
+:::
+
 :::note[New to the terminal?]
 Some Power User tools (Editor, Git, GitHub) involve running commands in the terminal. If that's unfamiliar, skim [Terminal Basics](terminal-basics/) first — it's a ~15-minute fluency primer, not a setup step.
 :::

--- a/src/content/docs/builder-setup/markdown-basics.mdx
+++ b/src/content/docs/builder-setup/markdown-basics.mdx
@@ -58,3 +58,73 @@ A Markdown file is simply a text file whose name ends in `.md`.
 
 A board memo you send once and never touch again? Use whatever you like. A style guide, a set of rules, a context file, or a process you will hand to an AI repeatedly? Markdown, every time.
 :::
+
+## What It Looks Like
+
+Here is a complete file — meeting notes from a client call. This is what you would actually type:
+
+```markdown
+# Client Sync — Acme Corp
+
+**Date:** 12 March  **Attendees:** James Gray, Sara Reyes
+
+## Decisions
+
+- Ship the pilot to three teams first, not the whole org
+- **Budget approved** at $40k for Q3
+- Sara owns the rollout comms
+
+## Open Questions
+
+- [ ] Who owns the onboarding docs?
+- [ ] Do we need legal review before the pilot?
+- [x] Confirm the Q3 start date
+```
+
+And here is the same file, rendered:
+
+---
+
+**Client Sync — Acme Corp**
+
+**Date:** 12 March  **Attendees:** James Gray, Sara Reyes
+
+*Decisions*
+
+- Ship the pilot to three teams first, not the whole org
+- **Budget approved** at $40k for Q3
+- Sara owns the rollout comms
+
+*Open Questions*
+
+- [ ] Who owns the onboarding docs?
+- [ ] Do we need legal review before the pilot?
+- [x] Confirm the Q3 start date
+
+---
+
+Same information, twice. The version on top is what lives in the file; the version underneath is what you and your AI both see. Nothing was lost — and the file is still something you could open in Notepad.
+
+**Why the rendered copy uses bold and italics for its headings rather than real `##` headings:** real headings would be picked up by this page's own table of contents and appear as if they were sections of the guide. The visual effect is the same for the reader.
+
+## The Six Symbols That Matter
+
+Six symbols. Some have two forms — two heading sizes, two kinds of list, ticked and unticked boxes — but there are still only six things to learn.
+
+| Symbol | You type | You get |
+|---|---|---|
+| **1. Headings** | `# Big Heading` | The title of the document |
+| | `## Section Heading` | A section within it |
+| **2. Bold** | `**urgent**` | **urgent** |
+| **3. Lists** | `- Ship the deck` | A bullet point |
+| | `1. First step` | A numbered list |
+| **4. Checklists** | `- [ ] Send the recap` | ☐ A checkbox you can tick |
+| | `- [x] Send the recap` | ☑ A ticked checkbox |
+| **5. Links** | `[our site](https://handsonai.info)` | [our site](https://handsonai.info) |
+| **6. Tables** | `\| Name \| Status \|` | A table row (see the note below) |
+
+**On tables:** they are the one symbol that is genuinely tedious to type by hand — every row needs its pipes lined up. Do not bother. Ask your AI: *"put that in a Markdown table."* It will get the pipes right every time.
+
+**You will also see these:** `` `backticks` `` around file names and commands, `>` at the start of a line for a quoted passage, and `![alt](image.png)` for images. You rarely need to type them, but now they will not surprise you.
+
+Anything beyond these six is rare enough that the better move is to ask your AI: *"how do I do X in Markdown?"* — you will get the answer faster than looking it up, and in the context of what you are already writing.

--- a/src/content/docs/builder-setup/markdown-basics.mdx
+++ b/src/content/docs/builder-setup/markdown-basics.mdx
@@ -201,3 +201,59 @@ description: Drafts my Monday status update
 That is called **frontmatter**. It is a small label on the file — a title, a description, a date — that tools read to know what the file is and how to use it. Your AI uses it to decide when a skill applies.
 
 You almost never write frontmatter by hand; the framework skills generate it. You just need to recognise it and leave it alone. If you delete those lines, tools stop recognising the file.
+
+## Try It — Five Minutes
+
+This exercise leaves you with a file you will genuinely reuse: a context file describing your role and your company, which you can attach to any future chat so you stop re-introducing yourself.
+
+1. **Ask your AI.** Paste this exactly:
+
+   > Interview me with three short questions about my role and my company. Then write my answers up as a context file in Markdown, using headings and bullet points.
+
+2. **Answer the three questions.**
+
+3. **Copy the Markdown it produces.** Copy the raw symbols, not a screenshot — if your AI shows a **Copy** button on the block, use that.
+
+4. **Save it as a file.** Follow the macOS or Windows steps in [Viewing and Editing It](#viewing-and-editing-it) above, and name it `my-context.md`.
+
+5. **Edit one line.** Open the file, change a single detail — add a project you are working on — and save again. You have now edited Markdown.
+
+6. **Hand it back.** Start a brand-new chat. Attach `my-context.md` using the paperclip or **+** button beside the message box, then ask for something ordinary: *"Draft a short intro paragraph about me for a conference bio."*
+
+Watch what happens on that last step. The AI does not ask who you are. That is the whole argument for Markdown, demonstrated in one file.
+
+## Common Gotchas
+
+Three things go wrong on the first attempt, and none of them are about syntax.
+
+<Tabs>
+  <TabItem label="macOS">
+
+**TextEdit saves rich text by default.** If you skip **Format → Make Plain Text**, TextEdit writes a formatted document instead of plain text, and your symbols will not behave. Set plain text first, before typing.
+
+**Smart quotes.** TextEdit may convert straight quotes into curly ones. Harmless in ordinary prose, but it breaks frontmatter. Turn it off under **Edit → Substitutions → Smart Quotes**.
+
+  </TabItem>
+  <TabItem label="Windows">
+
+**Windows hides file extensions.** By default, File Explorer does not show the ending of a file name — so a file you saved as `my-context.md` may silently be `my-context.md.txt`, and nothing will treat it as Markdown.
+
+To fix it: open **File Explorer**, click the **View** tab, and tick **File name extensions**. Now you can see what your files are actually called, and rename any that ended up wrong.
+
+**Notepad adds .txt unless told otherwise.** Always set **Save as type** to **All Files (\*.\*)** before naming the file.
+
+  </TabItem>
+</Tabs>
+
+**Blank lines matter — on both platforms.** Markdown needs an empty line between a paragraph and a list, or between a heading and the text beneath it. Without that gap, things run together. When something looks wrong, a missing blank line is the first thing to check.
+
+## Where Markdown Shows Up in the Playbook
+
+Now that you can read it, you will see it everywhere:
+
+- **[Context](../../agentic-building-blocks/context/)** — the background material you give your AI. Markdown is how you write it down so the model can navigate it.
+- **[Skills](../../agentic-building-blocks/skills/)** — every skill is a Markdown file with frontmatter at the top.
+- **[Prompts](../../agentic-building-blocks/prompts/)** — structured prompts use headings and lists for the same reason your context files do.
+- **[AI Registry](../ai-registry-setup/)** — your inventory of what you have built, kept as Markdown in your workspace.
+
+You do not need to write any of these by hand. But you can now read them, edit them, and tell when something looks wrong — which is the whole job.

--- a/src/content/docs/builder-setup/markdown-basics.mdx
+++ b/src/content/docs/builder-setup/markdown-basics.mdx
@@ -1,0 +1,60 @@
+---
+title: Markdown Basics
+description: What Markdown is, why it matters for capturing context, and how to create, view, edit, and share it — no technical background needed
+schema_type: HowTo
+howto_steps:
+  - name: Ask your AI for Markdown
+    text: Ask your AI assistant to interview you briefly and write your role and company context as Markdown.
+  - name: Save it as a .md file
+    text: "Paste the result into TextEdit (Mac, in plain text mode) or Notepad (Windows) and save it as my-context.md."
+  - name: Edit one line
+    text: Change a single line in the file and save again to confirm you can edit Markdown directly.
+  - name: Hand it back to your AI
+    text: Start a new chat, attach my-context.md, and ask a question — the AI reads your context and uses it.
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+Markdown is the format your AI writes in, and the format nearly everything in this playbook is stored in — skills, prompts, context files, and your AI Registry.
+
+Here is the whole ask: **you mostly read Markdown. Your AI mostly writes it.** You need to recognise six symbols and know how to save a file. That is the entire skill.
+
+Nothing on this page requires you to install anything.
+
+## You've Already Been Reading It
+
+Every time Claude or ChatGPT answers you with headings, bold text, and bullet points, you are looking at rendered Markdown. The model wrote a handful of symbols; the app turned them into formatting before you saw them.
+
+And every time you have pasted an AI answer into an email and watched stray `**asterisks**` or `###` hash marks come along for the ride — that was the same Markdown, arriving somewhere that did not know how to render it.
+
+So this is not a new thing to learn. It is a thing you have been reading for months, finally named.
+
+## What Markdown Is
+
+**Markdown is plain text plus a small number of punctuation marks that mean formatting.**
+
+You already do this instinctively. In Slack or email you type `*important*`, or start a line with a dash to make a list, and you expect it to look like something. Markdown formalises that instinct into a small, consistent set of rules that every modern tool understands.
+
+Three terms that get tangled together:
+
+- **Markdown** — plain text with light formatting marks. Readable as-is, even before anything renders it.
+- **HTML** — the language web pages are built from. Far more powerful, far heavier to write.
+- **Rich text** — what Word and Google Docs produce. Looks finished, but the formatting is locked inside that application's own file format.
+
+A Markdown file is simply a text file whose name ends in `.md`.
+
+## Why It Matters
+
+**1. Your AI reads and writes it natively.** Models produce Markdown by default. Handing them Markdown and taking Markdown back is a clean round trip — no reformatting, no copy-paste mangling, nothing lost in translation.
+
+**2. Structure is the point.** Headings and lists tell the model what is a section, what is a list of rules, and what is an example. A wall of prose does not. This is the direct link to [Context](../../agentic-building-blocks/context/): context is *what* you give the AI; Markdown is *how* you write it down so the model can navigate it.
+
+**3. It is plain text, so it lasts.** No corrupted files, no application lock-in, no document that only opens in the program that made it. A `.md` file written today opens in every tool you will ever use, including ones that do not exist yet.
+
+**4. It is what this playbook runs on.** Your skills, prompts, context files, and [AI Registry](../ai-registry-setup/) are all `.md`. You will meet Markdown whether or not you go looking for it.
+
+:::tip[The rule worth remembering]
+**Draft a one-off in Google Docs. Build anything you will reuse in Markdown.**
+
+A board memo you send once and never touch again? Use whatever you like. A style guide, a set of rules, a context file, or a process you will hand to an AI repeatedly? Markdown, every time.
+:::

--- a/src/content/docs/builder-setup/markdown-basics.mdx
+++ b/src/content/docs/builder-setup/markdown-basics.mdx
@@ -17,7 +17,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 Markdown is the format your AI writes in, and the format nearly everything in this playbook is stored in — skills, prompts, context files, and your AI Registry.
 
-Here is the whole ask: **you mostly read Markdown. Your AI mostly writes it.** You need to recognise six symbols and know how to save a file. That is the entire skill.
+Here is the whole ask: **you mostly read Markdown. Your AI mostly writes it.** You need to recognize six symbols and know how to save a file. That is the entire skill.
 
 Nothing on this page requires you to install anything.
 
@@ -33,7 +33,7 @@ So this is not a new thing to learn. It is a thing you have been reading for mon
 
 **Markdown is plain text plus a small number of punctuation marks that mean formatting.**
 
-You already do this instinctively. In Slack or email you type `*important*`, or start a line with a dash to make a list, and you expect it to look like something. Markdown formalises that instinct into a small, consistent set of rules that every modern tool understands.
+You already do this instinctively. In Slack or email you type `*important*`, or start a line with a dash to make a list, and you expect it to look like something. (One small trap: in Slack a single asterisk means bold, but in Markdown it means italic — double asterisks are bold.) Markdown formalizes that instinct into a small, consistent set of rules that most modern tools understand.
 
 Three terms that get tangled together:
 
@@ -85,17 +85,17 @@ And here is the same file, rendered:
 
 ---
 
-**Client Sync — Acme Corp**
+#### Client Sync — Acme Corp
 
 **Date:** 12 March  **Attendees:** James Gray, Sara Reyes
 
-*Decisions*
+##### Decisions
 
 - Ship the pilot to three teams first, not the whole org
 - **Budget approved** at $40k for Q3
 - Sara owns the rollout comms
 
-*Open Questions*
+##### Open Questions
 
 - [ ] Who owns the onboarding docs?
 - [ ] Do we need legal review before the pilot?
@@ -105,7 +105,7 @@ And here is the same file, rendered:
 
 Same information, twice. The version on top is what lives in the file; the version underneath is what you and your AI both see. Nothing was lost — and the file is still something you could open in Notepad.
 
-**Why the rendered copy uses bold and italics for its headings rather than real `##` headings:** real headings would be picked up by this page's own table of contents and appear as if they were sections of the guide. The visual effect is the same for the reader.
+**Why the headings look smaller here than in your own file:** this page shows them at a reduced size so they do not clutter the contents menu on the right. In a file of your own, `#` gives you a large document title and `##` a clear section heading — both bigger and heavier than what you see above.
 
 ## The Six Symbols That Matter
 
@@ -118,7 +118,7 @@ Six symbols. Some have two forms — two heading sizes, two kinds of list, ticke
 | **2. Bold** | `**urgent**` | **urgent** |
 | **3. Lists** | `- Ship the deck` | A bullet point |
 | | `1. First step` | A numbered list |
-| **4. Checklists** | `- [ ] Send the recap` | ☐ A checkbox you can tick |
+| **4. Checklists** | `- [ ] Send the recap` | ☐ An empty checkbox |
 | | `- [x] Send the recap` | ☑ A ticked checkbox |
 | **5. Links** | `[our site](https://handsonai.info)` | [our site](https://handsonai.info) |
 | **6. Tables** | `\| Name \| Status \|` | A table row (see the note below) |
@@ -167,11 +167,11 @@ Two routes, and you will mostly use the first.
 | Where you put it | What you see |
 |---|---|
 | Your AI chat (attached or pasted) | Fully rendered — this is the one that matters most |
-| GitHub | Fully rendered |
+| GitHub (open the .md file) | Fully rendered |
 | Notion (paste the text in) | Converts to Notion blocks as it arrives |
-| Slack | Bold and lists render; **checkboxes do not** — they appear as literal `[ ]` characters |
-| Google Drive preview | Raw text, symbols and all. Nothing is broken; Drive just does not render Markdown |
-| TextEdit / Notepad | Raw text, by design — this is the editing view |
+| Slack (paste the text in) | Bold and lists render; **checkboxes do not** — they appear as literal `[ ]` characters |
+| Google Drive (open the .md file) | Raw text, symbols and all. Nothing is broken; Drive just does not render Markdown |
+| TextEdit / Notepad | Raw text — though recent Windows 11 Notepad formats Markdown as you type. Use **View** to switch back to the raw symbols. |
 
 **When you are managing more than a few files,** move to a proper editor with a live preview pane. That is a setup step of its own — see the [AI Code Editor guide](../editor-setup/).
 
@@ -181,9 +181,9 @@ The question everyone asks: *if I write in Markdown, how do I send it to my CEO?
 
 Markdown is where you draft and store. It converts at the last step, and you have three ways to do it:
 
-- **Paste it.** Into Google Docs, Notion, or Slack. The formatting arrives with it.
+- **Paste it.** Copy the AI's answer as it appears on screen — the formatted version, not the raw symbols — then paste into Google Docs, Notion, or Slack. The formatting comes with it. (Notion also converts raw Markdown into its own blocks as you paste.)
 - **Ask your AI.** *"Turn this into a Word document"* or *"rewrite this as an email I can send to my CFO."* This is the most common route by far, and the model handles the tone shift as well as the format.
-- **Export from an editor.** Cursor and VS Code can export a Markdown file to PDF or HTML directly.
+- **Turn it into a PDF.** Paste it into Google Docs (see above), then use **File → Download → PDF Document**. Or simply ask your AI to produce the file for you.
 
 Nobody has to know your source file was Markdown. That is rather the point.
 
@@ -200,7 +200,7 @@ description: Drafts my Monday status update
 
 That is called **frontmatter**. It is a small label on the file — a title, a description, a date — that tools read to know what the file is and how to use it. Your AI uses it to decide when a skill applies.
 
-You almost never write frontmatter by hand; the framework skills generate it. You just need to recognise it and leave it alone. If you delete those lines, tools stop recognising the file.
+You almost never write frontmatter by hand; the framework skills generate it. You just need to recognize it and leave it alone. If you delete those lines, tools stop recognizing the file.
 
 ## Try It — Five Minutes
 
@@ -224,7 +224,7 @@ Watch what happens on that last step. The AI does not ask who you are. That is t
 
 ## Common Gotchas
 
-Three things go wrong on the first attempt, and none of them are about syntax.
+Three things go wrong on the first attempt, and none of them are about the symbols themselves.
 
 <Tabs>
   <TabItem label="macOS">
@@ -238,7 +238,7 @@ Three things go wrong on the first attempt, and none of them are about syntax.
 
 **Windows hides file extensions.** By default, File Explorer does not show the ending of a file name — so a file you saved as `my-context.md` may silently be `my-context.md.txt`, and nothing will treat it as Markdown.
 
-To fix it: open **File Explorer**, click the **View** tab, and tick **File name extensions**. Now you can see what your files are actually called, and rename any that ended up wrong.
+To fix it: open **File Explorer** and click **View** in the toolbar. On Windows 11, choose **Show**, then tick **File name extensions**. On Windows 10, tick **File name extensions** directly on the **View** tab. Now you can see what your files are actually called, and rename any that ended up wrong.
 
 **Notepad adds .txt unless told otherwise.** Always set **Save as type** to **All Files (\*.\*)** before naming the file.
 

--- a/src/content/docs/builder-setup/markdown-basics.mdx
+++ b/src/content/docs/builder-setup/markdown-basics.mdx
@@ -111,6 +111,8 @@ Same information, twice. The version on top is what lives in the file; the versi
 
 Six symbols. Some have two forms — two heading sizes, two kinds of list, ticked and unticked boxes — but there are still only six things to learn.
 
+<div class="table-scroll">
+
 | Symbol | You type | You get |
 |---|---|---|
 | **1. Headings** | `# Big Heading` | The title of the document |
@@ -122,6 +124,8 @@ Six symbols. Some have two forms — two heading sizes, two kinds of list, ticke
 | | `- [x] Send the recap` | ☑ A ticked checkbox |
 | **5. Links** | `[our site](https://handsonai.info)` | [our site](https://handsonai.info) |
 | **6. Tables** | `\| Name \| Status \|` | A table row (see the note below) |
+
+</div>
 
 **On tables:** they are the one symbol that is genuinely tedious to type by hand — every row needs its pipes lined up. Do not bother. Ask your AI: *"put that in a Markdown table."* It will get the pipes right every time.
 

--- a/src/content/docs/builder-setup/markdown-basics.mdx
+++ b/src/content/docs/builder-setup/markdown-basics.mdx
@@ -128,3 +128,76 @@ Six symbols. Some have two forms — two heading sizes, two kinds of list, ticke
 **You will also see these:** `` `backticks` `` around file names and commands, `>` at the start of a line for a quoted passage, and `![alt](image.png)` for images. You rarely need to type them, but now they will not surprise you.
 
 Anything beyond these six is rare enough that the better move is to ask your AI: *"how do I do X in Markdown?"* — you will get the answer faster than looking it up, and in the context of what you are already writing.
+
+## Creating It
+
+Two routes, and you will mostly use the first.
+
+**Ask your AI for it.** Add four words to any request: *"...and write it in Markdown."* That is the whole technique. The model already writes Markdown by default; you are just telling it to keep the symbols rather than strip them.
+
+**Convert what you already have.** Paste an existing document into your AI and ask: *"Convert this to Markdown, keeping the headings and lists."* Old meeting notes, a style guide, a process document — anything you want to start reusing with AI is a good candidate.
+
+## Viewing and Editing It
+
+**Start here — nothing to install.** A `.md` file is a plain text file, so tools you already have will open it.
+
+<Tabs>
+  <TabItem label="macOS">
+
+1. Open **TextEdit** (press **Cmd + Space**, type `TextEdit`, press Enter).
+2. Go to **Format** in the menu bar and choose **Make Plain Text**. Do this before you type anything — see the gotchas below for why.
+3. Type or paste your Markdown.
+4. Press **Cmd + S**. In the **Save As** box, type the full name including the ending: `my-context.md`.
+5. If a dialog asks about the extension, click **Use .md**.
+
+  </TabItem>
+  <TabItem label="Windows">
+
+1. Open **Notepad** (click **Start**, type `Notepad`, press Enter).
+2. Type or paste your Markdown.
+3. Press **Ctrl + S**.
+4. In the **Save as type** dropdown, choose **All Files (\*.\*)**. This step is what stops Windows from adding `.txt` on the end.
+5. In the **File name** box, type the full name including the ending: `my-context.md`.
+
+  </TabItem>
+</Tabs>
+
+**Where it renders, and where it does not.** This trips people up on their first file, so it is worth knowing in advance:
+
+| Where you put it | What you see |
+|---|---|
+| Your AI chat (attached or pasted) | Fully rendered — this is the one that matters most |
+| GitHub | Fully rendered |
+| Notion (paste the text in) | Converts to Notion blocks as it arrives |
+| Slack | Bold and lists render; **checkboxes do not** — they appear as literal `[ ]` characters |
+| Google Drive preview | Raw text, symbols and all. Nothing is broken; Drive just does not render Markdown |
+| TextEdit / Notepad | Raw text, by design — this is the editing view |
+
+**When you are managing more than a few files,** move to a proper editor with a live preview pane. That is a setup step of its own — see the [AI Code Editor guide](../editor-setup/).
+
+## Getting It Back Out
+
+The question everyone asks: *if I write in Markdown, how do I send it to my CEO?*
+
+Markdown is where you draft and store. It converts at the last step, and you have three ways to do it:
+
+- **Paste it.** Into Google Docs, Notion, or Slack. The formatting arrives with it.
+- **Ask your AI.** *"Turn this into a Word document"* or *"rewrite this as an email I can send to my CFO."* This is the most common route by far, and the model handles the tone shift as well as the format.
+- **Export from an editor.** Cursor and VS Code can export a Markdown file to PDF or HTML directly.
+
+Nobody has to know your source file was Markdown. That is rather the point.
+
+## What's That Dashed Block at the Top?
+
+Open a skill file or a registry entry and you will find something like this at the very top, fenced by three dashes:
+
+```markdown
+---
+name: weekly-report
+description: Drafts my Monday status update
+---
+```
+
+That is called **frontmatter**. It is a small label on the file — a title, a description, a date — that tools read to know what the file is and how to use it. Your AI uses it to decide when a skill applies.
+
+You almost never write frontmatter by hand; the framework skills generate it. You just need to recognise it and leave it alone. If you delete those lines, tools stop recognising the file.

--- a/src/content/docs/builder-setup/markdown-basics.mdx
+++ b/src/content/docs/builder-setup/markdown-basics.mdx
@@ -135,7 +135,7 @@ Two routes, and you will mostly use the first.
 
 **Ask your AI for it.** Add four words to any request: *"...and write it in Markdown."* That is the whole technique. The model already writes Markdown by default; you are just telling it to keep the symbols rather than strip them.
 
-**Convert what you already have.** Paste an existing document into your AI and ask: *"Convert this to Markdown, keeping the headings and lists."* Old meeting notes, a style guide, a process document — anything you want to start reusing with AI is a good candidate.
+**Convert what you already have.** Paste an existing document into your AI and ask: *"Convert this to Markdown, keeping the headings and lists."* Old meeting notes, a style guide, a process document — anything you want to start reusing with AI is a good candidate. If the document is already in Google Docs, you can skip the copy-and-paste entirely — see [Turn on Markdown in Google Docs](#getting-it-back-out) below.
 
 ## Viewing and Editing It
 
@@ -184,6 +184,23 @@ Markdown is where you draft and store. It converts at the last step, and you hav
 - **Paste it.** Copy the AI's answer as it appears on screen — the formatted version, not the raw symbols — then paste into Google Docs, Notion, or Slack. The formatting comes with it. (Notion also converts raw Markdown into its own blocks as you paste.)
 - **Ask your AI.** *"Turn this into a Word document"* or *"rewrite this as an email I can send to my CFO."* This is the most common route by far, and the model handles the tone shift as well as the format.
 - **Turn it into a PDF.** Paste it into Google Docs (see above), then use **File → Download → PDF Document**. Or simply ask your AI to produce the file for you.
+
+:::tip[Turn on Markdown in Google Docs]
+Google Docs can read and write Markdown, but the feature is **off by default**. Turning it on takes a minute, and you only do it once:
+
+1. Open any Google Doc.
+2. Go to **Tools → Preferences**.
+3. Tick **Enable Markdown**, then click **OK**.
+
+That gives you four things you did not have before:
+
+- **Right-click → Paste from Markdown** — pastes raw Markdown and converts it into proper Docs formatting. An ordinary **Ctrl/Cmd + V** still pastes the raw symbols, so you have to pick this option each time.
+- **Right-click → Copy as Markdown** — copies part of a Doc back out as Markdown, ready to hand to your AI.
+- **File → Download → Markdown (.md)** — turns a whole Doc into a `.md` file.
+- **File → Open → Upload** — brings a `.md` file into Docs as an editable document.
+
+Those last two make Google Docs a two-way door: draft in Markdown, share in Docs, and pull it back out again without retyping anything.
+:::
 
 Nobody has to know your source file was Markdown. That is rather the point.
 

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -273,3 +273,27 @@ header.header site-search button[data-open-modal] kbd {
   background: var(--sl-color-gray-6);
   z-index: -1;
 }
+
+/* Opt-in horizontal scroll for a wide table.
+
+   Starlight renders markdown tables straight into .sl-markdown-content with no
+   wrapper, so a table wider than the column is clipped on narrow screens rather
+   than scrolled — the overflowing columns become unreachable. This class is
+   applied by hand to tables where losing a column would break meaning, e.g. the
+   "You type" / "You get" comparison on /builder-setup/markdown-basics/, where the
+   right-hand column is the entire point.
+
+   Deliberately opt-in, not a global rule: making every table on the site a block
+   scroll container changes how tables size on desktop and needs its own pass. */
+.table-scroll {
+  overflow-x: auto;
+}
+
+/* The wrapper alone is not enough. Starlight constrains the table box to the
+   content column, so wide cells overflow the table's own box rather than the
+   wrapper's — leaving the wrapper with nothing to scroll. Letting the table grow
+   to its natural width is what actually hands the overflow to the wrapper. */
+.table-scroll table {
+  width: max-content;
+  min-width: 100%;
+}


### PR DESCRIPTION
Adds a **Markdown Basics** reference page for non-technical business students, plus a sidebar entry and three inbound cross-links.

The playbook runs on Markdown — skills, prompts, context files, the AI Registry — but no page anywhere on the site defined what Markdown is. Several pages already say "Markdown-based" as a given. This closes that silent prerequisite.

Spec: `specs/markdown-basics-prd.md` · Plan: `specs/markdown-basics-plan.md` (both gitignored)

## What's here

A 13-section page ordered **recognition → reassurance → motivation** before any syntax appears, on the theory that non-technical readers disengage when a page opens with symbols:

- Opens by naming something they've already seen — every formatted AI answer is rendered Markdown, and those stray `**asterisks**` on paste were its raw form
- States the ask up front: *you mostly read Markdown, your AI mostly writes it*
- Six symbols taught in a `Symbol` / `You type` / `You get` table — headings, bold, lists, **checklists**, links, tables
- A complete meeting-notes artifact shown raw and rendered, not syntax fragments
- Mac/Windows steps in tabs, naming literal menu items throughout
- **Getting It Back Out** — how to send Markdown to a colleague, the biggest adoption blocker
- A five-minute exercise producing a reusable `my-context.md` the reader attaches to a fresh chat

Checklists were chosen over code ticks deliberately: business writing is disproportionately action items, and a business professional types backticks almost never.

## Files

**New:** `src/content/docs/builder-setup/markdown-basics.mdx`
**Modified:** `astro.config.mjs` (sidebar), `builder-setup/index.md`, `agentic-building-blocks/context/index.md`, `builder-setup/ai-registry-setup.md`, `src/styles/custom.css`

## Verification

- `npm run build` — exit 0, 196 pages
- `node scripts/check-links.js` — 39,224 internal links and anchors OK
- Browser-verified at 390px and 1440px

## Factual errors caught before merge

Six claims were wrong on first draft and would have made a student's first attempt fail. Worth listing, since none were catchable from the source alone:

| Claim | Reality |
|---|---|
| Pasting Markdown into Google Docs carries formatting | Off by default; needs `Tools → Preferences → Enable Markdown`, then right-click → **Paste from Markdown** every time |
| VS Code and Cursor export Markdown to PDF | Neither does without a third-party extension |
| Windows: `View` tab → File name extensions | Windows 11 needs `View → Show → File name extensions` |
| Notepad shows raw text by design | Windows 11 Notepad now formats Markdown by default |
| The worked example taught `#` → bold, `##` → italic | Contradicted the page's own reference table. Now uses real `h4`/`h5`, which fall outside this site's TOC range so they don't pollute the contents menu |
| Checkboxes "you can tick" | Rendered checkboxes are disabled outside GitHub issues and Notion |

## Google Docs

Since students live in Docs, the page includes the one-time setup and the **Copy as Markdown** / **Download → Markdown (.md)** / **Open → Upload** paths — making Docs a two-way door rather than a dead end. Menu names taken from Google's documentation, not memory.

## One scoped CSS change

At 390px the six-symbol table was 417px in a 343px column and the "You get" column was **unreachable** — half the teaching device gone on mobile. Starlight renders markdown tables with no wrapper, so wide tables clip rather than scroll.

Fixed with an opt-in `.table-scroll` class rather than a global rule. **This is pre-existing and site-wide** — `/builder-setup/` alone has three clipped tables, including two 5-column ones, untouched here. A global fix changes how every table sizes on 196 pages and deserves its own PR.

## Known gaps

- The instructions are verified against vendor documentation, **not by performing them**. The TextEdit dialog and Google Docs flow would take five minutes to confirm on a Mac.
- **Windows is unverified.**
- No external reference links, by decision — where a reader would be sent outward, the page says to ask their AI instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
