### PR TITLE
Rename the Step-Decomposed path to Step-Driven

### DIFF
--- a/plugins/handsonai/.claude-plugin/plugin.json
+++ b/plugins/handsonai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "handsonai",
   "description": "Everything you need to design, build, and document AI workflows. The AI Workflow Framework as executable Claude Code skills, plus an AI registry and feature-spec toolkit.",
-  "version": "6.0.11",
+  "version": "6.1.0",
   "author": {
     "name": "James Gray"
   },

--- a/plugins/handsonai/skills/deconstruct/SKILL.md
+++ b/plugins/handsonai/skills/deconstruct/SKILL.md
@@ -5,7 +5,7 @@ description: >
   process, capture requirements for an AI workflow, or define a goal for an agent system.
   Step 2 is the PRD for the workflow — it captures what the workflow must do, the rules it must
   follow, and the edge cases it must handle, in clear requirements language suitable for the
-  Design step or any AI model to consume. Supports two paths: step-decomposed (you know how the
+  Design step or any AI model to consume. Supports two paths: step-driven (you know how the
   work gets done) and goal-driven (you know what "done" looks like and want an agent system
   to determine the path). Produces a structured Workflow Requirements document.
   Also use when the user says "continue my workflow" and the workflow manifest shows Step 2 (Deconstruct) is next.
@@ -25,18 +25,18 @@ Step 2 has **two paths**, mapped directly to the two ways students think about a
 
 | Path | When to use | Mental model |
 |------|-------------|--------------|
-| **Step-decomposed** *(a known-steps workflow)* | The work runs the same way each run — you can describe how it gets done, even if the steps aren't mapped yet. Design will classify it as a **deterministic or guided** workflow — both run on steps you own. | "I know how the work gets done" |
+| **Step-driven** *(a known-steps workflow)* | The work runs the same way each run — you can describe how it gets done, even if the steps aren't mapped yet. Design will classify it as a **deterministic or guided** workflow — both run on steps you own. | "I know how the work gets done" |
 | **Goal-driven** *(an agent system)* | You know what "done" looks like, but the work takes different steps depending on what comes in — so you give an agent system a goal and let it figure out the steps at runtime. Design classifies these as **autonomous**. | "I know the goal" |
 
 Both paths produce a Workflow Requirements document with the same shared shell — only the middle "what does the workflow do" block differs.
 
-**What "goal" means here.** An agent goal is a **deliverable with a completion state** — something you can look at after a single run and verify is done. It is *not* a business objective or an impact metric: "higher revenue" is a business objective (record it in `Value & Measurement` → Business Objective); "a ranked list of 20 qualified prospects matching our ICP, with contact info" is an agent goal. The goal bundles the deliverable plus the rules and acceptance criteria for it — what major agent frameworks call the expected output and success criteria. (If you know the product-management "outcomes over outputs" framing: the agent's goal is closer to an *output* — the business outcome belongs in Business Objective.) The defining trait of this path is **who owns the control flow**: the agent decides the *path* to the goal at runtime, while you own the *definition of done*. Note the inverse doesn't hold — a step-decomposed workflow can still use an agent for an individual step; what makes a workflow goal-driven is that the agent decides the overall sequence, not merely that agents are involved.
+**What "goal" means here.** An agent goal is a **deliverable with a completion state** — something you can look at after a single run and verify is done. It is *not* a business objective or an impact metric: "higher revenue" is a business objective (record it in `Value & Measurement` → Business Objective); "a ranked list of 20 qualified prospects matching our ICP, with contact info" is an agent goal. The goal bundles the deliverable plus the rules and acceptance criteria for it — what major agent frameworks call the expected output and success criteria. (If you know the product-management "outcomes over outputs" framing: the agent's goal is closer to an *output* — the business outcome belongs in Business Objective.) The defining trait of this path is **who owns the control flow**: the agent decides the *path* to the goal at runtime, while you own the *definition of done*. Note the inverse doesn't hold — a step-driven workflow can still use an agent for an individual step; what makes a workflow goal-driven is that the agent decides the overall sequence, not merely that agents are involved.
 
 **Which path? (quick heuristic — share this with the user when they're unsure).** The test: *imagine two different inputs — would the work take noticeably different steps?* The choice depends only on the **nature of the work** — never on whether the user can currently list the steps.
-- Choose **Step-decomposed** if the work runs **the same way each time** — same steps regardless of the input. The user does **not** need the steps written down or even fully clear in their head; describing how the work gets done is enough, and the interview maps and refines the steps with them.
+- Choose **Step-driven** if the work runs **the same way each time** — same steps regardless of the input. The user does **not** need the steps written down or even fully clear in their head; describing how the work gets done is enough, and the interview maps and refines the steps with them.
 - Choose **Goal-driven** if the work **takes different steps depending on what comes in**, and you'd rather define what "done" looks like plus the rules and let the agent figure out the steps at runtime.
 
-Worked example: *"Generate my weekly status report from the same three sources"* → step-decomposed (same recipe every run). *"Triage whatever lands in my inbox and handle each appropriately"* → goal-driven (a refund request, a partnership pitch, and spam each take a completely different sequence of steps). Getting this right matters: the choice selects the document template the Design step parses, so a wrong pick creates rework downstream.
+Worked example: *"Generate my weekly status report from the same three sources"* → step-driven (same recipe every run). *"Triage whatever lands in my inbox and handle each appropriately"* → goal-driven (a refund request, a partnership pitch, and spam each take a completely different sequence of steps). Getting this right matters: the choice selects the document template the Design step parses, so a wrong pick creates rework downstream.
 
 ## Workflow
 
@@ -49,16 +49,16 @@ Worked example: *"Generate my weekly status report from the same three sources"*
    **Cold entry (no Analyze output)**: Ask one question:
 
    > "Is the work the same every run, or does it vary by input? (Quick test: imagine two different inputs — would the work take the same steps, or different steps?)
-   > - **Known-steps workflow** *(step-decomposed)* — The work runs the same way each time — what the framework classifies as a **deterministic or guided** workflow. You don't need the steps written down — describing how the work gets done is enough, and I'll map and refine the steps with you, surfacing decision rules and edge cases along the way.
+   > - **Known-steps workflow** *(step-driven)* — The work runs the same way each time — what the framework classifies as a **deterministic or guided** workflow. You don't need the steps written down — describing how the work gets done is enough, and I'll map and refine the steps with you, surfacing decision rules and edge cases along the way.
    > - **Agent system** *(goal-driven)* — The steps vary depending on what comes in — an **autonomous** workflow. You can describe the deliverable — what "done" looks like — and want an agent system to figure out the steps at runtime. A goal here is a concrete deliverable, not a business result: "a ranked list of 20 qualified prospects" is a goal; "higher revenue" is why you want it. I'll capture the goal, inputs, acceptance criteria, and rules."
 
-   When rendering this choice as a structured form (e.g., option cards), preserve the framing above: the step-decomposed card must say the work is *repeatable* and that the interview will map the steps — never "I can list the steps," which wrongly reads as an entry requirement. A "Not sure / I have a problem" option should invite the user in ("help me figure out the right workflow") rather than imply they lack a process.
+   When rendering this choice as a structured form (e.g., option cards), preserve the framing above: the step-driven card must say the work is *repeatable* and that the interview will map the steps — never "I can list the steps," which wrongly reads as an entry requirement. A "Not sure / I have a problem" option should invite the user in ("help me figure out the right workflow") rather than imply they lack a process.
 
    **Problem-first handling (no separate path)**: If the user says they don't have a process *or* a goal — just a problem ("People drop off during onboarding and I don't have a way to follow up") — propose a candidate workflow based on what they describe, then route into one of the two paths:
-   > "Here's a candidate workflow that would solve this: [outline]. Do you want to refine these steps with me (step-decomposed), or just describe the goal and let an agent figure out the steps (goal-driven)?"
+   > "Here's a candidate workflow that would solve this: [outline]. Do you want to refine these steps with me (step-driven), or just describe the goal and let an agent figure out the steps (goal-driven)?"
 
    **After the path is chosen, gather scenario details:**
-   - **Step-decomposed**: Ask about the business scenario, objective, high-level steps, and ownership. One question at a time. If no lens was established, determine it: individual tasks (one person's repetitive work) = Individual lens; multi-role or business-objective processes = Organizational lens. Ask only if not obvious from context. Proceed to Step 2 (scope check) → Step 3 (naming) → Step 4 (deep dive).
+   - **Step-driven**: Ask about the business scenario, objective, high-level steps, and ownership. One question at a time. If no lens was established, determine it: individual tasks (one person's repetitive work) = Individual lens; multi-role or business-objective processes = Organizational lens. Ask only if not obvious from context. Proceed to Step 2 (scope check) → Step 3 (naming) → Step 4 (deep dive).
    - **Goal-driven**: Proceed to Step 2 (scope check) → Step 3 (naming) → Step 4-GD (goal-driven interview). The interview opens with scenario grounding, so don't pre-interview here — but if the user has already described the situation, trigger, or consumer, carry those answers forward.
 
    **Value case (both paths)** — capture four of the six `Value & Measurement` fields here, while the user is still describing the situation. Keep it conversational: two or three questions, not a form.
@@ -90,7 +90,7 @@ Worked example: *"Generate my weekly status report from the same three sources"*
 
    **Derive the workflow ID.** Convert the confirmed name to kebab-case (lowercase, hyphens, no punctuation — "Lead Qualification" → `lead-qualification`) and confirm it with the user: "I'll use `lead-qualification` as the workflow ID — it names the folder and files for everything we produce." This ID is the single source of truth for all artifact paths; every downstream skill uses it verbatim.
 
-4. **Deep dive (step-decomposed only)** — Before probing the first step, briefly frame what "context" means: "As we go through each step, I'll ask about the *context* it needs. Context is any data or information the step requires to do its job — that includes databases and spreadsheets, but also documents, transcripts, emails, style guides, SOPs, or even knowledge that currently lives in someone's head. If the step needs it, it's context."
+4. **Deep dive (step-driven only)** — Before probing the first step, briefly frame what "context" means: "As we go through each step, I'll ask about the *context* it needs. Context is any data or information the step requires to do its job — that includes databases and spreadsheets, but also documents, transcripts, emails, style guides, SOPs, or even knowledge that currently lives in someone's head. If the step needs it, it's context."
 
    Work through each step using the 6-question framework. **Ask one question at a time, adapt to the user's answers, and skip dimensions already well-covered — this is a scaffold for *you*, never a checklist to read aloud at the user.** These six dimensions shape what to ask, not how the spec is structured. Your job is to gather enough signal across all six to write the per-step requirements block (Goal / Inputs / Outputs / Rules & Edge Cases / Context Needed) in Step 10.
 
@@ -109,11 +109,11 @@ Worked example: *"Generate my weekly status report from the same three sources"*
 
    When probing context needs, push beyond vague answers — identify the specific artifact. For any step where AI is already being used, ask specifically for existing prompt instructions, project instructions, or system prompts — these contain workflow logic that must be included in the Baseline Prompt.
 
-5. **Propose and react (step-decomposed only)** — After the first step of the deep dive, switch to propose-and-react: propose a hypothesis across all dimensions (including context readiness and role transitions for organizational workflows) and ask "What's right, what's wrong, what am I missing?" instead of asking each question individually. Include a context readiness hypothesis: "I think this context lives in [location] and is in [format] which AI can interpret. Is that right?"
+5. **Propose and react (step-driven only)** — After the first step of the deep dive, switch to propose-and-react: propose a hypothesis across all dimensions (including context readiness and role transitions for organizational workflows) and ask "What's right, what's wrong, what am I missing?" instead of asking each question individually. Include a context readiness hypothesis: "I think this context lives in [location] and is in [format] which AI can interpret. Is that right?"
 
-6. **Map sequence (step-decomposed only)** — After all steps, identify sequential vs. parallel steps and the critical path.
+6. **Map sequence (step-driven only)** — After all steps, identify sequential vs. parallel steps and the critical path.
 
-7. **Optimize for AI (step-decomposed only)** — Now that the full process is mapped, step back and challenge it. The user described their *current* process — but an AI-powered version may not need every step. Present optimization recommendations for the user to react to. Look for:
+7. **Optimize for AI (step-driven only)** — Now that the full process is mapped, step back and challenge it. The user described their *current* process — but an AI-powered version may not need every step. Present optimization recommendations for the user to react to. Look for:
    - **Eliminable steps** — Steps that exist only because a human was doing the work. Examples: manual data transfer between systems (an integration eliminates this), reformatting output from one step to match the input of the next (AI handles format natively), or "wait for X to be available" steps that become instant with API access.
    - **Collapsible steps** — Adjacent steps that AI can do in a single pass. Examples: separate "draft" and "format" steps, or "research" followed immediately by "summarize findings" — these are distinct for humans but one operation for AI.
    - **Parallelizable steps** — Steps that were sequential only because a human can do one thing at a time. If two steps have no data dependency, flag that AI can run them concurrently.
@@ -133,7 +133,7 @@ Worked example: *"Generate my weekly status report from the same three sources"*
 
    Update the refined steps based on the user's confirmed optimizations. Renumber if steps were added, removed, or merged. If the user rejects all optimizations, that's fine — proceed with the original steps.
 
-8. **Validate the workflow (step-decomposed only)** — Before consolidating context, walk through the refined workflow end-to-end and present a validation summary. This is the quality gate that catches gaps before the workflow moves to Design. Check for:
+8. **Validate the workflow (step-driven only)** — Before consolidating context, walk through the refined workflow end-to-end and present a validation summary. This is the quality gate that catches gaps before the workflow moves to Design. Check for:
    - **Completeness** — Are there gaps in the end-to-end flow? Steps where an output doesn't connect to the next step's input?
    - **Logic gaps** — Decision points without clear criteria? Steps that assume information not produced by a prior step?
    - **Edge cases** — Scenarios the user hasn't mentioned (empty inputs, unexpected formats, partial data, exception paths)?
@@ -153,7 +153,7 @@ Worked example: *"Generate my weekly status report from the same three sources"*
 
 9. **Consolidate context** — Present a rolled-up "context inventory" of every piece of context the workflow needs — documents, data, rules, examples, and any other knowledge from the user's domain that the model doesn't have.
 
-   For step-decomposed workflows: assemble from per-step context needs gathered in Step 4. For goal-driven workflows: assemble from the Inputs + Context Sources gathered in Step 4-GD.
+   For step-driven workflows: assemble from per-step context needs gathered in Step 4. For goal-driven workflows: assemble from the Inputs + Context Sources gathered in Step 4-GD.
 
    **Then classify each artifact and settle sensitivity.** As you present the rolled-up inventory, fill the `Sensitivity` and `Provenance` columns for every row — what class of data it holds, and whether someone on the team wrote it or it came from outside.
 
@@ -195,7 +195,7 @@ Worked example: *"Generate my weekly status report from the same three sources"*
 
     These wait until now because a target describes the *revised* workflow, and until Step 7 there was no revision to describe. The pairing is natural: acceptance criteria say what good **output** looks like; the target says what good **performance** looks like.
 
-    For step-decomposed workflows, read the target alongside `Optimization Notes` — those record what the Optimize-for-AI pass changed and why; the target records what that change is expected to be worth.
+    For step-driven workflows, read the target alongside `Optimization Notes` — those record what the Optimize-for-AI pass changed and why; the target records what that change is expected to be worth.
 
     Goal-driven workflows have no optimize pass and so no "revised workflow" in the same sense. There, the target compares the agent system against however the work happens today. Say which: "4 hours to 20 minutes" means something different when the baseline is a person doing it than when nobody is and the work simply isn't getting done.
 
@@ -205,15 +205,15 @@ Worked example: *"Generate my weekly status report from the same three sources"*
 
     **Self-check before finishing (so Design can parse it).** After writing, verify the file against the machine-readability rules and fix any miss before handing off:
     - File lives in the workflow folder using the kebab-case ID: `outputs/[workflow-name]/requirements.md` (e.g., "Inbound Lead Triage" → `outputs/inbound-lead-triage/requirements.md`), and `workflow.yaml` exists alongside it with `current_step: 2` and the requirements path registered.
-    - All required headings are present and **exactly named** (no synonyms): Goal, Value & Measurement, Metadata, Context Inventory, Acceptance Criteria, Example Scenarios, Rules & Constraints, Human Gates, Security, Privacy & Safety, plus the path-specific middle (Steps Overview + Step Details + Sequence for step-decomposed; Inputs for goal-driven).
+    - All required headings are present and **exactly named** (no synonyms): Goal, Value & Measurement, Metadata, Context Inventory, Acceptance Criteria, Example Scenarios, Rules & Constraints, Human Gates, Security, Privacy & Safety, plus the path-specific middle (Steps Overview + Step Details + Sequence for step-driven; Inputs for goal-driven).
     - Canonical vocabulary used exactly (Definition Type, Lens, Context Status, AI Accessible) and stable IDs present (steps `1,2,3…`; context `C1,C2…`; scenarios `E1,E2…`).
     - If anything is off, fix it before telling the user it's ready.
 
 ### Goal-Driven Path (Step 4-GD)
 
-When the user selects goal-driven, run this interview instead of the step-decomposed deep dive (Steps 4–8). The goal-driven path handles context discovery internally (question 8, Context & Data Sources), so it skips straight to Step 9 (Consolidate Context) → Step 10 (Acceptance Criteria) → Step 11 (Generate) after the interview. Same interview principles apply: one question at a time, propose-and-react after the first few answers, push beyond vague answers. If scenario discovery (Step 1) already captured the situation, trigger, or consumer, build on those answers — confirm and deepen rather than re-asking from scratch.
+When the user selects goal-driven, run this interview instead of the step-driven deep dive (Steps 4–8). The goal-driven path handles context discovery internally (question 8, Context & Data Sources), so it skips straight to Step 9 (Consolidate Context) → Step 10 (Acceptance Criteria) → Step 11 (Generate) after the interview. Same interview principles apply: one question at a time, propose-and-react after the first few answers, push beyond vague answers. If scenario discovery (Step 1) already captured the situation, trigger, or consumer, build on those answers — confirm and deepen rather than re-asking from scratch.
 
-**Open with a frame** so the user knows what this path asks of them (parallel to the context frame the step-decomposed path opens with):
+**Open with a frame** so the user knows what this path asks of them (parallel to the context frame the step-driven path opens with):
 
 > "This path is for when you know what you want but not the exact steps — you don't need to map anything out. You'll give the agent system a goal — a concrete deliverable it produces each run — plus the rules it has to follow, and I'll handle the structure. Let's start with the situation."
 
@@ -225,11 +225,11 @@ When the user selects goal-driven, run this interview instead of the step-decomp
    - **Rejection test (testability)**: "Describe an output that *looks* plausible but you'd send back. What's wrong with it?" The answers surface implicit acceptance criteria — carry them forward to seed Step 10; don't re-elicit there.
 
    If the user's first answer in question 2 is purely metric-shaped (no deliverable at all), skip the reflect-back and go straight to the level test. If the probe cap is reached and the goal is still untestable, switch from asking to proposing: draft a sharp candidate goal yourself from everything heard so far and ask the user to confirm or correct it — never proceed to question 4 with a goal that fails the done/not-done test.
-4. **Variation envelope**: "This works as goal-driven because the work takes different steps depending on what comes in. What's the range it needs to handle? Give me the typical case, and a couple of the awkward or harder ones." These answers become the Example Scenarios in Step 10 — capture them now and harvest them there; don't re-elicit scenarios later. **Misroute check:** if the answer reveals the work actually takes the same steps every time (no meaningful variation), say so and offer to switch: "This sounds like it runs the same way each run — the step-decomposed path would capture it better. Want to switch?" Carry everything gathered so far into the step-decomposed deep dive rather than restarting.
+4. **Variation envelope**: "This works as goal-driven because the work takes different steps depending on what comes in. What's the range it needs to handle? Give me the typical case, and a couple of the awkward or harder ones." These answers become the Example Scenarios in Step 10 — capture them now and harvest them there; don't re-elicit scenarios later. **Misroute check:** if the answer reveals the work actually takes the same steps every time (no meaningful variation), say so and offer to switch: "This sounds like it runs the same way each run — the step-driven path would capture it better. Want to switch?" Carry everything gathered so far into the step-driven deep dive rather than restarting.
 5. **Inputs**: "What kicks it off, and what does the agent system get to work with — data, documents, access?" (Confirm against what the scenario already established rather than re-asking.)
 6. **Rules & Constraints**: "What rules should the agent follow? Things it must always do, must never do, or limits on scope, tone, length." Keep this **behavioral**. Where data may travel and what the agent may never *act* on — send, post, create, change — are captured at Step 9 under `Security, Privacy & Safety`, not here.
 7. **Fallback behavior**: "When it hits a case it can't confidently handle — missing info, something ambiguous — what should it do? Stop and ask you, make its best attempt and flag it, or skip that item?" This is the agent's behavior on *unplanned* exceptions — distinct from the *planned* pauses captured under Human gates. Record it under Rules & Constraints in the output. If the answer is "stop and ask," also capture it as a Human Gate (question 9) so the pause appears where Design looks for review points.
-8. **Context & Data Sources**: "What external systems, data sources, documents, or reference materials should the agent system have access to?" Apply the same context readiness probing as the step-decomposed path (sample — ask the one or two probes that matter, don't run all three mechanically):
+8. **Context & Data Sources**: "What external systems, data sources, documents, or reference materials should the agent system have access to?" Apply the same context readiness probing as the step-driven path (sample — ask the one or two probes that matter, don't run all three mechanically):
    - Access: Where does this context live today? Is it in a system with programmatic access (database, cloud app, shared drive), or does it require manual steps (logging in, copy-pasting, reading from a screen)?
    - Interpretability: Is the context in a format AI can process?
    - Persistence: Does this context need to exist as a durable artifact that AI can access across workflow runs?
@@ -238,7 +238,7 @@ When the user selects goal-driven, run this interview instead of the step-decomp
 
 **Do NOT ask about capability domains, agent count, model class, tools, or orchestration approach.** Those are Design decisions. Goal-driven Deconstruct stays in "what" territory: goal, inputs, acceptance criteria, rules, context, human gates.
 
-**Step 8-GD — Validate before consolidating (goal-driven quality gate).** Step-decomposed has a Step 8 validation gate; goal-driven needs the equivalent so a vague goal or missing guardrails doesn't sail through to Design. Walk the definition end-to-end and present a short validation summary covering:
+**Step 8-GD — Validate before consolidating (goal-driven quality gate).** Step-driven has a Step 8 validation gate; goal-driven needs the equivalent so a vague goal or missing guardrails doesn't sail through to Design. Walk the definition end-to-end and present a short validation summary covering:
    - **Goal is bounded, singular, and testable** — one clear deliverable that passes the done/not-done test ("help with email" is too vague; "a drafted reply per inbound inquiry" is bounded). If you can't tell from one run's output whether the goal is met, tighten it before Design.
    - **Variation range is captured** — the typical case and the awkward/edge cases are identified (these become the test scenarios in Step 10).
    - **Rules are sufficient** — must-do and must-never both covered; scope boundaries explicit enough to keep the agent in bounds.
@@ -280,7 +280,7 @@ health: ""                        # working | needs-attention | broken (set by t
 last_run: ""                      # YYYY-MM-DD of most recent run (set by run)
 apps: []                          # integrations used, e.g., [Gmail, Notion] (set by design/build)
 assets_used: []                   # skills/agents this workflow uses, by name (set by build)
-definition_type: Step-Decomposed  # or Goal-Driven (legacy files may say Outcome-Driven — treat as Goal-Driven)
+definition_type: Step-Driven  # or Goal-Driven (legacy files may say Outcome-Driven — treat as Goal-Driven)
 current_step: 2                   # last completed framework step (1-7); 0 = named only
 last_updated: YYYY-MM-DD
 artifacts:
@@ -342,7 +342,7 @@ So Design (and any agent model) can parse the document without re-asking:
 - **Fixed section headings**, in fixed order — use the exact headings in the template; no synonyms, no reordering.
 - **Tables for any list of items with shared fields** (steps, context artifacts, example scenarios) — not prose.
 - **Canonical vocabulary** for enumerated values:
-  - Definition Type: `Step-Decomposed` or `Goal-Driven`
+  - Definition Type: `Step-Driven` or `Goal-Driven`
   - Lens: `Individual` or `Organizational`
   - Context Status: `Exists` or `Needs Creation`
   - AI Accessible: `Yes`, `Partial`, or `No`
@@ -382,14 +382,14 @@ Notes:
 | Trigger | [what kicks the workflow off] |
 | Owner | [person or role] |
 | Lens | Individual / Organizational |
-| Definition Type | Step-Decomposed / Goal-Driven |
+| Definition Type | Step-Driven / Goal-Driven |
 
 For organizational lens, also include:
 | Stakeholders | [roles/teams involved] |
 
 ---
 
-[INSERT THE STEP-DECOMPOSED BLOCK OR THE GOAL-DRIVEN BLOCK HERE — see below]
+[INSERT THE STEP-DRIVEN BLOCK OR THE GOAL-DRIVEN BLOCK HERE — see below]
 
 ---
 
@@ -481,11 +481,11 @@ Notes:
 - **Prohibited actions are absolute; Human Gates are conditional.** "Never send a customer email without approval" is a gate — not until someone approves. "Never send a customer email" is a prohibition — never, regardless of who asks. If an approval can satisfy it, it belongs in Human Gates.
 - **The sensitivity of what the workflow produces belongs in `Access`.** The Context Inventory classifies what the workflow *consumes*. A generated deliverable can be more sensitive than any of its inputs — a specification assembled from customer evidence is the obvious case. Who may see the outputs and the intermediate state is an Access constraint, not a Context Inventory row.
 
-## Optimization Notes (optional, step-decomposed only)
+## Optimization Notes (optional, step-driven only)
 [Brief record of what changed from the original process and why — only if optimizations were applied in Step 7. Include declined optimizations and the reasoning, since this preserves context for Design.]
 ```
 
-### Step-Decomposed middle block
+### Step-Driven middle block
 
 Insert between the Metadata table and the Context Inventory:
 

--- a/plugins/handsonai/skills/design/SKILL.md
+++ b/plugins/handsonai/skills/design/SKILL.md
@@ -5,7 +5,7 @@ description: >
   an AI workflow. It gathers architecture decisions, assesses workflow autonomy level,
   chooses an orchestration mechanism and involvement mode, classifies steps, maps building blocks,
   identifies skill candidates, configures agents, and produces a Design Spec for approval.
-  Supports both step-decomposed and goal-driven Workflow Requirements.
+  Supports both step-driven and goal-driven Workflow Requirements.
   Also use when the user says "continue my workflow" and the workflow manifest shows Step 3 (Design) is next.
   This is Step 3 (Design) of the AI Workflow Framework.
 user-invocable: true
@@ -13,7 +13,7 @@ user-invocable: true
 
 # Workflow Design
 
-Take a Workflow Requirements document (produced by Step 2 — Deconstruct) and produce the Design deliverable: a Design Spec that captures architecture decisions, autonomy assessment, orchestration mechanism, per-step classifications (step-decomposed) or capability domain mapping (goal-driven), skill candidates, and agent blueprints.
+Take a Workflow Requirements document (produced by Step 2 — Deconstruct) and produce the Design deliverable: a Design Spec that captures architecture decisions, autonomy assessment, orchestration mechanism, per-step classifications (step-driven) or capability domain mapping (goal-driven), skill candidates, and agent blueprints.
 
 ## Bundled references — read at the step that calls for them
 
@@ -56,11 +56,11 @@ Read the workflow's manifest (`outputs/[workflow-name]/workflow.yaml`) to locate
 
 **Verify the requirements file exists and is parseable before relying on it.** If the file is missing, stop and tell the user — don't proceed against a path that doesn't resolve. Confirm the required headings exist (Goal — accept the legacy heading `Outcome` in older files — Metadata, Context Inventory, Acceptance Criteria, Example Scenarios, Human Gates, and either Steps Overview/Step Details or the goal-driven Inputs/Rules & Constraints). If any are missing or mis-named, **say exactly which are missing** and ask the user to re-run `/deconstruct` or fix the file — don't guess at the contents.
 
-Read the `Definition Type` field from the Metadata table. If `Goal-Driven` (or the legacy value `Outcome-Driven` — treat it as `Goal-Driven`): **STOP — read `references/goal-driven-path.md` now, in full, before proceeding.** It modifies Steps 3–9 and the spec template; do not run the goal-driven path from memory. If `Step-Decomposed` (or no Definition Type field is present), use the standard step-decomposed path below.
+Read the `Definition Type` field from the Metadata table. If `Goal-Driven` (or the legacy value `Outcome-Driven` — treat it as `Goal-Driven`): **STOP — read `references/goal-driven-path.md` now, in full, before proceeding.** It modifies Steps 3–9 and the spec template; do not run the goal-driven path from memory. If `Step-Driven` (or no Definition Type field is present), use the standard step-driven path below.
 
 #### Step 2 — Confirm Understanding
 
-For step-decomposed requirements: Summarize the workflow name, step count, and goal (from the Goal section of the Workflow Requirements — legacy files title it Outcome). Ask the user to confirm before proceeding.
+For step-driven requirements: Summarize the workflow name, step count, and goal (from the Goal section of the Workflow Requirements — legacy files title it Outcome). Ask the user to confirm before proceeding.
 
 For goal-driven requirements: Summarize the workflow name, goal, and the headline rules and constraints (from the Goal and Rules & Constraints sections). Ask the user to confirm before proceeding.
 
@@ -224,7 +224,7 @@ Before confirming Layer 1, walk four safety questions. This matters most when th
 3. **Unattended runs** — Will this run on a schedule or without a human watching? If yes: human gates on outward-facing actions, a cap on actions per run, and a log of every write.
 4. **Blast radius** — What's the worst realistic outcome of a bad run? Place a human gate in front of the highest-consequence action, or constrain it to drafts/test targets.
 
-**Write-action feasibility check (required when the workflow writes to an external system).** The four questions above scope *how much* write access to request; this one asks whether the required action is **possible at all** on the chosen platform. For each write/action the workflow needs — read them from the Workflow Requirements (the `External Action` fields in Step Details for step-decomposed; the goal, rules, and acceptance for goal-driven) — verify the chosen integration can actually perform it. Use the capability-check mechanism from Step 5 (registry lookup + a single targeted web check) — this is exactly the "check now rather than ship a spec Build can't honor" case. Distinguish two gap types:
+**Write-action feasibility check (required when the workflow writes to an external system).** The four questions above scope *how much* write access to request; this one asks whether the required action is **possible at all** on the chosen platform. For each write/action the workflow needs — read them from the Workflow Requirements (the `External Action` fields in Step Details for step-driven; the goal, rules, and acceptance for goal-driven) — verify the chosen integration can actually perform it. Use the capability-check mechanism from Step 5 (registry lookup + a single targeted web check) — this is exactly the "check now rather than ship a spec Build can't honor" case. Distinguish two gap types:
 
 - **Scope gap** — the connector *supports* the action but may not be authorized yet (fixable by reconnecting/authorizing at Build). Note it and move on.
 - **Capability gap** — the connector has **no such capability at all** (e.g., a read-only CRM connector with no create-deal tool). This is *not* fixable by reauthorizing, and it can invalidate the design. Flag it plainly and present **platform-aware options**, in this order:
@@ -259,7 +259,7 @@ By this point the user has already confirmed *where* (Step 3a) and *how it runs*
 
 **How to write the playback:** Use the technical term, then immediately explain it in plain language in the same line. Never drop a bare technical label on its own. Every row teaches as it confirms.
 
-For step-decomposed workflows:
+For step-driven workflows:
 
 > "Here's the design analysis based on your workflow definition. I'll explain each piece as I go — push back on anything that's off:
 >
@@ -386,7 +386,7 @@ After classifying every step, recommend available integration options for each t
 
 **Presentation format:**
 
-For step-decomposed: `**[Tool] access needed (Steps N, M):**`
+For step-driven: `**[Tool] access needed (Steps N, M):**`
 For goal-driven: `**[Tool] access needed (Domains: X, Y):**`
 
 > **[Tool] access needed ([Steps N, M / Domains: X, Y]):**
@@ -503,7 +503,7 @@ The 12 fields (field-by-field format in `references/spec-template.md`):
 - **Depends On** — other skill IDs (S2, S3) or artifacts that must exist first, or "None"
 - **Stateful?** — Yes / No, does the skill maintain state across invocations? Drives Memory building-block decisions.
 
-**Consolidation sweep (before presenting blueprints — no user question):** sweep the candidate list once. **Merge** candidates that are the same capability applied at different steps into one skill with multiple Covers Steps entries (the step-decomposed mirror of the goal-driven altitude rule). **Split** any candidate whose Decision Logic spans two unrelated capabilities — each skill should excel at one thing. Note each merge/split in one line when presenting the blueprints.
+**Consolidation sweep (before presenting blueprints — no user question):** sweep the candidate list once. **Merge** candidates that are the same capability applied at different steps into one skill with multiple Covers Steps entries (the step-driven mirror of the goal-driven altitude rule). **Split** any candidate whose Decision Logic spans two unrelated capabilities — each skill should excel at one thing. Note each merge/split in one line when presenting the blueprints.
 
 #### Step 8 — Agent Configuration
 

--- a/plugins/handsonai/skills/design/references/goal-driven-path.md
+++ b/plugins/handsonai/skills/design/references/goal-driven-path.md
@@ -33,7 +33,7 @@ Same Integration Discovery and Skill Discovery processes apply, operating on cap
 
 **Mandatory-but-with-an-exception:** document at least one agent **whenever the design includes a sub-agent/agent artifact** (the common case). A valid goal-driven design on a primary-loop platform (Claude Code/Cowork) may have **zero sub-agents** — just orchestration logic (an orchestrator skill and/or `CLAUDE.md` run section) + skills. In that case record `agents: 0` in the frontmatter counts and document the orchestration logic in the Deployment Plan / Orchestrator notes instead — **do not invent a sub-agent to satisfy the field.** Never document the orchestrator (the primary loop) as an agent artifact.
 
-**Step 8b (Verify Evaluation Inputs):** Same as step-decomposed — confirm Acceptance Criteria and Example Scenarios in the Workflow Requirements are complete; do not duplicate.
+**Step 8b (Verify Evaluation Inputs):** Same as step-driven — confirm Acceptance Criteria and Example Scenarios in the Workflow Requirements are complete; do not duplicate.
 
 **Step 9 (Generate Spec):** Use the modified template sections below. The spec uses the same filename pattern and same frontmatter shape (with `definition_type: Goal-Driven`). The Step-by-Step Decomposition section is replaced with Capability Domain Mapping; the Autonomy Spectrum Summary becomes a brief Autonomous statement; Build Output is captured per domain rather than per step.
 
@@ -49,7 +49,7 @@ Replace the `## Step-by-Step Decomposition` section of `references/spec-template
 | Domain | Description | Integration (use/build) | Intelligence | Build Output |
 |--------|-------------|------------------------|--------------|--------------|
 
-**Build Output values:** Same canonical forms as the step-decomposed table (`New skill: SN`, `Use existing: [name]`, `New agent: AN`, etc.). For goal-driven workflows, expect most domains to map to either `New skill: SN` (the orchestrator/sub-agent delegates to a reusable skill) or `Handled by orchestrator` (the orchestrating primary loop — or a deployed agent on SDK platforms — handles the domain inline via its own instructions; legacy synonym: `Handled by agent`).
+**Build Output values:** Same canonical forms as the step-driven table (`New skill: SN`, `Use existing: [name]`, `New agent: AN`, etc.). For goal-driven workflows, expect most domains to map to either `New skill: SN` (the orchestrator/sub-agent delegates to a reusable skill) or `Handled by orchestrator` (the orchestrating primary loop — or a deployed agent on SDK platforms — handles the domain inline via its own instructions; legacy synonym: `Handled by agent`).
 
 ### Autonomy Statement
 
@@ -63,7 +63,7 @@ Additional substitutions:
 - Agent Configuration documents the **sub-agent(s) the orchestrator dispatches** and is included whenever the design has ≥1 sub-agent (the common case). A primary-loop design with **zero sub-agents** (orchestration logic + skills only) is valid: set `agents: 0` and document the orchestration logic in the Deployment Plan instead.
 - The Safety & Permissions section applies unchanged — goal-driven workflows are Autonomous by definition, so the unattended-runs and blast-radius rows deserve extra attention.
 - **Constraint Conformance and Value & Measurement apply unchanged too.** Both are path-agnostic: the constraints a workflow must honor and what it is worth are true whether the steps are mapped or the agent chooses them at runtime. For an autonomous workflow the `Prohibited actions` constraints carry more weight than usual, because there is no fixed path to inspect — they are the boundary the agent operates inside.
-- Value's `Target` compares the agent system against however the work happens today, since there is no Optimize-for-AI pass and so no "revised workflow" in the step-decomposed sense.
+- Value's `Target` compares the agent system against however the work happens today, since there is no Optimize-for-AI pass and so no "revised workflow" in the step-driven sense.
 
 ## Checklist modifications
 

--- a/plugins/handsonai/skills/design/references/spec-template.md
+++ b/plugins/handsonai/skills/design/references/spec-template.md
@@ -19,7 +19,7 @@ For **goal-driven** workflows, apply the template substitutions in `references/g
 workflow: [kebab-case name]
 requirements_file: outputs/[workflow-name]/requirements.md
 spec_version: 2.5
-definition_type: Step-Decomposed | Goal-Driven
+definition_type: Step-Driven | Goal-Driven
 mechanism: Prompt | Skill-Powered Workflow | Agent
 involvement: Augmented | Automated
 platform: [user's platform, e.g., Claude Code, Claude.ai, Cowork, Codex, ChatGPT, Gemini CLI]
@@ -94,7 +94,7 @@ The spec is organized into three layers that build on each other:
 
 The workflow-level autonomy assessment and the rationale that drove it. (Per-step autonomy classifications appear in the Decomposition table below.)
 
-For step-decomposed workflows: group steps by autonomy level. For each group, explain WHY those steps have that classification.
+For step-driven workflows: group steps by autonomy level. For each group, explain WHY those steps have that classification.
 
 For goal-driven workflows: replace this section with an **Autonomy Statement** — a brief paragraph stating: "This is a goal-driven workflow. Autonomy is Autonomous — the agent system determines its own execution path based on the Goal, Inputs, Rules & Constraints, and Acceptance Criteria defined in the Workflow Requirements."
 

--- a/plugins/handsonai/skills/indexing-registry/references/manifest-resolution.md
+++ b/plugins/handsonai/skills/indexing-registry/references/manifest-resolution.md
@@ -40,7 +40,7 @@ where `<slug>` is the workflow's kebab-case ID (the same value the YAML backend 
 | `status` | frontmatter `status`, kebab-case (see status mapping below) |
 | `type` (execution mode) | frontmatter `execution_mode` — `manual` \| `augmented` \| `automated` |
 | `autonomy` | frontmatter `autonomy` — `deterministic` \| `guided` \| `autonomous` |
-| `definition_type` | frontmatter `definition_type` — `step-decomposed` \| `outcome-driven` (kebab-case) |
+| `definition_type` | frontmatter `definition_type` — `step-driven` \| `goal-driven` (kebab-case) |
 | `trigger` | frontmatter `trigger` |
 | `business_process` | a `N. [Title](/workflows/<slug>.md)` line in the Process node's curated ordered `# Workflows` list (`registry/processes/<process-slug>.md`) — the list is BOTH the Workflow→Process edge and the value-chain order. Never write a `process:` frontmatter field on the Workflow node (banned; lint errors). Place the line at the workflow's position in the process sequence (append at the end if unknown); a workflow must appear in exactly one process's list. |
 | `next_review` | frontmatter `next_review` |

--- a/plugins/handsonai/skills/indexing-registry/references/manifest-schema.md
+++ b/plugins/handsonai/skills/indexing-registry/references/manifest-schema.md
@@ -29,7 +29,7 @@ apps: [Gmail, HubSpot]            # integrations the workflow uses
 assets_used: [drafting-outreach]  # skills/agents used, by frontmatter name
 
 # Framework state ─ maintained by every step
-definition_type: Step-Decomposed  # or Goal-Driven (legacy "Outcome-Driven" = Goal-Driven)
+definition_type: Step-Driven  # or Goal-Driven (legacy "Outcome-Driven" = Goal-Driven)
 current_step: 4                   # last completed framework step (1-7); 0 = named only
 last_updated: 2026-07-01
 next_review: 2026-08-01           # set by run/improve

--- a/public/assets/courses/competitive-intelligence-workflow-requirements.md
+++ b/public/assets/courses/competitive-intelligence-workflow-requirements.md
@@ -12,7 +12,7 @@ Given a competitor name, research the competitor's recent moves and produce a pu
 | Trigger | Manual on demand, or scheduled per competitor (e.g., weekly for top-tier competitors, monthly for second tier) |
 | Owner | Workflow operator (the person tracking the competitor) |
 | Lens | Individual |
-| Definition Type | Step-Decomposed |
+| Definition Type | Step-Driven |
 | Business Objective | Stay current on competitor moves without paying the daily attention tax; turn one-off research effort into an institutional asset that survives team turnover |
 
 ---

--- a/src/content/docs/ai-workflow-framework/deconstruct.md
+++ b/src/content/docs/ai-workflow-framework/deconstruct.md
@@ -36,13 +36,13 @@ Step 2 presents one question upfront: **do you know the steps, or just the goal?
 
 | Path | When to use | Mental model |
 |---|---|---|
-| **Step-decomposed** | You can describe how the work gets done | "I know the steps" |
+| **Step-driven** | You can describe how the work gets done | "I know the steps" |
 | **Goal-driven** | You know what "done" looks like, but the work takes different steps depending on what comes in — you give an agent system a goal and let it figure out the steps at runtime | "I know the goal" |
 
-**Not sure which?** Imagine two different inputs and ask: *would the work take noticeably different steps?* If it runs the same way every time, it's step-decomposed. If the steps change depending on what comes in — a refund request, a partnership pitch, and a spam message each handled differently — it's goal-driven.
+**Not sure which?** Imagine two different inputs and ask: *would the work take noticeably different steps?* If it runs the same way every time, it's step-driven. If the steps change depending on what comes in — a refund request, a partnership pitch, and a spam message each handled differently — it's goal-driven.
 
 :::note[What "goal" means here]
-An agent goal is a **deliverable with a completion state** — something you can look at after a single run and verify is done. It is *not* a business objective or an impact metric: "higher revenue" is a business objective (it's recorded under `Value & Measurement`, alongside what you'd count and where that number stands today); "a ranked list of 20 qualified prospects matching our ICP, with contact info" is an agent goal. This matches how the major agent frameworks specify work — a goal bounded by an expected output and success criteria. (If you know the product-management "outcomes over outputs" framing: the agent's goal is closer to an *output* — the business outcome belongs in Business Objective.) What makes a workflow goal-driven is that **the agent decides the path** to the goal at runtime — not simply that agents are involved. A step-decomposed workflow can still use an agent for an individual step; it's goal-driven only when the agent owns the overall sequence.
+An agent goal is a **deliverable with a completion state** — something you can look at after a single run and verify is done. It is *not* a business objective or an impact metric: "higher revenue" is a business objective (it's recorded under `Value & Measurement`, alongside what you'd count and where that number stands today); "a ranked list of 20 qualified prospects matching our ICP, with contact info" is an agent goal. This matches how the major agent frameworks specify work — a goal bounded by an expected output and success criteria. (If you know the product-management "outcomes over outputs" framing: the agent's goal is closer to an *output* — the business outcome belongs in Business Objective.) What makes a workflow goal-driven is that **the agent decides the path** to the goal at runtime — not simply that agents are involved. A step-driven workflow can still use an agent for an individual step; it's goal-driven only when the agent owns the overall sequence.
 :::
 
 Both paths produce a Workflow Requirements document with the same shared structure — only the middle "what does the workflow do" block differs.
@@ -59,7 +59,7 @@ Phases 1–3 establish *what* you're deconstructing and are the same for both pa
 2. **Scope check** — Is this one workflow or multiple bundled together? If multiple, the skill recommends splitting and asks which to start with.
 3. **Name the workflow** — The skill proposes 2–3 name options (2–4 word noun phrases, Title Case) and confirms name, description, goal, trigger, and type.
 
-**Step-decomposed (phase 4 on):**
+**Step-driven (phase 4 on):**
 
 4. **Deep dive** — For each step, the skill probes six dimensions: discrete steps, decision points, data flows, context needs, failure modes, data readiness.
 5. **Propose and react** — From step 4 onward, the skill proposes a hypothesis across all six dimensions and asks "What's right, what's wrong, what am I missing?"
@@ -113,15 +113,15 @@ The skill asks you to choose a path, runs an interactive interview to capture th
 Download the skill file from [GitHub](https://github.com/jamesgray-ai/handsonai-plugins/tree/main/plugins/handsonai/skills/deconstruct) and paste it into your system prompt or project instructions.
 :::
 
-### Example: Step-decomposed path
+### Example: Step-driven path
 
-After you start the conversation, the model asks you to choose a path. If you pick step-decomposed, here's what the opening looks like:
+After you start the conversation, the model asks you to choose a path. If you pick step-driven, here's what the opening looks like:
 
 > **Model:** Do you know the steps, or just the goal? (Quick test: imagine two different inputs — would the work take the same steps, or different steps?)
-> - **Step-decomposed** — The work runs the same way each time and you can describe how it gets done.
+> - **Step-driven** — The work runs the same way each time and you can describe how it gets done.
 > - **Goal-driven** — You can't list the steps, but you can describe the deliverable — what "done" looks like — and want an agent system to figure out the steps. A goal here is a concrete deliverable, not a business result: "a ranked list of 20 qualified prospects" is a goal; "higher revenue" is why you want it.
 >
-> **You:** Step-decomposed. I research LinkedIn prospects before sales outreach. The goal is to find people who'd be a good fit for our AI training programs, understand their background, and write personalized outreach messages.
+> **You:** Step-driven. I research LinkedIn prospects before sales outreach. The goal is to find people who'd be a good fit for our AI training programs, understand their background, and write personalized outreach messages.
 >
 > **Model:** Got it — LinkedIn prospect research for personalized sales outreach. Can you walk me through the high-level steps? Don't worry about being complete or precise — we'll refine them together.
 >
@@ -165,7 +165,7 @@ You don't need an existing process. If you have a gap or pain point, describe th
 >
 > **You:** Yes, that's the shape of it.
 >
-> **Model:** Good. Two paths from here: do you want to refine these steps with me (step-decomposed), or describe the goal and let an agent figure out the steps (goal-driven)?
+> **Model:** Good. Two paths from here: do you want to refine these steps with me (step-driven), or describe the goal and let an agent figure out the steps (goal-driven)?
 
 You pick the path, and the conversation continues into the deep dive.
 
@@ -194,22 +194,22 @@ The **Workflow Requirements** document uses a shared structure for both paths �
 
 - **Goal** — what a successful run produces, when it runs, who consumes it
 - **Value & Measurement** — why the workflow is worth building and how you would know it worked: the business objective it supports, the outcome that changes and for whom, what gets counted, today's number, and the target the revised workflow should hit
-- **Metadata** — workflow name, trigger, owner, lens (Individual / Organizational), Definition Type (Step-Decomposed / Goal-Driven)
+- **Metadata** — workflow name, trigger, owner, lens (Individual / Organizational), Definition Type (Step-Driven / Goal-Driven)
 - **Context Inventory** — every artifact the workflow needs, with stable IDs (C1, C2, …), status (Exists / Needs Creation), how sensitive it is (**Public** — a published price list; **Internal** — a project tracker; **Confidential** — an unannounced roadmap; **Regulated** — anything covered by a rule such as patient records or EU customer data), where it came from (**Authored** by someone on your team, or **External** — it arrived from outside), AI accessibility (Yes / Partial / No), and location
 - **Acceptance Criteria** — what good output looks like, dimensions that matter (accuracy, completeness, tone, etc.), and the minimum bar
 - **Example Scenarios** — 3-5 representative inputs with what to look for in the output, plus optional **Golden Examples** — real past outputs you'd consider "exactly right." These feed Step 5 (Test), where scoring against a known-good reference beats gut-feel ratings
 - **Rules & Constraints** — how the work should be done: must-do, must-never-do, scope boundaries, tone, format, length, and fallback behavior when a case can't be confidently completed
 - **Human Gates** — where human review or input is required
 - **Security, Privacy & Safety** — what the workflow must protect: where data may and may not travel, who may see the outputs, what has to be recorded, what it must never do, and which regulation applies. Every constraint names its source
-- **Optimization Notes** (optional, step-decomposed only) — what changed from the original process and why
+- **Optimization Notes** (optional, step-driven only) — what changed from the original process and why
 
-**Step-decomposed middle block:**
+**Step-driven middle block:**
 
 - **Steps Overview** — a scannable numbered list, one line per step
 - **Step Details** — each step captured as **Goal / Inputs / Outputs / Rules & Edge Cases / Context Needed**, plus a **Role** field when the workflow uses the Organizational lens (to capture which role owns each step)
 - **Sequence** — sequential vs. parallel steps, critical path, role swimlane
 
-Most step-decomposed workflows expand from 5-8 rough steps to 12-20 refined steps after the deep dive.
+Most step-driven workflows expand from 5-8 rough steps to 12-20 refined steps after the deep dive.
 
 **Goal-driven middle block:**
 
@@ -240,11 +240,11 @@ The Workflow Requirements reads like a PRD, not an interview transcript:
 - **Tables for lists of items with shared fields** — easier to parse than prose
 - **No interview residue** — no "the user mentioned", "usually", or other narrative
 
-### Process optimization (step-decomposed only)
+### Process optimization (step-driven only)
 
-For step-decomposed workflows, the skill includes an **Optimize for AI** pass after the deep dive. Once the full process is mapped, the model steps back and challenges it — looking for steps that exist only because a human was doing the work (an integration eliminates the manual transfer), steps that can be collapsed (AI drafts and formats in one pass), steps that can be parallelized (no data dependency), handoffs that can be simplified, and new steps needed for the AI version. These are presented as recommendations for you to accept or reject — you may have good reasons to keep steps as-is (compliance, audit trail, stakeholder expectations). The Workflow Requirements records what changed and why.
+For step-driven workflows, the skill includes an **Optimize for AI** pass after the deep dive. Once the full process is mapped, the model steps back and challenges it — looking for steps that exist only because a human was doing the work (an integration eliminates the manual transfer), steps that can be collapsed (AI drafts and formats in one pass), steps that can be parallelized (no data dependency), handoffs that can be simplified, and new steps needed for the AI version. These are presented as recommendations for you to accept or reject — you may have good reasons to keep steps as-is (compliance, audit trail, stakeholder expectations). The Workflow Requirements records what changed and why.
 
-### Workflow validation (step-decomposed only)
+### Workflow validation (step-driven only)
 
 After optimization, the skill runs a **validation pass** — walking through the refined workflow end-to-end to catch gaps before it moves to Design. This is the quality gate that stress-tests the workflow for:
 

--- a/src/content/docs/ai-workflow-framework/examples/worked-example.md
+++ b/src/content/docs/ai-workflow-framework/examples/worked-example.md
@@ -111,7 +111,7 @@ The full file (trimmed to two candidates for readability — a real report often
 
 ## Step 2 — Deconstruct → `requirements.md` + `workflow.yaml`
 
-The deconstruct skill interviewed Maya for about 30 minutes (step-decomposed path — she knows exactly how the work gets done). Two things worth noticing: the **Optimization Notes** show the framework collapsed her original "summarize, then format" into one AI step, and scenario **E1 has a golden example** — a real past report Test will compare against.
+The deconstruct skill interviewed Maya for about 30 minutes (step-driven path — she knows exactly how the work gets done). Two things worth noticing: the **Optimization Notes** show the framework collapsed her original "summarize, then format" into one AI step, and scenario **E1 has a golden example** — a real past report Test will compare against.
 
 The manifest first — the small file every later step reads and updates:
 
@@ -119,7 +119,7 @@ The manifest first — the small file every later step reads and updates:
 # outputs/weekly-status-report/workflow.yaml
 workflow: weekly-status-report
 display_name: Weekly Status Report
-definition_type: Step-Decomposed
+definition_type: Step-Driven
 current_step: 2                   # each step bumps this as it completes
 last_updated: 2026-06-01
 artifacts:
@@ -156,7 +156,7 @@ Maya's review by 10am. Consumed by the leadership team; posted after Maya approv
 | Trigger | Manual — Maya starts it Friday mornings |
 | Owner | Maya R. (Program Manager) |
 | Lens | Individual |
-| Definition Type | Step-Decomposed |
+| Definition Type | Step-Driven |
 
 ---
 
@@ -293,7 +293,7 @@ The complete Design Spec:
 workflow: weekly-status-report
 requirements_file: outputs/weekly-status-report/requirements.md
 spec_version: 2.5
-definition_type: Step-Decomposed
+definition_type: Step-Driven
 mechanism: Skill-Powered Workflow
 involvement: Augmented
 platform: Claude Cowork

--- a/src/content/docs/ai-workflow-framework/index.md
+++ b/src/content/docs/ai-workflow-framework/index.md
@@ -13,13 +13,13 @@ The framework is facilitated by **seven skills** — reusable AI routines that g
 
 | Step | Skill | What it guides you through |
 |------|-------|---------------------------|
-| 1. Analyze | `analyze` | Identify and prioritize the workflows worth reimagining with AI |
-| 2. Deconstruct | `deconstruct` | Map the workflow’s process — or define the goal for an agent system |
-| 3. Design | `design` | Architect how AI building blocks will power your workflow |
-| 4. Build | `build` | Build the AI building blocks your design specifies |
-| 5. Test | `test` | Test your workflow's output quality and fix what's not working |
-| 6. Run | `run` | Deploy and operationalize your workflow |
-| 7. Improve | `improve` | Monitor quality and innovate your workflow over time |
+| 1.&nbsp;Analyze | `analyze` | Identify and prioritize the workflows worth reimagining with AI |
+| 2.&nbsp;Deconstruct | `deconstruct` | Map the workflow’s process — or define the goal for an agent system |
+| 3.&nbsp;Design | `design` | Architect how AI building blocks will power your workflow |
+| 4.&nbsp;Build | `build` | Build the AI building blocks your design specifies |
+| 5.&nbsp;Test | `test` | Test your workflow's output quality and fix what's not working |
+| 6.&nbsp;Run | `run` | Deploy and operationalize your workflow |
+| 7.&nbsp;Improve | `improve` | Monitor quality and innovate your workflow over time |
 
 **Get the skills:** See [Set Up the Skills](skills/) for installation instructions across Claude Code, Claude Cowork, Claude.ai, M365 Copilot (Cowork), Cursor, Codex CLI, Gemini CLI, and VS Code Copilot. The plugin name is `handsonai`.
 

--- a/src/content/docs/ai-workflow-framework/index.md
+++ b/src/content/docs/ai-workflow-framework/index.md
@@ -87,12 +87,12 @@ Define *what* the business process does — every step, decision, and handoff �
 
 Step 2 is the **Product Requirements Document (PRD) for your workflow** — clear requirements, decision rules, and edge cases that feed directly into Design. There are two paths, chosen by one question at the start: *do you know the steps, or just the goal?*
 
-- **Step-decomposed** — You can describe how the work gets done. The model interviews you to refine the steps and surface decision rules, edge cases, and the context each step needs. Each step is captured as Goal / Inputs / Outputs / Rules & Edge Cases / Context.
+- **Step-driven** — You can describe how the work gets done. The model interviews you to refine the steps and surface decision rules, edge cases, and the context each step needs. Each step is captured as Goal / Inputs / Outputs / Rules & Edge Cases / Context.
 - **Goal-driven** — You know what "done" looks like, but the work takes different steps depending on what comes in, so you give an agent system a goal and let it figure out the steps at runtime. The model captures the goal, inputs, acceptance criteria, rules, and constraints — without prescribing steps.
 
 Don't have either yet? Describe the problem you're trying to solve. The model proposes a candidate workflow and routes you into one of the two paths above.
 
-For step-decomposed workflows, the model uses the **six-question framework** as the interview structure to identify what belongs in each step's requirements block:
+For step-driven workflows, the model uses the **six-question framework** as the interview structure to identify what belongs in each step's requirements block:
 
 1. Is this step actually multiple steps bundled together?
 2. Are there decision points, branches, or quality gates?
@@ -108,7 +108,7 @@ Two questions run alongside the mapping, whichever path you took:
 
 This is purely the *what* — the workflow's requirements, with no prescription of how AI will handle it. The *how* comes in Step 3 (Design).
 
-**Deliverable:** **Workflow Requirements** (`outputs/[name]/requirements.md`) — a PRD-style document. Every Workflow Requirements file contains: Goal, Value & Measurement, Metadata, Context Inventory, Acceptance Criteria, Example Scenarios, Rules & Constraints, Human Gates, and Security, Privacy & Safety. Step-decomposed workflows add a Steps Overview with per-step requirements; goal-driven workflows add Inputs.
+**Deliverable:** **Workflow Requirements** (`outputs/[name]/requirements.md`) — a PRD-style document. Every Workflow Requirements file contains: Goal, Value & Measurement, Metadata, Context Inventory, Acceptance Criteria, Example Scenarios, Rules & Constraints, Human Gates, and Security, Privacy & Safety. Step-driven workflows add a Steps Overview with per-step requirements; goal-driven workflows add Inputs.
 
 **Facilitated by the `deconstruct` skill.** See [Deconstruct Workflows](deconstruct/) for details and [Set Up the Skills](skills/) for installation on any supported platform.
 
@@ -203,7 +203,7 @@ Every AI workflow is classified on two dimensions — autonomy and human involve
 
 ### Six-Question Framework
 
-Used to decompose each step in a step-decomposed workflow:
+Used to decompose each step in a step-driven workflow:
 
 1. **Discrete steps** — Is this one step or multiple bundled together?
 2. **Decision points** — Any if/then branches, quality gates, or judgment calls?

--- a/src/content/docs/courses/framework-end-to-end.md
+++ b/src/content/docs/courses/framework-end-to-end.md
@@ -37,7 +37,7 @@ Do these three steps in the folder where you run Cowork or Claude Code:
 workflow: competitive-intelligence-brief
 display_name: Competitive Intelligence Brief
 description: Research a competitor's recent moves and produce a structured brief plus an updated knowledge file
-definition_type: Step-Decomposed
+definition_type: Step-Driven
 status: under-development
 trigger: Manual on demand, or scheduled per competitor
 owner: Workflow operator


### PR DESCRIPTION
Students were confused by "Step-decomposed". This renames it to **Step-driven**.

## Why the old name failed

It was grammatically mismatched with its partner. **Goal-driven** describes *what drives the system*; **Step-decomposed** described *an activity the analyst already performed* — and at the moment of choosing, the user hasn't decomposed anything. They're being asked what they **know**.

The tell: the skill had already been patched around the label. The chooser shown to users reads

> **Known-steps workflow** *(step-decomposed)* — ... what the framework classifies as a **deterministic or guided** workflow

— a plain-English alias *and* a second gloss, bolted on to make the term land.

**Step-driven** puts the contrast exactly where the decision lives — step vs goal — and keeps the anchor students already learned. The mental models ("I know the steps" / "I know the goal") now match their labels.

| Path | When to use | Mental model |
|---|---|---|
| **Step-driven** | You can describe how the work gets done | "I know the steps" |
| **Goal-driven** | You know what done looks like; the steps vary by input | "I know the goal" |

Considered and rejected: *Deterministic* (a fixed sequence of LLM steps isn't deterministic — Anthropic deliberately says "predefined path" for this reason, and the name would promise something the system can't deliver), *Guided* (guided by what?), *Procedural* (academic).

## What is deliberately NOT renamed

A find-replace on `step.decompos` would have corrupted the skills. Two protected patterns:

1. **"Step-by-Step Decomposition"** (17 occurrences) — a section heading inside the spec template, the part that lists the actual steps. It also drives `build/SKILL.md`'s generation checklist and the self-test checklist. **Those two files needed no change at all**, as did `design.md`, `content-calendar-planning.md`, and the example design-spec.
2. **"do not force step decomposition"** — correct English about decomposing into steps, not the path name.

Safe here because the replacement matches only the exact token `step-decomposed`; both protected phrases use *decomposition*, a different word. Verified 17 protected occurrences before **and** after, with **zero** modified lines touching either phrase.

## Also fixed

`manifest-resolution.md` listed the accepted values as `step-decomposed | outcome-driven`. **Both halves were wrong** — `outcome-driven` was replaced by `goal-driven` long ago.

## Scope

71 occurrences across 11 files, plus a regenerated MCP content index. No filenames, no code, no config, no redirects contained the term; five headings change anchors but **zero inbound links** point at them.

The 2026-03-20 blog post keeps the old name — it's a dated changelog recording what shipped that day.

**No legacy tolerance**, per decision: manifests carrying `definition_type: Step-Decomposed` will not match.

## Heads-up on the release

`handsonai` goes to **v6.1.0**, and it carries **237 lines of drift across 16 files** that had accumulated unreleased since v6.0.10 — the spec 2.5 work from #221 plus five earlier commits. Nothing detects that: `check-plugin-sync.sh` only guards `multi-agent-example`, which is why it built up silently. Worth its own guard later.

## Verification

```
build                     198 pages, clean
protected phrases         17 before, 17 after; 0 modified lines touch them
old token in dist         blog post + its RSS/index syndication only
distributed copy          identical to canonical, 0 old tokens, 45 new
```

Also included: a separate first commit stopping the step names wrapping in the framework table (`2.&nbsp;Deconstruct`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)