### PR TITLE
Fix claude-review: grant the tool allowlist the reviewer needs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -66,6 +66,17 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
+          # The action grants NO tools by default in automation (prompt) mode. Without
+          # this allowlist the reviewer cannot read the diff or post anything: runs on
+          # #217 and #231 burned 42-56 turns on 41-131 permission denials, then posted
+          # junk probe comments ("test", "test-approval-check") or nothing at all —
+          # issue #218's whole failure mode. The grants follow the action's own
+          # "Automatic PR Code Review" example in docs/solutions.md, plus the read-only
+          # git commands and scoped `gh api .../comments` POST the code-review plugin's
+          # --comment step uses for inline findings. The workflow's GITHUB_TOKEN caps
+          # the blast radius at contents:read + pull-requests/issues:write regardless.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api repos/${{ github.repository }}/pulls/*:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git fetch:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary

The `claude-review` workflow passes the code-review plugin a prompt but grants **no tools** — the action allows none by default in automation mode. Every recent run thrashed against permission denials and posted junk or nothing, which is exactly issue #218's silent-failure mode:

| PR | Run | Turns | Permission denials | Cost | Posted |
|---|---|---|---|---|---|
| #217 | 30554342853 | 56 | 78 | $11.88 | `test` (4 chars) |
| #217 | 30588109426 | 39 | 110 | $13.08 | `_(test comment retracted)_` |
| #231 | 31455560124 (run 1) | 42 | 41 | $3.35 | nothing (0 chars) |
| #231 | 31455560124 (rerun) | 42 | 41 | — | nothing (0 chars) |
| #231 | 31489635764 | 42 | 131 | $14.71 | `test-approval-check` (19 chars) |

All five reported `"is_error": false` — the guard step added in #218's wake is what turned them red.

## Fix

Add `claude_args` with the `--allowedTools` grants from the action's own [Automatic PR Code Review example](https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md): the inline-comment MCP tool plus `gh pr comment/diff/view`, extended with the read-only git commands and the repo-scoped `gh api …/pulls/*` calls the code-review plugin's `--comment` step uses for inline findings. The job's `GITHUB_TOKEN` permissions are unchanged (contents: read, PRs/issues: write), so the token still caps what any granted tool can do.

Why a separate PR: the action refuses to run against a PR that modifies its own workflow file, so this can't ship with #231.

## Verification

- YAML validated with `yaml.safe_load`.
- Allowlist syntax matches the action's documented example verbatim, plus scoped additions.
- Real proof comes from the first PR reviewed after this merges — expect a posted `Code review` comment and a denial count near zero. #231's next push (or a manual rerun after merging this) is the natural canary.

Closes the diagnosis gap in #218 (root cause: empty tool allowlist, not model flakiness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)