### PR TITLE
Point course content at Maven, drop the retired repo reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ cd mcp-server && npm install && wrangler dev
   - `article-to-docx.js` (markdown → Word, via the `docx` package), `render-docx.sh` (the wrapper agents call — it preflights the dependency, renders, then verifies the output is a real Word file), and `test-article-to-docx.sh`. Always invoke the wrapper, never the renderer directly: on a fresh install only the wrapper installs `docx`.
 - `outputs/` - Local working directory for agent outputs (gitignored)
 - `specs/` - Feature specs (`*-prd.md`), implementation plans (`*-plan.md`), and architecture decision records (`decisions/`) (gitignored)
-- **Private course content** lives in the separate `jamesgray-ai/handsonai-courses` repo (instructor guides, self-study articles, assignments, exercises)
+- **Course content is not maintained here.** Instructor guides, self-study articles, assignments, and exercises live in Maven.
 - **Course syllabi are not generated here.** The Notion pipeline that built
   `courses/*/syllabus.md` and `courses/*/lessons/` was retired with the Notion course
   databases (2026-07-15); the script and its deploy steps are gone. Course pages link


### PR DESCRIPTION
## The problem

`CLAUDE.md` stated:

> **Private course content** lives in the separate `jamesgray-ai/handsonai-courses` repo (instructor guides, self-study articles, assignments, exercises)

That repo is dormant — **last commit 2026-02-22**, and it contains **zero** occurrences of the framework terminology. Course content lives in Maven now.

## Why this mattered, concretely

The line wasn't merely stale, it was actively misleading. While shipping the Step-Driven rename I read it, concluded course material needed the same rename, and warned that students would otherwise see two names for the same concept. None of that was true. Checking the repo's contents took thirty seconds and would have avoided the detour entirely.

## Why replace rather than delete

Deleting outright loses something small but real: the line answers *"where does course content live?"*, and without it the next session finds nothing and asks again.

But the **repo name** is gone. Naming a dormant private repo is precisely what created the false pull — a tombstone entry ("this repo is retired") would keep the same hazard alive in weaker form.

```diff
- **Private course content** lives in the separate `jamesgray-ai/handsonai-courses` repo (instructor guides, self-study articles, assignments, exercises)
+ **Course content is not maintained here.** Instructor guides, self-study articles, assignments, and exercises live in Maven.
```

The syllabus bullet below it is kept as-is — that one earns its length by preventing a specific wrong action (regenerating syllabi from the retired Notion pipeline) and naming the real source of truth.

## Verification

- No references to `handsonai-courses` remain anywhere in the repo
- `npm run build` clean at 198 pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)