### PR TITLE
Fix the three defects the post-merge review found

### DIFF
--- a/.claude/commands/hbr-article-strict.md
+++ b/.claude/commands/hbr-article-strict.md
@@ -68,11 +68,20 @@ publish. Before asking, show them:
 - the article's title and opening paragraph from `03-edited.md`
 - the full paths to both files, so they can open them
 
-If they **approve**, continue to Stage 4.
+If they **approve**, record it before going anywhere near Stage 4:
+
+```bash
+echo "approved by human at $(date -u '+%Y-%m-%dT%H:%M:%SZ')" > <workspace>/APPROVED
+```
+
+This is not bookkeeping. A `PreToolUse` hook refuses to dispatch `hbr-publisher` until
+that file exists, so without it Stage 4 is blocked no matter what the human said. Then
+continue to Stage 4.
 
 If they **decline**, capture their notes and re-dispatch `hbr-editor` with them, then ask
 again. **Maximum two revision rounds** — after that, stop, report where things stand, and
-leave every artifact in place. Publish nothing without explicit approval.
+leave every artifact in place. Never create the marker on the human's behalf, and publish
+nothing without explicit approval.
 
 ## Stage 4 — `hbr-publisher` → `04-article.md` + `04-article.docx`
 

--- a/plugins/multi-agent-example/commands/hbr-article-strict.md
+++ b/plugins/multi-agent-example/commands/hbr-article-strict.md
@@ -68,11 +68,20 @@ publish. Before asking, show them:
 - the article's title and opening paragraph from `03-edited.md`
 - the full paths to both files, so they can open them
 
-If they **approve**, continue to Stage 4.
+If they **approve**, record it before going anywhere near Stage 4:
+
+```bash
+echo "approved by human at $(date -u '+%Y-%m-%dT%H:%M:%SZ')" > <workspace>/APPROVED
+```
+
+This is not bookkeeping. A `PreToolUse` hook refuses to dispatch `hbr-publisher` until
+that file exists, so without it Stage 4 is blocked no matter what the human said. Then
+continue to Stage 4.
 
 If they **decline**, capture their notes and re-dispatch `hbr-editor` with them, then ask
 again. **Maximum two revision rounds** — after that, stop, report where things stand, and
-leave every artifact in place. Publish nothing without explicit approval.
+leave every artifact in place. Never create the marker on the human's behalf, and publish
+nothing without explicit approval.
 
 ## Stage 4 — `hbr-publisher` → `04-article.md` + `04-article.docx`
 

--- a/plugins/multi-agent-example/scripts/article-to-docx.js
+++ b/plugins/multi-agent-example/scripts/article-to-docx.js
@@ -55,13 +55,26 @@ function parseFrontmatter(raw) {
   const end = raw.indexOf('\n---', 3);
   if (end === -1) return { meta, body: raw };
 
-  for (const line of raw.slice(4, end).split('\n')) {
-    // Tolerate leading whitespace. Indented keys are still valid YAML, and anchoring
-    // the key to column 0 meant an indented `title:` was silently skipped — the
-    // document shipped headed "Untitled" with nothing anywhere reporting why.
-    const match = line.match(/^\s*([A-Za-z_][\w-]*):\s*(.*)$/);
+  // Read only keys at the frontmatter's own indentation level.
+  //
+  // Anchoring to column 0 meant a uniformly indented block silently lost its `title:`
+  // and shipped a document headed "Untitled". Accepting any indentation instead was
+  // worse: nested keys (`author:` / `  name:` / `  title:`) then overwrote the top-level
+  // ones, producing a plausible-looking wrong title AND suppressing the missing-title
+  // warning. So take the indentation of the first key as the document's level and ignore
+  // anything deeper — nested values belong to their parent, not to the document.
+  const lines = raw.slice(4, end).split('\n');
+  let baseIndent = null;
+
+  for (const line of lines) {
+    const match = line.match(/^(\s*)([A-Za-z_][\w-]*):\s*(.*)$/);
     if (!match) continue;
-    meta[match[1].toLowerCase()] = match[2].trim().replace(/^["']|["']$/g, '');
+
+    const [, indent, key, value] = match;
+    if (baseIndent === null) baseIndent = indent.length;
+    if (indent.length > baseIndent) continue;
+
+    meta[key.toLowerCase()] = value.trim().replace(/^["']|["']$/g, '');
   }
 
   const body = raw.slice(end + 4).replace(/^\n+/, '');
@@ -108,7 +121,10 @@ function inlineRuns(text, base = {}) {
     } else if (ital1 !== undefined || ital2 !== undefined) {
       runs.push(new TextRun({ text: ital1 ?? ital2, italics: true, ...base }));
     } else if (code !== undefined) {
-      runs.push(new TextRun({ text: code, font: 'Courier New', ...base }));
+      // font AFTER the spread. Every caller passes `font: FONT` in base, so spreading it
+      // last silently overrode Courier New and rendered code spans in Georgia — a valid
+      // file, just wrong, which is the kind of defect nothing downstream catches.
+      runs.push(new TextRun({ text: code, ...base, font: 'Courier New' }));
     }
 
     rest = rest.slice(m.index + m[0].length);

--- a/plugins/multi-agent-example/scripts/test-article-to-docx.sh
+++ b/plugins/multi-agent-example/scripts/test-article-to-docx.sh
@@ -172,10 +172,6 @@ if command -v unzip > /dev/null; then
     bad "headings are not built-in styles"
   fi
 
-  # Two separate ordered lists must not share one counter, or the second renders as
-  # 4, 5, 6 instead of restarting at 1. The fixture has one bullet list and two ordered
-  # lists, so a correct render produces three distinct w:numId values. Sharing one
-  # counter produces two — which is why the fixture needs the second ordered list.
   # Inline code must be monospace. `font` was being overridden by a spread that came
   # after it, so every code span silently rendered in the body serif.
   if grep -q 'w:ascii="Courier New"' "$TMP/document.xml"; then
@@ -184,6 +180,10 @@ if command -v unzip > /dev/null; then
     bad "inline code is not monospace — the code span font was overridden"
   fi
 
+  # Two separate ordered lists must not share one counter, or the second renders as
+  # 4, 5, 6 instead of restarting at 1. The fixture has one bullet list and two ordered
+  # lists, so a correct render produces three distinct w:numId values. Sharing one
+  # counter produces two — which is why the fixture needs the second ordered list.
   NUM_IDS="$(grep -o '<w:numId w:val="[0-9]*"' "$TMP/document.xml" | sort -u | wc -l | tr -d ' ')"
   if [ "${NUM_IDS:-0}" -ge 3 ]; then
     ok "each ordered list gets its own numbering instance ($NUM_IDS distinct)"
@@ -233,15 +233,21 @@ NESTED="$TMP/nested.md"
   echo 'Body text long enough to render into a document block for this check.'
 } > "$NESTED"
 
-if bash "$RENDER" "$NESTED" "$TMP/nested.docx" > "$TMP/nested.log" 2>&1 && command -v unzip > /dev/null; then
+# A render failure is a FAILURE, never a skip. Folding it into the same condition as the
+# unzip check made a crash in parseFrontmatter — the exact regression these two tests
+# exist to catch — print "skip" and exit 0. Skips are for missing tools only; the code
+# under test never gets to opt out of being tested.
+if ! bash "$RENDER" "$NESTED" "$TMP/nested.docx" > "$TMP/nested.log" 2>&1; then
+  bad "nested frontmatter render failed: $(head -3 "$TMP/nested.log" | tr '\n' ' ')"
+elif ! command -v unzip > /dev/null; then
+  skip "nested frontmatter check (unzip unavailable)"
+else
   unzip -p "$TMP/nested.docx" word/document.xml > "$TMP/nested.xml" 2>/dev/null
   if grep -q 'The Real Title' "$TMP/nested.xml" && ! grep -q 'Chief Nested Officer' "$TMP/nested.xml"; then
     ok "nested frontmatter keys do not overwrite the document title"
   else
     bad "a nested frontmatter key overwrote the top-level title"
   fi
-else
-  skip "nested frontmatter check (render failed or unzip unavailable)"
 fi
 
 INDENTED="$TMP/indented.md"
@@ -254,15 +260,17 @@ INDENTED="$TMP/indented.md"
   echo 'Body text long enough to render into a document block for this check.'
 } > "$INDENTED"
 
-if bash "$RENDER" "$INDENTED" "$TMP/indented.docx" > "$TMP/indented.log" 2>&1 && command -v unzip > /dev/null; then
+if ! bash "$RENDER" "$INDENTED" "$TMP/indented.docx" > "$TMP/indented.log" 2>&1; then
+  bad "indented frontmatter render failed: $(head -3 "$TMP/indented.log" | tr '\n' ' ')"
+elif ! command -v unzip > /dev/null; then
+  skip "indented frontmatter check (unzip unavailable)"
+else
   unzip -p "$TMP/indented.docx" word/document.xml > "$TMP/indented.xml" 2>/dev/null
   if grep -q 'Uniformly Indented Title' "$TMP/indented.xml"; then
     ok "uniformly indented frontmatter is still read"
   else
     bad "indented frontmatter was skipped — the document lost its title"
   fi
-else
-  skip "indented frontmatter check (render failed or unzip unavailable)"
 fi
 
 echo

--- a/plugins/multi-agent-example/scripts/test-article-to-docx.sh
+++ b/plugins/multi-agent-example/scripts/test-article-to-docx.sh
@@ -38,6 +38,10 @@ FIXTURE="$TMP/article.md"
   echo 'Most companies deploying AI agents are **measuring the wrong thing**. They track'
   echo 'model accuracy when they should track *cycle time*. See [the research](https://hbr.org/example).'
   echo
+  # Inline code was absent from this fixture entirely, which is why code spans rendering
+  # in the body font instead of monospace went unnoticed.
+  echo 'One team tracked it with a single `cycle_time_p95` metric and nothing else.'
+  echo
   echo '> The agents that paid for themselves were the ones nobody had to supervise.'
   echo
   echo '### Three Signals'
@@ -172,6 +176,14 @@ if command -v unzip > /dev/null; then
   # 4, 5, 6 instead of restarting at 1. The fixture has one bullet list and two ordered
   # lists, so a correct render produces three distinct w:numId values. Sharing one
   # counter produces two — which is why the fixture needs the second ordered list.
+  # Inline code must be monospace. `font` was being overridden by a spread that came
+  # after it, so every code span silently rendered in the body serif.
+  if grep -q 'w:ascii="Courier New"' "$TMP/document.xml"; then
+    ok "inline code renders in a monospace font"
+  else
+    bad "inline code is not monospace — the code span font was overridden"
+  fi
+
   NUM_IDS="$(grep -o '<w:numId w:val="[0-9]*"' "$TMP/document.xml" | sort -u | wc -l | tr -d ' ')"
   if [ "${NUM_IDS:-0}" -ge 3 ]; then
     ok "each ordered list gets its own numbering instance ($NUM_IDS distinct)"
@@ -199,6 +211,58 @@ if command -v soffice > /dev/null && command -v pdfinfo > /dev/null; then
   fi
 else
   echo "  skip  pagination (soffice/pdfinfo unavailable)"
+fi
+
+# --- Frontmatter indentation ----------------------------------------------
+
+# Two opposite failures, one regex. Anchoring keys to column 0 dropped a uniformly
+# indented `title:` and shipped a document headed "Untitled". Accepting any indentation
+# instead let NESTED keys overwrite the top-level ones — worse, because the wrong title
+# looks plausible and silences the missing-title warning. Both directions are asserted
+# here so a future fix for one cannot silently reintroduce the other.
+
+NESTED="$TMP/nested.md"
+{
+  echo '---'
+  echo 'title: The Real Title'
+  echo 'author:'
+  echo '  name: Someone Else'
+  echo '  title: Chief Nested Officer'
+  echo '---'
+  echo
+  echo 'Body text long enough to render into a document block for this check.'
+} > "$NESTED"
+
+if bash "$RENDER" "$NESTED" "$TMP/nested.docx" > "$TMP/nested.log" 2>&1 && command -v unzip > /dev/null; then
+  unzip -p "$TMP/nested.docx" word/document.xml > "$TMP/nested.xml" 2>/dev/null
+  if grep -q 'The Real Title' "$TMP/nested.xml" && ! grep -q 'Chief Nested Officer' "$TMP/nested.xml"; then
+    ok "nested frontmatter keys do not overwrite the document title"
+  else
+    bad "a nested frontmatter key overwrote the top-level title"
+  fi
+else
+  skip "nested frontmatter check (render failed or unzip unavailable)"
+fi
+
+INDENTED="$TMP/indented.md"
+{
+  echo '---'
+  echo '  title: Uniformly Indented Title'
+  echo '  author: James Gray'
+  echo '---'
+  echo
+  echo 'Body text long enough to render into a document block for this check.'
+} > "$INDENTED"
+
+if bash "$RENDER" "$INDENTED" "$TMP/indented.docx" > "$TMP/indented.log" 2>&1 && command -v unzip > /dev/null; then
+  unzip -p "$TMP/indented.docx" word/document.xml > "$TMP/indented.xml" 2>/dev/null
+  if grep -q 'Uniformly Indented Title' "$TMP/indented.xml"; then
+    ok "uniformly indented frontmatter is still read"
+  else
+    bad "indented frontmatter was skipped — the document lost its title"
+  fi
+else
+  skip "indented frontmatter check (render failed or unzip unavailable)"
 fi
 
 echo

--- a/scripts/article-to-docx.js
+++ b/scripts/article-to-docx.js
@@ -55,13 +55,26 @@ function parseFrontmatter(raw) {
   const end = raw.indexOf('\n---', 3);
   if (end === -1) return { meta, body: raw };
 
-  for (const line of raw.slice(4, end).split('\n')) {
-    // Tolerate leading whitespace. Indented keys are still valid YAML, and anchoring
-    // the key to column 0 meant an indented `title:` was silently skipped — the
-    // document shipped headed "Untitled" with nothing anywhere reporting why.
-    const match = line.match(/^\s*([A-Za-z_][\w-]*):\s*(.*)$/);
+  // Read only keys at the frontmatter's own indentation level.
+  //
+  // Anchoring to column 0 meant a uniformly indented block silently lost its `title:`
+  // and shipped a document headed "Untitled". Accepting any indentation instead was
+  // worse: nested keys (`author:` / `  name:` / `  title:`) then overwrote the top-level
+  // ones, producing a plausible-looking wrong title AND suppressing the missing-title
+  // warning. So take the indentation of the first key as the document's level and ignore
+  // anything deeper — nested values belong to their parent, not to the document.
+  const lines = raw.slice(4, end).split('\n');
+  let baseIndent = null;
+
+  for (const line of lines) {
+    const match = line.match(/^(\s*)([A-Za-z_][\w-]*):\s*(.*)$/);
     if (!match) continue;
-    meta[match[1].toLowerCase()] = match[2].trim().replace(/^["']|["']$/g, '');
+
+    const [, indent, key, value] = match;
+    if (baseIndent === null) baseIndent = indent.length;
+    if (indent.length > baseIndent) continue;
+
+    meta[key.toLowerCase()] = value.trim().replace(/^["']|["']$/g, '');
   }
 
   const body = raw.slice(end + 4).replace(/^\n+/, '');
@@ -108,7 +121,10 @@ function inlineRuns(text, base = {}) {
     } else if (ital1 !== undefined || ital2 !== undefined) {
       runs.push(new TextRun({ text: ital1 ?? ital2, italics: true, ...base }));
     } else if (code !== undefined) {
-      runs.push(new TextRun({ text: code, font: 'Courier New', ...base }));
+      // font AFTER the spread. Every caller passes `font: FONT` in base, so spreading it
+      // last silently overrode Courier New and rendered code spans in Georgia — a valid
+      // file, just wrong, which is the kind of defect nothing downstream catches.
+      runs.push(new TextRun({ text: code, ...base, font: 'Courier New' }));
     }
 
     rest = rest.slice(m.index + m[0].length);

--- a/scripts/check-pipeline-consistency.sh
+++ b/scripts/check-pipeline-consistency.sh
@@ -71,6 +71,11 @@ for f in "$H/subagent-gate.sh" "$H/publish-gate.sh" "$C/hbr-article.md" "$C/hbr-
 done
 must_contain "approval marker checked by publish-gate" "$H/publish-gate.sh" "APPROVED"
 must_contain "approval marker written by /hbr-article" "$C/hbr-article.md"  "APPROVED"
+# Both commands, not just one. /hbr-article-strict collected human approval and then
+# never wrote the marker, so the gate blocked its publisher on every single run — and
+# this suite passed 64 assertions without noticing, because it only ever asked about the
+# sibling command. Any invariant that applies to both has to be asserted against both.
+must_contain "approval marker written by /hbr-article-strict" "$C/hbr-article-strict.md" "APPROVED"
 must_contain "publish-gate guards the right agent"     "$H/publish-gate.sh" "hbr-publisher"
 
 echo

--- a/scripts/test-article-to-docx.sh
+++ b/scripts/test-article-to-docx.sh
@@ -172,10 +172,6 @@ if command -v unzip > /dev/null; then
     bad "headings are not built-in styles"
   fi
 
-  # Two separate ordered lists must not share one counter, or the second renders as
-  # 4, 5, 6 instead of restarting at 1. The fixture has one bullet list and two ordered
-  # lists, so a correct render produces three distinct w:numId values. Sharing one
-  # counter produces two — which is why the fixture needs the second ordered list.
   # Inline code must be monospace. `font` was being overridden by a spread that came
   # after it, so every code span silently rendered in the body serif.
   if grep -q 'w:ascii="Courier New"' "$TMP/document.xml"; then
@@ -184,6 +180,10 @@ if command -v unzip > /dev/null; then
     bad "inline code is not monospace — the code span font was overridden"
   fi
 
+  # Two separate ordered lists must not share one counter, or the second renders as
+  # 4, 5, 6 instead of restarting at 1. The fixture has one bullet list and two ordered
+  # lists, so a correct render produces three distinct w:numId values. Sharing one
+  # counter produces two — which is why the fixture needs the second ordered list.
   NUM_IDS="$(grep -o '<w:numId w:val="[0-9]*"' "$TMP/document.xml" | sort -u | wc -l | tr -d ' ')"
   if [ "${NUM_IDS:-0}" -ge 3 ]; then
     ok "each ordered list gets its own numbering instance ($NUM_IDS distinct)"
@@ -233,15 +233,21 @@ NESTED="$TMP/nested.md"
   echo 'Body text long enough to render into a document block for this check.'
 } > "$NESTED"
 
-if bash "$RENDER" "$NESTED" "$TMP/nested.docx" > "$TMP/nested.log" 2>&1 && command -v unzip > /dev/null; then
+# A render failure is a FAILURE, never a skip. Folding it into the same condition as the
+# unzip check made a crash in parseFrontmatter — the exact regression these two tests
+# exist to catch — print "skip" and exit 0. Skips are for missing tools only; the code
+# under test never gets to opt out of being tested.
+if ! bash "$RENDER" "$NESTED" "$TMP/nested.docx" > "$TMP/nested.log" 2>&1; then
+  bad "nested frontmatter render failed: $(head -3 "$TMP/nested.log" | tr '\n' ' ')"
+elif ! command -v unzip > /dev/null; then
+  skip "nested frontmatter check (unzip unavailable)"
+else
   unzip -p "$TMP/nested.docx" word/document.xml > "$TMP/nested.xml" 2>/dev/null
   if grep -q 'The Real Title' "$TMP/nested.xml" && ! grep -q 'Chief Nested Officer' "$TMP/nested.xml"; then
     ok "nested frontmatter keys do not overwrite the document title"
   else
     bad "a nested frontmatter key overwrote the top-level title"
   fi
-else
-  skip "nested frontmatter check (render failed or unzip unavailable)"
 fi
 
 INDENTED="$TMP/indented.md"
@@ -254,15 +260,17 @@ INDENTED="$TMP/indented.md"
   echo 'Body text long enough to render into a document block for this check.'
 } > "$INDENTED"
 
-if bash "$RENDER" "$INDENTED" "$TMP/indented.docx" > "$TMP/indented.log" 2>&1 && command -v unzip > /dev/null; then
+if ! bash "$RENDER" "$INDENTED" "$TMP/indented.docx" > "$TMP/indented.log" 2>&1; then
+  bad "indented frontmatter render failed: $(head -3 "$TMP/indented.log" | tr '\n' ' ')"
+elif ! command -v unzip > /dev/null; then
+  skip "indented frontmatter check (unzip unavailable)"
+else
   unzip -p "$TMP/indented.docx" word/document.xml > "$TMP/indented.xml" 2>/dev/null
   if grep -q 'Uniformly Indented Title' "$TMP/indented.xml"; then
     ok "uniformly indented frontmatter is still read"
   else
     bad "indented frontmatter was skipped — the document lost its title"
   fi
-else
-  skip "indented frontmatter check (render failed or unzip unavailable)"
 fi
 
 echo

--- a/scripts/test-article-to-docx.sh
+++ b/scripts/test-article-to-docx.sh
@@ -38,6 +38,10 @@ FIXTURE="$TMP/article.md"
   echo 'Most companies deploying AI agents are **measuring the wrong thing**. They track'
   echo 'model accuracy when they should track *cycle time*. See [the research](https://hbr.org/example).'
   echo
+  # Inline code was absent from this fixture entirely, which is why code spans rendering
+  # in the body font instead of monospace went unnoticed.
+  echo 'One team tracked it with a single `cycle_time_p95` metric and nothing else.'
+  echo
   echo '> The agents that paid for themselves were the ones nobody had to supervise.'
   echo
   echo '### Three Signals'
@@ -172,6 +176,14 @@ if command -v unzip > /dev/null; then
   # 4, 5, 6 instead of restarting at 1. The fixture has one bullet list and two ordered
   # lists, so a correct render produces three distinct w:numId values. Sharing one
   # counter produces two — which is why the fixture needs the second ordered list.
+  # Inline code must be monospace. `font` was being overridden by a spread that came
+  # after it, so every code span silently rendered in the body serif.
+  if grep -q 'w:ascii="Courier New"' "$TMP/document.xml"; then
+    ok "inline code renders in a monospace font"
+  else
+    bad "inline code is not monospace — the code span font was overridden"
+  fi
+
   NUM_IDS="$(grep -o '<w:numId w:val="[0-9]*"' "$TMP/document.xml" | sort -u | wc -l | tr -d ' ')"
   if [ "${NUM_IDS:-0}" -ge 3 ]; then
     ok "each ordered list gets its own numbering instance ($NUM_IDS distinct)"
@@ -199,6 +211,58 @@ if command -v soffice > /dev/null && command -v pdfinfo > /dev/null; then
   fi
 else
   echo "  skip  pagination (soffice/pdfinfo unavailable)"
+fi
+
+# --- Frontmatter indentation ----------------------------------------------
+
+# Two opposite failures, one regex. Anchoring keys to column 0 dropped a uniformly
+# indented `title:` and shipped a document headed "Untitled". Accepting any indentation
+# instead let NESTED keys overwrite the top-level ones — worse, because the wrong title
+# looks plausible and silences the missing-title warning. Both directions are asserted
+# here so a future fix for one cannot silently reintroduce the other.
+
+NESTED="$TMP/nested.md"
+{
+  echo '---'
+  echo 'title: The Real Title'
+  echo 'author:'
+  echo '  name: Someone Else'
+  echo '  title: Chief Nested Officer'
+  echo '---'
+  echo
+  echo 'Body text long enough to render into a document block for this check.'
+} > "$NESTED"
+
+if bash "$RENDER" "$NESTED" "$TMP/nested.docx" > "$TMP/nested.log" 2>&1 && command -v unzip > /dev/null; then
+  unzip -p "$TMP/nested.docx" word/document.xml > "$TMP/nested.xml" 2>/dev/null
+  if grep -q 'The Real Title' "$TMP/nested.xml" && ! grep -q 'Chief Nested Officer' "$TMP/nested.xml"; then
+    ok "nested frontmatter keys do not overwrite the document title"
+  else
+    bad "a nested frontmatter key overwrote the top-level title"
+  fi
+else
+  skip "nested frontmatter check (render failed or unzip unavailable)"
+fi
+
+INDENTED="$TMP/indented.md"
+{
+  echo '---'
+  echo '  title: Uniformly Indented Title'
+  echo '  author: James Gray'
+  echo '---'
+  echo
+  echo 'Body text long enough to render into a document block for this check.'
+} > "$INDENTED"
+
+if bash "$RENDER" "$INDENTED" "$TMP/indented.docx" > "$TMP/indented.log" 2>&1 && command -v unzip > /dev/null; then
+  unzip -p "$TMP/indented.docx" word/document.xml > "$TMP/indented.xml" 2>/dev/null
+  if grep -q 'Uniformly Indented Title' "$TMP/indented.xml"; then
+    ok "uniformly indented frontmatter is still read"
+  else
+    bad "indented frontmatter was skipped — the document lost its title"
+  fi
+else
+  skip "indented frontmatter check (render failed or unzip unavailable)"
 fi
 
 echo


### PR DESCRIPTION
The third `claude-review` run on #217 posted a genuine review *after* that PR merged (see #218 — the check is intermittent, not permanently broken). Three findings were confirmed by reproducing them, and are fixed here.

## 1. `/hbr-article-strict` never wrote the `APPROVED` marker — demo-breaking

It collected human approval via `AskUserQuestion`, then went straight to Stage 4. But `publish-gate.sh` refuses to dispatch `hbr-publisher` until `<workspace>/APPROVED` exists, so the deterministic variant — the one meant to be the *predictable* contrast in a live session — was blocked on every run.

The sibling `/hbr-article` had the instruction all along. The consistency suite asserted the marker for that command and never asked the same of this one: 64 assertions covering half an invariant. Now asserted for both.

## 2. Inline code rendered in Georgia, not Courier New

```js
{ text: code, font: 'Courier New', ...base }   // base carries font: FONT, and spreads last
```

Verified in the OOXML, before and after:

```
before:  fonts on the code run: ['Georgia']
after:   fonts on the code run: ['Courier New']
```

The test fixture contained no inline code at all, which is why nothing caught it.

## 3. Nested frontmatter keys overwrote the top-level ones

A regression from the previous pass. Anchoring keys to column 0 dropped a uniformly indented `title:` and shipped a document headed "Untitled", so I loosened the regex to `^\s*` — which then let `author:` / `  title:` overwrite the document title. Worse than the original: the wrong title looks plausible *and* silences the missing-title warning.

The first key's indentation now defines the document's level; anything deeper is ignored. Both directions are asserted so a future fix for one can't quietly reintroduce the other.

## Verification

```
28 + 17 + 20 gate and renderer assertions   0 failed
65 consistency assertions                   0 failed
15 files in sync
npm run build                               198 pages, clean
```

Each new assertion was confirmed to **fail** against the pre-fix code by reverting each change in turn:

```
revert code font        →  FAIL  inline code is not monospace
revert frontmatter      →  FAIL  a nested frontmatter key overwrote the document title
revert strict command   →  FAIL  approval marker written by /hbr-article-strict
```

## Not addressed here

`render-docx.sh`'s comment claiming it installs "beside the renderer" (npm walks up to the repo root, since `scripts/` has no `package.json`), and four CLAUDE.md accuracy items from the same review — including that the doc still states plugin content is never duplicated under `.claude/`, which the `multi-agent-example` mirroring made false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)