### PR TITLE
fix(registry): make index.md link form explicit in scaffolding-registry skill

### DIFF
--- a/plugins/handsonai/skills/scaffolding-registry/SKILL.md
+++ b/plugins/handsonai/skills/scaffolding-registry/SKILL.md
@@ -95,7 +95,7 @@ If a phase runs over its timebox, write what's been gathered, note the gap for t
 - **The student's `registry/SCHEMA.md` is authoritative once it exists.** Re-read it immediately before every write in this skill, including during gap-filling and migration — never write from memory of what the schema template said.
 - **Stamp `generated: { by: process:scaffolding-registry, at: <date> }`** (single-line flow map, `at` as `YYYY-MM-DD`) on every node this skill creates or edits.
 - **Function nodes are always written with their empty GENERATED `# Owns` block** at creation time — never deferred to a later maintenance pass. A Function missing that block is a lint error, because the maintenance pass has nothing to fill.
-- **Every new node gets added to its typed directory's `index.md`.** A concept file with no entry in its directory index is a lint error; write or update the index in the same pass as the node.
+- **Every new node gets added to its typed directory's `index.md`.** A concept file with no entry in its directory index is a lint error; write or update the index in the same pass as the node. Index entries use bundle-root-relative leading-slash links — `[First Workflow](/workflows/first-workflow.md)`, never a bare same-directory link like `[First Workflow](first-workflow.md)`, which the schema's link discriminator resolves repo-root-relative and lint flags as broken.
 
 ## Close
 

--- a/plugins/handsonai/skills/scaffolding-registry/references/example-registry.md
+++ b/plugins/handsonai/skills/scaffolding-registry/references/example-registry.md
@@ -131,6 +131,19 @@ kickoff to handoff.
 <!-- /GENERATED -->
 ```
 
+## Directory index: `registry/workflows/index.md`
+
+Every typed directory gets one. Entries are bundle-root-relative leading-slash
+links — never bare same-directory links like `[Client Status Reporting](client-status-reporting.md)`,
+which the schema's link discriminator resolves repo-root-relative and lint
+flags as broken.
+
+```markdown
+# Workflows
+
+- [Client Status Reporting](/workflows/client-status-reporting.md)
+```
+
 ## Note: `registry/notes/2026-08-status-report-timing.md`
 
 ```markdown


### PR DESCRIPTION
Replaces #234 (same commit, clean base — #234's diff was polluted by the squash-merge of #231).

## Summary
- A scaffolding run wrote directory `index.md` entries as bare same-directory links (`[Node](node.md)`); the schema's link discriminator resolves those repo-root-relative, so lint flags them as broken links and index-coverage misses. A maintenance pass had to repair them after the fact.
- Root cause was a documentation gap, not a lint or schema bug: `scaffolding-registry/SKILL.md` never stated the index link form, and `references/example-registry.md` had no example `index.md`, so the scaffolding model fell back on standard markdown relative-link instinct.
- Fix: the SKILL.md write rule now states index entries use bundle-root-relative leading-slash links (with correct/incorrect examples), and the example registry gains a worked `registry/workflows/index.md` section.

Skill-only edits — `SCHEMA.md` / `schema-template.md` untouched, so the byte-identity sync constraint is unaffected. Will ship as a PATCH bump with the next `handsonai` plugin sync.

## Verification
- Red/green against the real lint tool: valid-bundle fixture with bare index links → **6 errors** (broken repo link + index-coverage miss per entry); with leading-slash links → **0 errors**.
- `./scripts/check-registry-consistency.sh --full` → 190 passed, 0 failed, 0 skipped.
- `./scripts/check-plugin-sync.sh handsonai` → drift on exactly these two files (expected release payload), nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)