### PR TITLE
Fix Git/GitHub setup guide accuracy and beginner gaps

### DIFF
--- a/src/content/docs/ai-workflow-framework/analyze-examples.md
+++ b/src/content/docs/ai-workflow-framework/analyze-examples.md
@@ -19,6 +19,7 @@ Examples 1 and 2 use the **individual lens** — analyzing one person's workflow
 Sarah Chen is a Marketing Operations Manager at a mid-size B2B SaaS company. She manages campaign reporting, lead operations, content production workflows, and marketing analytics. Her team uses HubSpot, Google Ads, LinkedIn Ads, Ahrefs, and Google Slides.
 
 </details>
+
 ### Report Header
 
 |                              |                                                                                                                         |
@@ -258,6 +259,7 @@ Based on impact, frequency, and feasibility, the following three candidates are 
 James Gray is an AI Instructor who runs live cohort courses and maintains the Hands-on AI Playbook — a documentation site with setup guides, framework content, and an MCP server. His work spans teaching, content creation, student support, and meeting with prospective clients and partners.
 
 </details>
+
 ### Report Header
 
 |                              |                                                                                                          |
@@ -497,6 +499,7 @@ Based on impact, frequency, and feasibility, the following three candidates are 
 Maria Torres is VP of Operations at a 200-person logistics company. She oversees warehouse operations, fleet management, and customer fulfillment. She's looking at AI from an organizational perspective — identifying value chain processes where AI can improve outcomes tied to business objectives. This example demonstrates the **organizational lens**.
 
 </details>
+
 ### Report Header
 
 |                              |                                                                                                    |

--- a/src/content/docs/builder-setup/editor-setup.md
+++ b/src/content/docs/builder-setup/editor-setup.md
@@ -143,6 +143,7 @@ If you're stuck, paste this into ChatGPT, Claude, or Gemini:
 > I'm setting up [Cursor / VS Code] on [Mac / Windows] and running into this issue: [describe what's happening]. I followed the installation steps from the official site. What should I try next?
 
 </details>
+
 ## Next Steps
 
 - Set up Git (see [Git Installation Guide](../git-install/))

--- a/src/content/docs/builder-setup/git-install.md
+++ b/src/content/docs/builder-setup/git-install.md
@@ -51,9 +51,11 @@ If you see a version number (e.g., `git version 2.39.0`), Git is already install
 1. Open Terminal
 2. Run: `xcode-select --install`
 3. Click **Install** in the popup dialog
-4. Wait for installation to complete
+4. Wait for installation to complete — the download can take 10–30 minutes, and the dialog's time estimate is famously unreliable (it may claim hours). Let it run.
 
 This installs Git along with other developer tools.
+
+> **Seeing "command line tools are already installed"?** That red text isn't a problem — it means Git is already there. Skip to [Verify Installation](#verify-installation).
 
 ### Option 2: Homebrew
 
@@ -70,14 +72,16 @@ brew install git
 1. Go to [git-scm.com](https://git-scm.com)
 2. Click **Download for Windows**
 3. Run the installer
-4. Use the default settings (click Next through the prompts)
+4. Click **Next** through the prompts — the installer shows about ten screens, and the defaults are fine everywhere except the three settings below
 5. Complete the installation
 
 ### Important Settings During Install
 
-- **Default editor**: Select **VS Code** or **Cursor** if listed — avoid the default (Vim) unless you're familiar with it
-- **PATH environment**: Select "Git from the command line and also from 3rd-party software" (recommended)
-- **Line endings**: Select "Checkout Windows-style, commit Unix-style line endings" (recommended)
+These screens appear in this order as you click through:
+
+- **Default editor**: Select **VS Code** or **Cursor** if listed. If neither appears (you haven't installed an editor yet), choose **Notepad** — you can change this later. Avoid the default (Vim) unless you're familiar with it.
+- **PATH environment**: Select "Git from the command line and also from 3rd-party software" — this is already the default, so just confirm it's selected
+- **Line endings**: Select "Checkout Windows-style, commit Unix-style line endings" — also the default
 
 ## Verify Installation
 
@@ -91,26 +95,38 @@ You should see a version number confirming Git is installed.
 
 ## Configure Your Identity
 
-Set your name and email for Git commits:
+Set your name and email for Git commits. Keep the quotation marks — without them, a name with a space in it won't save correctly:
 
 ```bash
 git config --global user.name "Your Name"
 git config --global user.email "your.email@example.com"
 ```
 
-Use the email address you plan to use for your GitHub account (set up in the next step). If these don't match, your commits still work but GitHub won't attribute them to your profile — they show up as an unlinked name, and fixing it later means rewriting history.
+Use the email address you plan to use for your GitHub account (set up in the next step). If they don't match, your commits still work, but GitHub shows them under an unlinked name instead of your profile. That's easy to fix later — add the email address to your GitHub account (**Settings → Emails**) and GitHub links your past commits to your profile automatically.
+
+> **Planning to keep your email private on GitHub?** GitHub's **Keep my email addresses private** setting (under **Settings → Emails**) gives you a substitute address ending in `@users.noreply.github.com`. Once your account exists, come back and run the email command again with that address:
+>
+> ```bash
+> git config --global user.email "12345678+yourusername@users.noreply.github.com"
+> ```
+>
+> Otherwise, if the companion setting **Block command line pushes that expose my email** is on, GitHub rejects pushes made with your real email (`error: GH007`).
 
 Confirm your identity actually saved:
 
 ```bash
-git config --list
+git config --global user.name
+git config --global user.email
 ```
 
-Look for `user.name` and `user.email` in the output, with the values you just set.
+Each command prints back the value you just set. If either prints nothing, re-run the matching command above.
 
 ## Corporate Networks (Proxy / Firewall)
 
-On a work machine, Git may fail to reach GitHub if traffic has to go through a corporate proxy or a restrictive firewall.
+If Git commands work at home but fail on your work machine, your company network is the likely cause. Don't troubleshoot this alone: ask your IT team whether your network uses a proxy, and share this section with them — the commands below are the fix, but IT has the details (like the proxy address) that make them work.
+
+<details>
+<summary>Proxy and firewall fixes (for you and your IT team)</summary>
 
 **Behind a proxy:**
 
@@ -127,6 +143,8 @@ git config --global --unset https.proxy
 ```
 
 **Behind a firewall that blocks SSH:** if `git clone git@github.com:...` hangs or times out, corporate firewalls often allow HTTPS (port 443) but block the SSH port. Use the HTTPS clone URL instead (`https://github.com/...`) — this is also what the [GitHub Setup Guide](../github-setup/) and [Repository Creation and Cloning Guide](../repo-creation-and-cloning/) use by default.
+
+</details>
 
 ## Troubleshooting
 
@@ -159,6 +177,7 @@ If you're stuck, paste this into ChatGPT, Claude, or Gemini:
 > I'm trying to install Git on [Mac / Windows] and getting this error: [paste the error message]. I followed the steps from the official guide. What should I try next?
 
 </details>
+
 ## Next Steps
 
 - Set up your GitHub account (see [GitHub Setup Guide](../github-setup/))

--- a/src/content/docs/builder-setup/github-setup.md
+++ b/src/content/docs/builder-setup/github-setup.md
@@ -10,7 +10,7 @@ howto_steps:
   - name: Give an agent or tool access
     text: Generate a fine-grained personal access token scoped to a specific repository, grant only the permissions the tool asks for, and store it in a password manager.
   - name: Work with files on your own machine
-    text: Install gh via Homebrew or the macOS installer, winget (Windows), or apt (Linux), then run gh auth login to connect your GitHub account.
+    text: Install gh with the macOS .pkg installer from the GitHub CLI releases page or the Windows MSI from cli.github.com (or via Homebrew / winget), then run gh auth login to connect your GitHub account.
 ---## What Is GitHub?
 
 GitHub is a website where people store, version, and share files — application code, but equally the prompts, skills, agents, and markdown you build with AI. If Git tracks your changes locally (like a save history on your computer), GitHub is where that history lives in the cloud — backed up, shareable, and accessible from anywhere.
@@ -58,6 +58,7 @@ Creating an account and generating a token happen entirely in your browser — n
    - Choose an authenticator app (recommended — e.g., 1Password, Authy, Google Authenticator) or a security key
    - Scan the QR code with your authenticator app and enter the generated code to confirm
    - Save the recovery codes GitHub shows you somewhere safe (a password manager, not a text file) — you'll need one if you lose access to your authenticator
+   - Tip: once 2FA is set up, you can also install the **GitHub mobile app**, sign in, and add it as a second method under **Settings → Password and authentication** — future sign-ins become a single tap on your phone instead of typing a code
 
 **Already have an account with 2FA enabled?** Skip ahead to whichever path you need.
 
@@ -79,7 +80,7 @@ The difference that matters: a **CLI login is tied to your machine**, so anythin
 | How much access | Only the repositories and permissions you tick, and it expires on a date you choose | Broad access to your account, and it doesn't expire on its own |
 | What to watch | It's a secret. If it leaks, it works until you revoke it or it expires | Anyone who can use your computer can use your GitHub access |
 
-**If you generate a token, make it a fine-grained one.** GitHub offers two kinds, and the older "classic" tokens reach every repository you can reach and can be created with no expiry at all. Fine-grained tokens always expire and only ever grant the specific permissions you tick — even at their widest setting.
+**If you generate a token, make it a fine-grained one.** GitHub offers two kinds. The older "classic" tokens reach every repository you can reach and grant broad permission scopes. Fine-grained tokens only ever grant the specific repositories and permissions you tick — even at their widest setting.
 
 ## Give an Agent or Tool Access
 
@@ -90,8 +91,8 @@ Complete this path when something *other than you* needs to reach GitHub — an 
 1. Go to **Settings → Developer settings → Personal access tokens → Fine-grained tokens**
 2. Click **Generate new token**
 3. Give it a descriptive name (e.g., `claude-code-my-repo`)
-4. Choose the **Resource owner** — your personal account, or an organisation if the repository belongs to one. Organisation-owned tokens usually need an admin to approve them before they work, which can take days; start early if that applies to you.
-5. Set an **expiration** that outlasts whatever you're building with it — if you're on a course, set it past the last session; otherwise 30 or 90 days is a good default. Fine-grained tokens always expire, and GitHub caps a custom expiry at 366 days, so pick deliberately: one that lapses mid-project silently breaks every integration using it.
+4. Choose the **Resource owner** — your personal account, or an organisation if the repository belongs to one. If your own username is the only option, choose it — that's the normal case on a personal account. Organisation-owned tokens usually need an admin to approve them before they work, which can take days; start early if that applies to you.
+5. Set an **expiration** that outlasts whatever you're building with it — if you're on a course, set it past the last session; otherwise 30 or 90 days is a good default. On a personal account GitHub also offers **No expiration** — skip it; an expiry date is your safety net if the token ever leaks. Pick deliberately either way: a token that lapses mid-project silently breaks every integration using it. (Tokens for organisation-owned repositories are usually capped at 366 days by the organisation's policy.)
 6. Set **Repository access** — **Only select repositories**, and choose just the repo(s) needed. Create the repository first if it doesn't exist yet (see the [Repository Creation and Cloning Guide](../repo-creation-and-cloning/)); you can't select one that isn't there.
 
    **All repositories** also exists, and covers current *and future* repositories — occasionally useful on a personal account holding nothing you care about, when you want a token that keeps working as you add repos. Two reasons to prefer selecting: many tools that consume a token require a specific repository anyway (Notion's Claude agent connector, for one, states this on its connect screen), and on any account holding real work the wider scope is a genuine risk. Never point a token at an organisation's full repository list to save a step.
@@ -101,7 +102,7 @@ Complete this path when something *other than you* needs to reach GitHub — an 
 
 ### Storing Your Token Safely
 
-Save the token in a password manager (1Password, Bitwarden, etc.), not in a plain text file, a `.env` you might commit, or a note. If a hosted agent or tool needs the token, paste it directly into that tool's credential/secret field rather than writing it to disk in your repository.
+Save the token in a password manager (1Password, Bitwarden, etc.) — not in a plain text file, a document, or a note on your computer. If a hosted agent or tool needs the token, paste it directly into that tool's credential/secret field rather than writing it to disk in your repository.
 
 ## Work With Files on Your Own Machine
 
@@ -113,13 +114,18 @@ The GitHub CLI (`gh`) is the simplest way to authenticate Git on your own machin
 
 #### macOS
 
-With [Homebrew](https://brew.sh):
+Install with the `.pkg` installer — no terminal needed. (If you installed Git via [Xcode Command Line Tools](../git-install/#option-1-xcode-command-line-tools-recommended) — the path the Git guide recommends — this is your route.)
+
+1. Go to the [GitHub CLI releases page](https://github.com/cli/cli/releases/latest)
+2. Scroll down to **Assets** and click **Show all assets** if you don't see many files listed
+3. Download the file whose name ends in `macOS_universal.pkg` — it works on every Mac
+4. Double-click the downloaded file and follow the installer prompts
+
+**Already use [Homebrew](https://brew.sh)?** Then this is quicker:
 
 ```bash
 brew install gh
 ```
-
-**No Homebrew?** If you installed Git via [Xcode Command Line Tools](../git-install/#option-1-xcode-command-line-tools-recommended) — the path the Git guide recommends — you probably don't have Homebrew. Download the macOS `.pkg` installer from [cli.github.com](https://cli.github.com) and run it — no terminal needed.
 
 #### Windows
 
@@ -127,13 +133,7 @@ brew install gh
 winget install --id GitHub.cli
 ```
 
-#### Linux (Debian/Ubuntu)
-
-```bash
-sudo apt install gh
-```
-
-For other Linux distributions, see the [official install instructions](https://github.com/cli/cli/blob/trunk/docs/install_linux.md).
+**`winget` is not recognized?** Some Windows 10 machines (and some corporate laptops) don't have it. Go to [cli.github.com](https://cli.github.com), click **Download MSI**, and run the downloaded installer instead — no terminal needed.
 
 ### Authenticate
 
@@ -145,10 +145,12 @@ Before it opens your browser, `gh` asks four questions in the terminal. Use the 
 
 | Question | Choose |
 |---|---|
-| What account do you want to log into? | **GitHub.com** |
-| What is your preferred protocol for Git operations? | **HTTPS** |
+| Where do you use GitHub? | **GitHub.com** |
+| What is your preferred protocol for Git operations on this host? | **HTTPS** |
 | Authenticate Git with your GitHub credentials? | **Yes** |
-| How would you like to authenticate? | **Login with a web browser** |
+| How would you like to authenticate GitHub CLI? | **Login with a web browser** |
+
+The exact wording shifts slightly between `gh` versions, but the questions come in this order and these are the answers to give.
 
 It then shows a one-time code and opens your browser. Paste the code, approve the access, and return to the terminal — it confirms when it's done.
 
@@ -164,6 +166,9 @@ gh auth status
 **Official docs:** [GitHub CLI manual](https://cli.github.com/manual/)
 
 ## Troubleshooting
+
+**`gh` is not recognized / command not found after installing?**
+- Close and reopen your terminal, then run `gh --version` again — a terminal only picks up newly installed programs when it starts
 
 **`gh auth login` fails or hangs?**
 - Make sure you have a browser available to complete the flow
@@ -183,6 +188,7 @@ If you're stuck, paste this into ChatGPT, Claude, or Gemini:
 > I'm setting up GitHub authentication (2FA / gh auth login / a fine-grained personal access token) and getting this error: [paste the error message]. What should I try?
 
 </details>
+
 ## Next Steps
 
 - [Create a repository and clone it](../repo-creation-and-cloning/) — the next step now that your account and authentication are set up

--- a/src/content/docs/builder-setup/repo-creation-and-cloning.md
+++ b/src/content/docs/builder-setup/repo-creation-and-cloning.md
@@ -100,6 +100,7 @@ If you're stuck, paste this into ChatGPT, Claude, or Gemini:
 > I'm trying to create/clone a GitHub repository in [Cursor / VS Code] on [Mac / Windows] and getting this error: [paste the error message]. I have Git installed, a GitHub account, and the GitHub CLI authenticated. What should I try?
 
 </details>
+
 ## Next Steps
 
 - Try cloning a public repository to practice the workflow

--- a/src/content/docs/builder-setup/voice-to-text-setup.md
+++ b/src/content/docs/builder-setup/voice-to-text-setup.md
@@ -120,6 +120,7 @@ If you're stuck, paste this into ChatGPT, Claude, or Gemini:
 > I'm setting up [Wispr Flow / Claude Desktop Quick Entry] on [Mac / Windows] for voice-to-text and running into this issue: [describe what's happening]. I granted microphone permissions. What should I check?
 
 </details>
+
 ## Next Steps
 
 - Practice dictating a few prompts to get comfortable


### PR DESCRIPTION
## Summary

- **Technical accuracy** (each claim verified against current GitHub behavior, docs, or the gh 2.91.0 binary):
  - Mismatched commit email no longer claims "rewriting history" — adding the address to your GitHub account links past commits retroactively
  - New callout for GitHub's email-privacy setting: the noreply address, the `GH007` push rejection, and the exact re-run command
  - Removed the outdated "fine-grained tokens always expire" claim (personal accounts offer **No expiration** since Oct 2024; 366 days is the org-policy default) while still recommending an expiry
  - `gh auth login` prompt table updated to current wording ("Where do you use GitHub?", "…on this host?")
  - macOS `gh` install corrected: cli.github.com's Mac link is a raw `.zip` binary (dead end for beginners); now step-by-step to the `macOS_universal.pkg` on the releases page
- **Beginner-lens improvements** for the Mac/Windows student audience: Linux section removed, Windows MSI fallback for missing `winget`, "gh not recognized" troubleshooting, pager-trap-free identity verification, xcode-select wait expectations, Windows installer reassurance + Notepad fallback, IT-first proxy framing in a collapsible, GitHub Mobile 2FA tip, quotation-mark warning, `.env` jargon removed
- **Rendering bug fix across six files**: `## Next Steps` (and similar headings) directly after `</details>` never parsed, so live pages showed literal `##` markdown text. Blank line inserted in the two guides above plus `repo-creation-and-cloning`, `editor-setup`, `voice-to-text-setup`, and `analyze-examples`

## Verification

- `npm run build` passes (198 pages)
- Built HTML checked: all previously-raw headings now render as `<h2>`, no stray `## ` text remains on the affected pages, and the new `<details>` blocks render with their code fences intact
- `gh_2.97.0_macOS_universal.pkg` confirmed present on the latest release via the GitHub API; "Download MSI" link text confirmed on cli.github.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)