### PR TITLE
Sync multi-agent-example v1.0.2

### DIFF
--- a/plugins/multi-agent-example/.claude-plugin/plugin.json
+++ b/plugins/multi-agent-example/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "multi-agent-example",
   "description": "A complete, runnable worked example of multi-agent orchestration. Four specialist agents research, write, edit, and publish a business article, with automatic delegation, machine quality gates, and an enforced human approval step. Built to be read and adapted, not used as-is.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "James Gray"
   },


### PR DESCRIPTION
#220 and #222 both changed mirrored plugin files, so the distributed copy went stale again — same version number, older contents:

```
commands/hbr-article-strict.md    differ    ← the APPROVED-marker fix
scripts/article-to-docx.js        differ    ← the code-font + frontmatter fixes
scripts/render-docx.sh            differ    ← the --prefix pinning
scripts/test-article-to-docx.sh   differ
distributed: 1.0.1    main: 1.0.1
```

Left alone, a student installing the plugin would get exactly the code those two PRs exist to fix — including `/hbr-article-strict`, which cannot publish at all.

Re-synced and patch-bumped to **1.0.2**. The shipped copy's suites were run **from the distributed repo**, not from here:

```
28 passed, 0 failed    (subagent gate)
17 passed, 0 failed    (publish gate)
20 passed, 0 failed    (renderer)
```

`handsonai-plugins` stays uncommitted and unpushed — it goes last, after this is on `main`, so Cowork only ever syncs a complete version-bumped state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)