### PR TITLE
chore(plugins): bump handsonai to 7.0.1 — scaffolding-registry index-link fix

### DIFF
--- a/plugins/handsonai/.claude-plugin/plugin.json
+++ b/plugins/handsonai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "handsonai",
   "description": "Everything you need to design, build, and document AI workflows. The AI Workflow Framework as executable Claude Code skills, plus an AI registry and feature-spec toolkit.",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "author": {
     "name": "James Gray"
   },


### PR DESCRIPTION
PATCH bump shipping #235 (scaffolding-registry index.md link-form fix) to the distributed marketplace as handsonai v7.0.1 / marketplace v6.0.17. Sync already run via `sync-plugins.sh handsonai patch` (preflight consistency checks passed); the `handsonai-plugins` release + push happens after this merges, per the ship-order rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)